### PR TITLE
docs: add Sprites vs Machines section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,53 @@ Compositions are hypotheses. The current v1 is 5 full-stack sprites with special
 
 Any sprite can handle any task. Preferences improve quality for domain work but never block progress.
 
-## Sprites vs Machines
+## Fleet Management: Sprites
 
 **Important:** This uses Fly.io **Sprites**, not Machines. They are different products:
 - Sprites: AI-native workloads with durable 100GB disks, auto-sleep (~$0 idle), Claude Code pre-installed
 - Machines: General-purpose VMs
 
 Always use the `sprite` CLI, not `fly machines`.
+
+### API Endpoint
+
+Sprites are managed through the `api.sprites.dev` endpoint:
+```bash
+export FLY_API_HOSTNAME="https://api.sprites.dev"
+```
+
+### Sprite CLI Commands
+
+The sprite CLI provides specialized commands for managing AI workloads:
+
+```bash
+# Create a new sprite
+sprite create <name> --region <region>
+
+# List all sprites
+sprite list
+
+# Get sprite details
+sprite show <name>
+
+# Connect to a sprite (SSH access)
+sprite connect <name>
+
+# Destroy a sprite
+sprite destroy <name>
+```
+
+### Sprites vs Machines Comparison
+
+| Feature | Sprites | Machines |
+|---------|---------|----------|
+| **Purpose** | AI-native workloads | General-purpose VMs |
+| **Disk** | 100GB durable disk | Variable, ephemeral by default |
+| **Auto-sleep** | Yes (~$0 when idle) | No (always running) |
+| **Claude Code** | Pre-installed | Manual installation |
+| **Cost model** | Sleep-based billing | Always-on billing |
+| **CLI** | `sprite` commands | `fly machines` commands |
+| **API endpoint** | api.sprites.dev | api.fly.io |
 
 ## Experimentation
 


### PR DESCRIPTION
## Summary\n\nAdded a comprehensive "Fleet Management: Sprites" section to README.md that explains:\n- Fly.io Sprites vs Machines distinction\n- API endpoint (api.sprites.dev)\n- Sprite CLI commands\n- Detailed comparison table\n\nThis clarifies that Misty Step uses Fly.io Sprites (not Machines) for fleet management.\n\n## Test plan\n- [x] Verified README formatting\n- [x] Confirmed section order and clarity\n- [x] Validated comparison table accuracy\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Sprites documentation with comprehensive API endpoint usage guidance and practical examples.
  * Added detailed CLI command examples for common Sprite operations.
  * Introduced a feature comparison table outlining Sprites vs Machines capabilities and differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->