### PR TITLE
feat: integrate Landfall release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Landfall: Automated semantic-release pipeline
+      # https://github.com/misty-step/landfall
+      - name: Run Landfall
+        uses: misty-step/landfall@v1
+        with:
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}


### PR DESCRIPTION
## Summary
- add .github/workflows/release.yml to run misty-step/landfall@v1 on pushes to main/master
- configure workflow permissions required for semantic-release and release updates
- use org secrets GH_RELEASE_TOKEN and MOONSHOT_API_KEY

## Notes
- Landfall integration work for priority repository rollout.
- Verified default branch is master; workflow trigger includes this branch.
- No existing semantic-release config conflicts were found in this repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release process to streamline deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->