### PR TITLE
fix: use two-component go directive with toolchain pin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/misty-step/bitterblossom
 
-go 1.25.6
+go 1.25
+
+toolchain go1.25.6
 
 require (
 	github.com/spf13/cobra v1.8.1


### PR DESCRIPTION
## Summary
- `go` directive changed from `1.25.6` to `1.25` (only two-component versions valid)
- Added `toolchain go1.25.6` directive to pin exact toolchain and prevent auto-download failures with Homebrew-installed Go

## Test plan
- [x] `go mod tidy` passes clean
- [x] `go build ./...` passes clean
- [x] Diagnostics no longer report invalid version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version configuration in project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->