### PR TITLE
fix: ignore python bytecode artifacts globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ observations/archives/*/settings.json
 
 # OS
 .DS_Store
-base/hooks/__pycache__/
+
+# Python bytecode/cache artifacts
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- replace path-specific ignore with repo-wide Python bytecode ignores
- add `__pycache__/` and `*.pyc` to root `.gitignore`
- keep change scoped to VCS hygiene only

## Validation
- `git check-ignore -v base/hooks/__pycache__/probe.pyc scripts/__pycache__/probe.pyc tools/tmp.pyc`

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to more comprehensively exclude Python artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->