### PR TITLE
fix: allow git push --tags in destructive command guard

### DIFF
--- a/base/hooks/destructive-command-guard.py
+++ b/base/hooks/destructive-command-guard.py
@@ -291,6 +291,11 @@ def _has_short_flag(args: list[str], flag_char: str) -> bool:
     )
 
 
+def _has_push_tags_flag(args: list[str]) -> bool:
+    """Return True if git push args include --tags."""
+    return any(arg == "--tags" for arg in _iter_option_args(args))
+
+
 def _normalize_branch_ref(ref: str) -> str:
     return ref.removeprefix("refs/heads/")
 
@@ -351,7 +356,7 @@ def check_push_protection(cmd: str) -> tuple[bool, str]:
     # On protected branch with bare push
     current = get_current_branch()
     if is_protected_branch(current):
-        if not targets:
+        if not targets and not _has_push_tags_flag(args):
             return True, (
                 f"On {current}. Direct push blocked.\n"
                 "Switch to feature branch:\n"


### PR DESCRIPTION
Fixes CI failure on master where `git push origin --tags` was incorrectly blocked by the destructive command guard.

**Root cause:** Bare `git push origin --tags` was treated as a push to a protected branch because `--tags` was not recognized as a valid non-destructive target.

**Fix:** Added `_has_push_tags_flag()` check — if the push includes `--tags`, it's pushing tags, not pushing to a protected branch.

**Test:** `test_allows_feature_branch_push[git push origin --tags]` now passes (was the only failing test in the 111-test suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated push protection on protected branches to allow pushes using the `--tags` flag while maintaining protection for direct pushes without explicit targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->