### PR TITLE
test(hooks): add coverage for fast-feedback and memory-reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Secret detection runs on every PR and push to master via [TruffleHog](https://gi
 
 API keys are never stored in git. `base/settings.json` uses a placeholder rendered at provision/sync time from `$ANTHROPIC_AUTH_TOKEN`.
 
+## Hook Testing
+
+Safety-critical hooks in `base/hooks/` are covered with pytest:
+
+```bash
+python3 -m pytest -q
+```
+
 ## Constraints
 
 - PR review is a separate GitHub Action (multi-model council), not done by sprites

--- a/base/hooks/test_fast_feedback.py
+++ b/base/hooks/test_fast_feedback.py
@@ -1,0 +1,152 @@
+"""Tests for fast-feedback hook."""
+
+import importlib.util
+import io
+import os
+from types import SimpleNamespace
+
+import pytest
+
+
+_spec = importlib.util.spec_from_file_location(
+    "fast_feedback",
+    os.path.join(os.path.dirname(__file__), "fast-feedback.py"),
+)
+fast_feedback = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fast_feedback)
+
+
+def test_get_cwd_reads_hook_payload(monkeypatch):
+    monkeypatch.setattr(fast_feedback.sys, "stdin", io.StringIO('{"cwd":"/tmp/repo"}'))
+    assert fast_feedback.get_cwd() == "/tmp/repo"
+
+
+def test_get_cwd_falls_back_on_invalid_json(monkeypatch):
+    monkeypatch.setattr(fast_feedback.sys, "stdin", io.StringIO("not-json"))
+    monkeypatch.setattr(fast_feedback.os, "getcwd", lambda: "/fallback")
+    assert fast_feedback.get_cwd() == "/fallback"
+
+
+def test_detect_project_returns_none_without_markers(tmp_path):
+    assert fast_feedback.detect_project(str(tmp_path)) is None
+
+
+def test_detect_project_prefers_typescript_marker(tmp_path):
+    (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    assert fast_feedback.detect_project(str(tmp_path)) == "typescript"
+
+
+@pytest.mark.parametrize(
+    ("marker", "project_type"),
+    [
+        ("pyproject.toml", "python"),
+        ("setup.py", "python"),
+        ("Cargo.toml", "rust"),
+        ("go.mod", "go"),
+    ],
+)
+def test_detect_project_for_each_supported_marker(tmp_path, marker, project_type):
+    (tmp_path / marker).write_text("", encoding="utf-8")
+    assert fast_feedback.detect_project(str(tmp_path)) == project_type
+
+
+@pytest.mark.parametrize(
+    ("project_type", "expected_cmd", "expected_timeout"),
+    [
+        ("typescript", ["npx", "tsc", "--noEmit", "--pretty"], 30),
+        ("python", ["ruff", "check", "."], 15),
+        ("rust", ["cargo", "check", "--message-format=short"], 60),
+        ("go", ["go", "vet", "./..."], 30),
+    ],
+)
+def test_run_check_uses_expected_command(monkeypatch, project_type, expected_cmd, expected_timeout):
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, timeout, cwd):
+        captured["cmd"] = cmd
+        captured["capture_output"] = capture_output
+        captured["text"] = text
+        captured["timeout"] = timeout
+        captured["cwd"] = cwd
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(fast_feedback.subprocess, "run", fake_run)
+
+    result = fast_feedback.run_check(project_type, "/repo")
+    assert result.returncode == 0
+    assert captured["cmd"] == expected_cmd
+    assert captured["capture_output"] is True
+    assert captured["text"] is True
+    assert captured["timeout"] == expected_timeout
+    assert captured["cwd"] == "/repo"
+
+
+def test_run_check_returns_none_for_unknown_project():
+    assert fast_feedback.run_check("unknown", "/repo") is None
+
+
+def test_run_check_returns_none_on_missing_binary(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(fast_feedback.subprocess, "run", fake_run)
+    assert fast_feedback.run_check("python", "/repo") is None
+
+
+def test_run_check_returns_none_on_timeout(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        raise fast_feedback.subprocess.TimeoutExpired(cmd=["go", "vet", "./..."], timeout=30)
+
+    monkeypatch.setattr(fast_feedback.subprocess, "run", fake_run)
+    assert fast_feedback.run_check("go", "/repo") is None
+
+
+def test_main_exits_without_running_checks_when_project_undetected(monkeypatch, capsys):
+    monkeypatch.setattr(fast_feedback, "get_cwd", lambda: "/repo")
+    monkeypatch.setattr(fast_feedback, "detect_project", lambda _cwd: None)
+    monkeypatch.setattr(
+        fast_feedback,
+        "run_check",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("run_check should not be called")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        fast_feedback.main()
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_prints_issues_when_check_fails(monkeypatch, capsys):
+    monkeypatch.setattr(fast_feedback, "get_cwd", lambda: "/repo")
+    monkeypatch.setattr(fast_feedback, "detect_project", lambda _cwd: "python")
+    monkeypatch.setattr(
+        fast_feedback,
+        "run_check",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout="ruff error\n", stderr=""),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        fast_feedback.main()
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "[fast-feedback] python issues:" in output
+    assert "ruff error" in output
+
+
+def test_main_stays_silent_on_successful_check(monkeypatch, capsys):
+    monkeypatch.setattr(fast_feedback, "get_cwd", lambda: "/repo")
+    monkeypatch.setattr(fast_feedback, "detect_project", lambda _cwd: "go")
+    monkeypatch.setattr(
+        fast_feedback,
+        "run_check",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="ignored", stderr="ignored"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        fast_feedback.main()
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out == ""

--- a/base/hooks/test_memory_reminder.py
+++ b/base/hooks/test_memory_reminder.py
@@ -1,0 +1,45 @@
+"""Tests for memory-reminder hook."""
+
+import importlib.util
+import io
+import os
+
+import pytest
+
+
+_spec = importlib.util.spec_from_file_location(
+    "memory_reminder",
+    os.path.join(os.path.dirname(__file__), "memory-reminder.py"),
+)
+memory_reminder = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(memory_reminder)
+
+
+def run_hook(monkeypatch, payload):
+    monkeypatch.setattr(memory_reminder.sys, "stdin", io.StringIO(payload))
+    with pytest.raises(SystemExit) as exc:
+        memory_reminder.main()
+    assert exc.value.code == 0
+
+
+def test_prints_reminder_for_stop_event(monkeypatch, capsys):
+    run_hook(monkeypatch, '{"event":"Stop"}')
+    output = capsys.readouterr().out
+    assert "[memory-reminder] Session ending." in output
+    assert "MEMORY.md" in output
+
+
+def test_prints_reminder_for_lowercase_stop_event(monkeypatch, capsys):
+    run_hook(monkeypatch, '{"event":"stop"}')
+    output = capsys.readouterr().out
+    assert "Session ending" in output
+
+
+def test_no_output_for_other_events(monkeypatch, capsys):
+    run_hook(monkeypatch, '{"event":"PostToolUse"}')
+    assert capsys.readouterr().out == ""
+
+
+def test_no_output_for_invalid_json(monkeypatch, capsys):
+    run_hook(monkeypatch, "not-json")
+    assert capsys.readouterr().out == ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = base/hooks
+python_files = test_*.py


### PR DESCRIPTION
## Summary
- add `base/hooks/test_fast_feedback.py` to cover JSON cwd parsing, project detection, command selection/timeouts, and main output behavior
- add `base/hooks/test_memory_reminder.py` to cover stop event behavior and safe no-op paths
- add `pytest.ini` to standardize hook test discovery
- document hook test invocation in `README.md`

## Verification
- `python3 -m pytest -q` (109 passed)

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hook Testing section with test execution instructions.

* **Tests**
  * Added comprehensive unit tests for safety-critical hooks, covering various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->