### PR TITLE
fix(security): close guard bypass via subshells and refs/heads/

### DIFF
--- a/base/hooks/test_destructive_command_guard.py
+++ b/base/hooks/test_destructive_command_guard.py
@@ -50,6 +50,16 @@ class TestPushProtection:
         blocked, _ = check(cmd)
         assert not blocked, f"should allow: {cmd}"
 
+    def test_blocks_bare_push_on_protected_branch(self, monkeypatch):
+        monkeypatch.setattr(guard, "get_current_branch", lambda: "master")
+        blocked, _ = check("git push")
+        assert blocked
+
+    def test_allows_bare_push_on_non_protected_branch(self, monkeypatch):
+        monkeypatch.setattr(guard, "get_current_branch", lambda: "feature/test")
+        blocked, _ = check("git push")
+        assert not blocked
+
     @pytest.mark.parametrize("cmd", [
         "git -C /tmp push origin main",
         "git -c core.abbrev=8 push origin master",


### PR DESCRIPTION
## Summary

- **Subshell bypass (#24):** `$(git push --force origin main)` and backtick equivalents were invisible to the guard because subshell contents were stripped before inspection. Now extracted and checked.
- **refs/heads bypass (#25):** `git push origin refs/heads/main` and `HEAD:refs/heads/main` evaded regex patterns. Now handles optional `refs/heads/` prefix.

### Additional bypasses closed (found during review)

- **Nested subshells:** `$(echo $(git push origin main))` — iterative innermost-first extraction replaces broken greedy match
- **+refspec force push:** `git push origin +master` — now caught with optional `\+?` prefix
- **Trailing args:** `git push origin master --delete` — anchor changed from `\s*$` to `(?:\s|$)`
- **Shell grouping:** `(git push origin main)` and `{ git rebase main; }` — bare parens and brace groups stripped before checking

### Pre-existing issues tracked separately

- #37: `git -c`/`-C` global flag prefix bypass
- #35: shell wrapper bypass (`command`, `env`, `eval`, `bash -c`)
- #36: combined short flags (`-fv`, `-dn`)

## Test plan

- [x] 57 pytest tests covering all guard behaviors (new)
- [x] Subshells: simple, backtick, nested, deeply nested
- [x] refs/heads: direct push, refspec, with/without prefix
- [x] +refspec, trailing args, bare parens, brace groups
- [x] Normal pushes to feature branches still allowed
- [x] Existing protections (force push, hard reset, rebase, clean, flag bypass) still work

Fixes #24, fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stronger protection against destructive git operations: configurable protected-branch support, robust detection across varied push formats and refspecs, safer handling of force pushes (permits explicit safe flags, blocks unsafe forms), and improved parsing of multi-part commands, subshells, and brace groups.

* **Tests**
  * Added an extensive test suite covering push/rebase/clean protections, force scenarios, nested subshells/groupings, compound commands, and many edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->