### PR TITLE
fix: ignore Python cache artifacts in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ observations/archives/*/settings.json
 
 # OS
 .DS_Store
+__pycache__/
+*.pyc
 base/hooks/__pycache__/
 bin/


### PR DESCRIPTION
## Summary
- add repo-wide Python cache ignore pattern (`__pycache__/`)
- add Python bytecode ignore pattern (`*.pyc`)
- keep existing hook-specific ignore entry intact

## Validation
- `git check-ignore -v __pycache__/x.pyc base/hooks/__pycache__/x.pyc foo.pyc`
- `go test ./...`

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude Python cache artifacts and compiled bytecode files from version control, improving repository cleanliness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->