### PR TITLE
fix: centralize sprite workspace path for dispatch

### DIFF
--- a/base/hooks/test_workspace_contract.py
+++ b/base/hooks/test_workspace_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+LIB_SH = ROOT_DIR / "scripts" / "lib.sh"
+DISPATCH_SH = ROOT_DIR / "scripts" / "dispatch.sh"
+
+
+def test_lib_defines_workspace_from_remote_home():
+    content = LIB_SH.read_text(encoding="utf-8")
+    assert 'REMOTE_HOME="/home/sprite"' in content
+    assert 'WORKSPACE="$REMOTE_HOME/workspace"' in content
+
+
+def test_dispatch_uses_lib_workspace_without_redefining():
+    content = DISPATCH_SH.read_text(encoding="utf-8")
+    assert 'source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"' in content
+    assert 'WORKSPACE="$REMOTE_HOME/workspace"' not in content
+    assert 'local remote_prompt="$WORKSPACE/.dispatch-prompt.md"' in content

--- a/scripts/dispatch.sh
+++ b/scripts/dispatch.sh
@@ -25,7 +25,6 @@ LOG_PREFIX="dispatch"
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TEMPLATE_DIR="$(dirname "${BASH_SOURCE[0]}")"
-WORKSPACE="$REMOTE_HOME/workspace"
 
 # Max iterations before Ralph loop self-terminates (safety valve)
 MAX_RALPH_ITERATIONS="${MAX_RALPH_ITERATIONS:-50}"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -13,6 +13,7 @@ BASE_DIR="$ROOT_DIR/base"
 SPRITE_CLI="${SPRITE_CLI:-sprite}"
 ORG="${FLY_ORG:-misty-step}"
 REMOTE_HOME="/home/sprite"
+WORKSPACE="$REMOTE_HOME/workspace"
 COMPOSITION="${COMPOSITION:-$ROOT_DIR/compositions/v1.yaml}"
 
 # Rendered settings tempfile (cleaned up via lib_cleanup)
@@ -200,7 +201,7 @@ composition_sprites() {
 # Single source of truth for what config artifacts get uploaded.
 push_config() {
     local name="$1"
-    upload_file "$name" "$BASE_DIR/CLAUDE.md" "$REMOTE_HOME/workspace/CLAUDE.md"
+    upload_file "$name" "$BASE_DIR/CLAUDE.md" "$WORKSPACE/CLAUDE.md"
     upload_dir "$name" "$BASE_DIR/hooks" "$REMOTE_HOME/.claude/hooks"
     upload_dir "$name" "$BASE_DIR/skills" "$REMOTE_HOME/.claude/skills"
     upload_dir "$name" "$BASE_DIR/commands" "$REMOTE_HOME/.claude/commands"


### PR DESCRIPTION
## Summary
- define `WORKSPACE` once in `scripts/lib.sh` (`$REMOTE_HOME/workspace`)
- remove duplicate `WORKSPACE` assignment from `scripts/dispatch.sh`
- update `push_config` to use shared `WORKSPACE` constant
- add regression test ensuring lib exports `WORKSPACE` and dispatch does not redefine it

## Validation
- `find scripts -type f -name "*.sh" -print0 | xargs -0 shellcheck -x -S error`
- `ruff check base/hooks`
- `python3 -m pytest -q base/hooks`
- `yamllint -c .yamllint.yml compositions`

Closes #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Introduced test module to verify shell script runtime behavior, including workspace path definitions and script sourcing expectations

## Chores
* Refactored workspace path configuration to use centralized variable references across shell scripts for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->