### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ observations/archives/*/settings.json
 
 # OS
 .DS_Store
+__pycache__/
 base/hooks/__pycache__/


### PR DESCRIPTION
Adds a global `__pycache__/` entry to .gitignore. The existing `base/hooks/__pycache__/` was too narrow — Python bytecache can appear anywhere in the repo.

Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore configuration for Python development files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->