### PR TITLE
docs: agent-first CLI reference and shell-shim deprecation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working in this repository.
 
 Bitterblossom is a declarative sprite factory. It provisions and manages Fly.io Sprites running Claude Code. This is infrastructure-as-config for AI agent orchestration.
 
-**No build steps, no tests, no dependencies.** Just config, scripts, and documentation.
+Go control plane (`bb` CLI) for fleet lifecycle, dispatch, and monitoring. Config, personas, and compositions are declarative.
 
 ## Key Concepts
 
@@ -19,26 +19,36 @@ Bitterblossom is a declarative sprite factory. It provisions and manages Fly.io 
 ## Architecture
 
 ```
+cmd/bb/            → Go CLI control plane (Cobra)
+internal/          → Core packages (dispatch, watchdog, agent, lifecycle, fleet)
+pkg/               → Shared libraries (fly, events)
 base/              → Shared config pushed to every sprite
 compositions/      → Team hypotheses (YAML)
 sprites/           → Individual persona definitions
 observations/      → Learning journal + experiment archives
-scripts/           → Real lifecycle scripts (provision, sync, teardown, dispatch, status)
+scripts/           → Legacy shell scripts (deprecated, see docs/MIGRATION.md)
 openclaw/          → Integration docs
+docs/              → CLI reference, contracts, migration guide
 ```
 
-## Scripts
+## CLI
 
-All scripts are real implementations using the `sprite` CLI:
+Primary interface is `bb` (Go CLI). See `docs/CLI-REFERENCE.md` for full reference.
 
-| Script | Purpose |
-|--------|---------|
-| `lib.sh` | Shared functions (sourced by other scripts) |
-| `provision.sh` | Create sprite + upload config |
-| `sync.sh` | Push config updates to running sprites |
-| `teardown.sh` | Export data + destroy sprite |
-| `dispatch.sh` | Send a task to a sprite (one-shot or Ralph loop) |
-| `status.sh` | Fleet overview |
+| Command | Purpose |
+|---------|---------|
+| `bb provision` | Create sprite + upload config |
+| `bb sync` | Push config updates to running sprites |
+| `bb teardown` | Export data + destroy sprite |
+| `bb dispatch` | Send a task to a sprite (one-shot or Ralph loop) |
+| `bb status` | Fleet overview or sprite detail |
+| `bb watchdog` | Fleet health checks + auto-recovery |
+| `bb compose` | Composition-driven reconciliation |
+| `bb agent` | On-sprite supervisor (start, stop, status, logs) |
+| `bb watch` | Real-time event stream dashboard |
+| `bb logs` | Historical event log queries |
+
+Build: `go build -o bb ./cmd/bb`
 
 ## Hooks
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Bitterblossom is how OpenClaw (Kaylee) provisions, manages, experiments with, an
 
 ```
 bitterblossom/
+├── cmd/bb/                # Go CLI control plane
+├── internal/              # Core packages (dispatch, watchdog, agent, lifecycle, fleet)
+├── pkg/                   # Shared libraries (fly, events)
 ├── base/                  # Shared config all sprites inherit
 │   ├── CLAUDE.md          # Base engineering philosophy (prompt)
 │   ├── settings.json      # Claude Code config (env, hooks)
@@ -24,66 +27,64 @@ bitterblossom/
 ├── sprites/               # Individual sprite identity + persona
 ├── observations/          # Learning journal + experiment results
 │   └── archives/          # Exported data from decommissioned sprites
-├── scripts/               # Lifecycle scripts (real implementations)
-│   ├── provision.sh       # Create sprite + upload config
-│   ├── sync.sh            # Push config updates to running sprites
-│   ├── teardown.sh        # Export data + destroy sprite
-│   ├── dispatch.sh        # Send a task to a sprite
-│   └── status.sh          # Fleet overview
+├── scripts/               # Legacy shell scripts (deprecated, see docs/MIGRATION.md)
+├── docs/                  # CLI reference, contracts, migration guide
 └── openclaw/              # Integration docs for Kaylee
 ```
 
 ## How It Works
 
-1. **Provision:** `./scripts/provision.sh bramble` — creates a Fly.io sprite, uploads base config + persona, configures Claude Code
-2. **Dispatch:** `./scripts/dispatch.sh bramble "Implement the auth middleware"` — sends work to a sprite
-3. **Observe:** After tasks complete, log patterns in `observations/OBSERVATIONS.md`
-4. **Iterate:** Edit composition YAML, re-provision, observe again
-5. **Experiment:** Try different compositions, compare observations, evolve
+1. **Provision:** `bb provision bramble` — creates a Fly.io sprite, uploads base config + persona, configures Claude Code
+2. **Dispatch:** `bb dispatch bramble "Implement the auth middleware" --execute` — sends work to a sprite
+3. **Monitor:** `bb watchdog` — check fleet health, auto-recover dead sprites
+4. **Observe:** After tasks complete, log patterns in `observations/OBSERVATIONS.md`
+5. **Iterate:** Edit composition YAML, `bb compose apply --execute`, observe again
+6. **Experiment:** Try different compositions, compare observations, evolve
 
 ## Quick Start
 
 ```bash
 # Required for provision/sync (settings.json is rendered at runtime)
 export ANTHROPIC_AUTH_TOKEN="<moonshot-key>"
+export FLY_APP="<fly-app-name>"
+export FLY_API_TOKEN="<fly-api-token>"
 
 # Recommended for GitHub permission isolation (phase 1 shared bot account)
 export SPRITE_GITHUB_DEFAULT_USER="misty-step-sprites"
 export SPRITE_GITHUB_DEFAULT_EMAIL="misty-step-sprites@users.noreply.github.com"
 export SPRITE_GITHUB_DEFAULT_TOKEN="<github-bot-token>"
 
-# Optional phase 2 override for one sprite (example: bramble)
-# export SPRITE_GITHUB_USER_BRAMBLE="bramble-sprite"
-# export SPRITE_GITHUB_EMAIL_BRAMBLE="bramble-sprite@users.noreply.github.com"
-# export SPRITE_GITHUB_TOKEN_BRAMBLE="<github-token-for-bramble>"
-
 # Fleet status
-./scripts/status.sh
+bb status --format text
+
+# Composition health: desired vs actual
+bb compose status
 
 # Provision all sprites from current composition
-./scripts/provision.sh --all
+bb provision --all
 
 # Provision a single sprite
-./scripts/provision.sh bramble
+bb provision bramble
 
-# Dispatch a task
-./scripts/dispatch.sh bramble "Build the user authentication API"
-./scripts/dispatch.sh thorn --repo misty-step/heartbeat "Write tests for the webhook handler"
+# Dispatch a task (dry-run first, then execute)
+bb dispatch bramble "Build the user authentication API"
+bb dispatch bramble "Build the user authentication API" --execute
 
-# Tail sprite logs (last N or live follow)
-./scripts/tail-logs.sh bramble -n 120
-./scripts/tail-logs.sh bramble --follow
+# Dispatch with repo clone
+bb dispatch thorn --repo misty-step/heartbeat "Write tests for the webhook handler" --execute
 
-# Go control-plane equivalents for issue dispatch and fleet polling
-go run ./cmd/bb run-task bramble heartbeat 42
-go run ./cmd/bb check-fleet --composition compositions/v2.yaml
+# Fleet health check (identifies dead/stale/blocked sprites)
+bb watchdog
+bb watchdog --execute    # auto-redispatch dead sprites
 
 # Sync config updates to running fleet
-./scripts/sync.sh
+bb sync
 
 # Decommission a sprite (exports MEMORY.md first)
-./scripts/teardown.sh bramble
+bb teardown bramble
 ```
+
+See [docs/CLI-REFERENCE.md](docs/CLI-REFERENCE.md) for the complete command reference.
 
 ## Composition Philosophy
 

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1,0 +1,485 @@
+# CLI Reference
+
+`bb` is the Bitterblossom fleet control plane. All commands emit JSON by default for agent consumption. Human-readable output is available via `--format text` or the absence of `--json`.
+
+## Global Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `FLY_APP` | Fly.io app name |
+| `FLY_API_TOKEN` / `FLY_TOKEN` | Fly.io API token |
+| `FLY_ORG` | Fly.io organization |
+| `SPRITE_CLI` | Path to `sprite` binary |
+| `ANTHROPIC_AUTH_TOKEN` | Moonshot key for settings rendering |
+
+---
+
+## compose
+
+Composition-driven fleet reconciliation.
+
+```
+bb compose <subcommand> [flags]
+```
+
+### Persistent Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--composition` | `compositions/v1.yaml` | Path to composition YAML |
+| `--app` | `$FLY_APP` | Fly.io app name |
+| `--token` | `$FLY_API_TOKEN` | Fly.io API token |
+| `--api-url` | `https://api.machines.dev` | Fly Machines API base URL |
+| `--json` | `false` | Emit JSON output |
+
+### compose diff
+
+Show reconciliation actions without executing.
+
+```bash
+bb compose diff
+bb compose diff --json
+```
+
+### compose apply
+
+Apply reconciliation actions. Dry-run by default.
+
+```bash
+bb compose apply                # dry-run: preview actions
+bb compose apply --execute      # apply actions
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--execute` | `false` | Execute reconciliation actions |
+
+### compose status
+
+Show current composition vs desired state.
+
+```bash
+bb compose status
+bb compose status --json
+```
+
+Exit code `0` always. Output includes missing, extra, and drifted sprites.
+
+---
+
+## dispatch
+
+Dispatch a task prompt to a sprite. **Dry-run by default.**
+
+```
+bb dispatch <sprite> [prompt] [flags]
+```
+
+### Examples
+
+```bash
+# Preview dispatch plan
+bb dispatch bramble "Build the auth API"
+
+# Execute dispatch
+bb dispatch bramble "Build the auth API" --execute
+
+# Ralph loop with file prompt
+bb dispatch bramble --ralph --file prompts/refactor.md --execute
+
+# With repo clone
+bb dispatch bramble --repo misty-step/heartbeat "Write webhook tests" --execute
+
+# JSON output for agent consumption
+bb dispatch bramble "Fix the bug" --execute --json
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--repo` | | Repo to clone/pull (`org/repo` or URL) |
+| `--file` | | Read prompt from file |
+| `--ralph` | `false` | Start persistent Ralph loop |
+| `--execute` | `false` | Execute dispatch (default is dry-run) |
+| `--dry-run` | `true` | Preview dispatch plan |
+| `--json` | `false` | Emit JSON output |
+| `--app` | `$FLY_APP` | Fly app name |
+| `--token` | `$FLY_API_TOKEN` | Fly API token |
+| `--api-url` | `https://api.machines.dev` | Fly Machines API URL |
+| `--org` | `$FLY_ORG` | Sprite org |
+| `--sprite-cli` | `$SPRITE_CLI` | Sprite CLI binary path |
+| `--composition` | `compositions/v1.yaml` | Composition YAML |
+| `--max-iterations` | `50` | Ralph loop iteration safety cap |
+| `--webhook-url` | `$SPRITE_WEBHOOK_URL` | Optional webhook URL |
+
+### State Machine
+
+```
+pending → provisioning → ready → prompt_uploaded → running → completed
+                                                          ↘ failed
+```
+
+Any state can transition to `failed` on error.
+
+### Exit Codes
+
+Standard (see [contracts](contracts.md)).
+
+---
+
+## watchdog
+
+Fleet health checks with optional auto-recovery. **Dry-run by default.**
+
+```
+bb watchdog [flags]
+```
+
+### Examples
+
+```bash
+# Check all sprites (dry-run)
+bb watchdog
+
+# Check specific sprites
+bb watchdog --sprite bramble --sprite fern
+
+# Execute redispatch on dead sprites
+bb watchdog --execute
+
+# JSON for monitoring integration
+bb watchdog --json
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sprite` | all | Specific sprite(s) to check |
+| `--execute` | `false` | Execute redispatch actions |
+| `--dry-run` | `true` | Preview watchdog actions |
+| `--json` | `false` | Emit JSON output |
+| `--stale-after` | `2h` | Duration before a sprite is classified stale |
+| `--max-iterations` | `50` | MAX_ITERATIONS for redispatch recovery |
+| `--org` | `$FLY_ORG` | Sprite org |
+| `--sprite-cli` | `$SPRITE_CLI` | Sprite CLI binary path |
+
+### Health States
+
+| State | Meaning | Action |
+|-------|---------|--------|
+| `active` | Running, producing commits | None |
+| `idle` | No agent, no task | None |
+| `complete` | Task finished | Needs attention |
+| `blocked` | BLOCKED.md present | Needs attention |
+| `dead` | No agent but has task | Redispatch (if PROMPT.md exists) |
+| `stale` | Running but no commits for >2h | Investigate |
+| `error` | Probe failed | Needs attention |
+
+### Exit Codes
+
+Exit `1` if any sprite needs attention. Exit `0` if fleet is healthy.
+
+---
+
+## agent
+
+On-sprite coding-agent supervisor. Runs on the sprite itself.
+
+```
+bb agent <subcommand> [flags]
+```
+
+### agent start
+
+Start the supervisor daemon. Daemonizes by default; use `--foreground` for direct execution.
+
+```bash
+bb agent start --task-prompt "Build the API" --task-repo misty-step/heartbeat
+bb agent start --task-prompt "Fix tests" --task-repo misty-step/api --foreground
+bb agent start --agent codex --yolo --task-prompt "Refactor auth" --task-repo org/repo
+```
+
+| Flag | Env | Default | Description |
+|------|-----|---------|-------------|
+| `--sprite` | `BB_SPRITE` | hostname | Sprite name |
+| `--repo-dir` | `BB_REPO_DIR` | `.` | Repository directory |
+| `--agent` | `BB_AGENT` | `codex` | Agent kind: `codex`, `kimi-code`, `claude` |
+| `--agent-command` | `BB_AGENT_COMMAND` | | Explicit agent executable |
+| `--agent-flags` | `BB_AGENT_FLAGS` | | Comma-separated agent flags |
+| `--model` | `BB_AGENT_MODEL` | | Model selection |
+| `--yolo` | `BB_AGENT_YOLO` | `false` | Enable agent YOLO mode |
+| `--full-auto` | `BB_AGENT_FULL_AUTO` | `false` | Enable full-auto mode |
+| `--env` | `BB_AGENT_ENV` | | `KEY=VALUE` environment overrides |
+| `--pass-env` | `BB_AGENT_PASS_ENV` | | Environment variables to pass through |
+| `--issue-url` | `BB_TASK_ISSUE_URL` | | Task issue URL |
+| `--task-prompt` | `BB_TASK_PROMPT` | | **Required.** Task prompt |
+| `--task-repo` | `BB_TASK_REPO` | | **Required.** Task repository |
+| `--task-branch` | `BB_TASK_BRANCH` | | Task branch |
+| `--event-log` | `BB_EVENT_LOG` | `.bb/events.jsonl` | JSONL event log path |
+| `--output-log` | `BB_OUTPUT_LOG` | `.bb/output.log` | Agent output log path |
+| `--pid-file` | `BB_PID_FILE` | `.bb/supervisor.pid` | PID file path |
+| `--state-file` | `BB_STATE_FILE` | `.bb/state.json` | State file path |
+| `--heartbeat-interval` | `BB_HEARTBEAT_INTERVAL` | `30s` | Heartbeat interval |
+| `--progress-interval` | `BB_PROGRESS_INTERVAL` | `60s` | Progress polling interval |
+| `--stall-timeout` | `BB_STALL_TIMEOUT` | `30m` | Stall timeout |
+| `--restart-delay` | `BB_RESTART_DELAY` | `5s` | Delay before restart |
+| `--shutdown-grace` | `BB_SHUTDOWN_GRACE` | `10s` | Grace period before SIGKILL |
+| `--foreground` | `BB_AGENT_FOREGROUND` | `false` | Run in foreground |
+
+### agent stop
+
+Gracefully stop the supervisor. Sends SIGTERM, waits, then SIGKILL.
+
+```bash
+bb agent stop
+bb agent stop --timeout 30s
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--pid-file` | `.bb/supervisor.pid` | PID file path |
+| `--timeout` | `15s` | Wait time before SIGKILL |
+
+### agent status
+
+Show supervisor state, task, and progress.
+
+```bash
+bb agent status
+bb agent status --json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--state-file` | `.bb/state.json` | State file path |
+| `--pid-file` | `.bb/supervisor.pid` | PID file path |
+| `--json` | `false` | JSON output |
+
+### agent logs
+
+Show agent output log.
+
+```bash
+bb agent logs
+bb agent logs --lines 50
+bb agent logs --follow
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output-log` | `.bb/output.log` | Output log path |
+| `--lines` | `100` | Number of tail lines |
+| `--follow` | `false` | Follow appended output |
+
+---
+
+## provision
+
+Provision sprites from a composition.
+
+```
+bb provision <sprite-name> [flags]
+bb provision --all [flags]
+```
+
+### Examples
+
+```bash
+bb provision bramble
+bb provision --all
+bb provision --all --composition compositions/v2.yaml
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--composition` | `compositions/v1.yaml` | Path to composition YAML |
+| `--all` | `false` | Provision all sprites from composition |
+| `--org` | `$FLY_ORG` | Fly.io organization |
+| `--sprite-cli` | `$SPRITE_CLI` | Path to sprite CLI |
+| `--timeout` | `30m` | Command timeout |
+
+---
+
+## sync
+
+Push base config and persona definitions to running sprites.
+
+```
+bb sync [sprite-name ...] [flags]
+```
+
+If no sprite names given, syncs all sprites from composition.
+
+### Examples
+
+```bash
+bb sync                     # sync all
+bb sync bramble             # sync one
+bb sync bramble fern        # sync specific sprites
+bb sync --base-only         # only shared config, skip personas
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--composition` | `compositions/v1.yaml` | Path to composition YAML |
+| `--base-only` | `false` | Only sync shared base config |
+| `--org` | `$FLY_ORG` | Fly.io organization |
+| `--sprite-cli` | `$SPRITE_CLI` | Path to sprite CLI |
+| `--timeout` | `30m` | Command timeout |
+
+---
+
+## status
+
+Fleet overview or detailed sprite status.
+
+```
+bb status [sprite-name] [flags]
+```
+
+### Examples
+
+```bash
+bb status                           # fleet overview (JSON)
+bb status --format text             # human-readable fleet overview
+bb status bramble                   # detailed single sprite
+bb status bramble --format text     # human-readable detail
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--composition` | `compositions/v1.yaml` | Path to composition YAML |
+| `--org` | `$FLY_ORG` | Fly.io organization |
+| `--sprite-cli` | `$SPRITE_CLI` | Path to sprite CLI |
+| `--format` | `json` | Output format: `json` or `text` |
+| `--timeout` | `2m` | Command timeout |
+
+---
+
+## teardown
+
+Export sprite learnings and destroy the sprite. Prompts for confirmation unless `--force`.
+
+```
+bb teardown <sprite-name> [flags]
+```
+
+### Examples
+
+```bash
+bb teardown bramble
+bb teardown bramble --force
+bb teardown bramble --archive-dir /tmp/archives
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--archive-dir` | `observations/archives` | Archive directory for exported data |
+| `--force` | `false` | Skip confirmation prompt |
+| `--org` | `$FLY_ORG` | Fly.io organization |
+| `--sprite-cli` | `$SPRITE_CLI` | Path to sprite CLI |
+| `--timeout` | `5m` | Command timeout |
+
+---
+
+## watch
+
+Real-time event stream dashboard.
+
+```
+bb watch --file <path> [flags]
+```
+
+### Examples
+
+```bash
+# Live dashboard
+bb watch --file events.jsonl
+
+# Filter by sprite
+bb watch --file events.jsonl --sprite bramble --sprite fern
+
+# JSON stream for piping
+bb watch --file events.jsonl --json
+
+# One-shot scan
+bb watch --file events.jsonl --once
+
+# Filter by severity
+bb watch --file events.jsonl --severity critical,warning
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file` | | **Required.** JSONL event file(s) |
+| `--sprite` | all | Filter by sprite name |
+| `--type` | all | Filter by event type |
+| `--severity` | all | Filter signals: `info`, `warning`, `critical` |
+| `--since` | | Events since duration or RFC3339 |
+| `--until` | | Events until RFC3339 |
+| `--json` | `false` | Emit JSONL output |
+| `--poll-interval` | `250ms` | File tail polling interval |
+| `--refresh` | `1s` | Dashboard refresh interval |
+| `--start-at-end` | `true` | Ignore existing lines |
+| `--once` | `false` | Scan once and exit |
+
+---
+
+## logs
+
+Query historical JSONL event logs.
+
+```
+bb logs --file <path> [flags]
+```
+
+### Examples
+
+```bash
+# Read all events
+bb logs --file events.jsonl
+
+# Last hour, JSON format
+bb logs --file events.jsonl --since 1h --json
+
+# Follow new events
+bb logs --file events.jsonl --follow
+
+# Filter by sprite and type
+bb logs --file events.jsonl --sprite bramble --type progress
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file` | | **Required.** JSONL event file(s) |
+| `--sprite` | all | Filter by sprite name |
+| `--type` | all | Filter by event type |
+| `--since` | | Events since duration or RFC3339 |
+| `--until` | | Events until RFC3339 |
+| `--follow` | `false` | Follow events as files grow |
+| `--json` | `false` | Emit JSONL output |
+| `--poll-interval` | `250ms` | File tail polling interval |
+
+---
+
+## version
+
+Print `bb` version.
+
+```bash
+bb version
+```

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,114 @@
+# Migration: Shell Scripts → Go CLI
+
+Bitterblossom is migrating from shell scripts to a Go control plane (`bb` CLI). This document maps deprecated shell commands to their Go replacements and tracks deprecation status.
+
+## Why
+
+Shell scripts served well as v1 glue but hit limits:
+
+- **Brittle process handling** — `nohup`, `pkill -f`, PID file races
+- **No testability** — can't unit test `bash -c` pipelines
+- **Injection risk** — crafted `--repo` URLs could break out of single-quoted `bash -c` strings (#26)
+- **No machine contracts** — exit codes and output formats were ad hoc
+- **N+1 remote calls** — `upload_dir` called `sprite exec` per file (#22)
+
+The Go CLI provides: explicit state machines, dependency-injected tests, validated inputs, JSON/NDJSON contracts, and deterministic exit codes.
+
+## Command Mapping
+
+| Shell Script | Go Command | Status |
+|-------------|-----------|--------|
+| `./scripts/provision.sh <sprite>` | `bb provision <sprite>` | Ported |
+| `./scripts/provision.sh --all` | `bb provision --all` | Ported |
+| `./scripts/sync.sh` | `bb sync` | Ported |
+| `./scripts/sync.sh <sprite>` | `bb sync <sprite>` | Ported |
+| `./scripts/status.sh` | `bb status` | Ported |
+| `./scripts/status.sh <sprite>` | `bb status <sprite>` | Ported |
+| `./scripts/teardown.sh <sprite>` | `bb teardown <sprite>` | Ported |
+| `./scripts/dispatch.sh <sprite> <prompt>` | `bb dispatch <sprite> <prompt> --execute` | Ported |
+| `./scripts/dispatch.sh <sprite> --ralph <prompt>` | `bb dispatch <sprite> --ralph <prompt> --execute` | Ported |
+| `./scripts/dispatch.sh <sprite> --file prompt.md` | `bb dispatch <sprite> --file prompt.md --execute` | Ported |
+| `./scripts/dispatch.sh <sprite> --repo org/repo <prompt>` | `bb dispatch <sprite> --repo org/repo <prompt> --execute` | Ported |
+| `./scripts/dispatch.sh <sprite> --status` | `bb watchdog --sprite <sprite>` | Ported (different model) |
+| `./scripts/dispatch.sh <sprite> --stop` | `bb agent stop` (on-sprite) | Ported |
+| `./scripts/tail-logs.sh <sprite> -n 120` | `bb agent logs --lines 120` (on-sprite) | Ported |
+| `./scripts/tail-logs.sh <sprite> --follow` | `bb agent logs --follow` (on-sprite) | Ported |
+
+### New Commands (no shell equivalent)
+
+| Go Command | Purpose |
+|-----------|---------|
+| `bb compose diff` | Preview fleet reconciliation actions |
+| `bb compose apply --execute` | Apply reconciliation (provision + teardown + update) |
+| `bb compose status` | Composition vs actual state comparison |
+| `bb watch --file events.jsonl` | Real-time event stream dashboard |
+| `bb logs --file events.jsonl` | Historical event log queries |
+| `bb agent start` | On-sprite supervisor daemon |
+| `bb agent status` | Supervisor state and progress |
+
+## Key Differences
+
+### Dry-Run Default
+
+All Go commands that modify state are dry-run by default. Pass `--execute` to apply changes.
+
+```bash
+# Shell: executes immediately
+./scripts/dispatch.sh bramble "Build the API"
+
+# Go: previews the plan
+bb dispatch bramble "Build the API"
+
+# Go: executes
+bb dispatch bramble "Build the API" --execute
+```
+
+### JSON Output
+
+Every Go command supports `--json` for machine consumption. Output follows the [contract envelope](contracts.md).
+
+```bash
+bb dispatch bramble "Build the API" --execute --json | jq '.data.state'
+bb watchdog --json | jq '.data.summary.needs_attention'
+bb status --format json | jq '.data.sprites'
+```
+
+### Composition-Driven Operations
+
+Go commands use composition files as the source of truth for fleet topology. Shell scripts had implicit sprite knowledge.
+
+```bash
+# Shell: knew about sprites from lib.sh globals
+./scripts/sync.sh
+
+# Go: reads composition YAML
+bb sync --composition compositions/v1.yaml
+```
+
+### Input Validation
+
+Go commands validate all inputs before making remote calls. Shell scripts validated minimally.
+
+- Sprite names: must match `^[a-z][a-z0-9-]*$`
+- Repo format: `org/repo` validated per component; URLs parsed via `url.Parse`
+- Prompt: rejects empty strings
+- Flags: conflicting combinations produce clear errors
+
+## Deprecation Timeline
+
+| Phase | Shell Scripts | Go CLI | When |
+|-------|-------------|--------|------|
+| Current | Available, still work | Primary interface | Now |
+| Next | Deprecated warnings in README | Sole documented interface | After #44 |
+| Final | Removed from `scripts/` | Only implementation | After full parity confirmed |
+
+Shell scripts remain in the repo for reference during the transition but are no longer the documented interface. New features are Go-only.
+
+## Issues Resolved by Migration
+
+| Issue | Problem | Resolution |
+|-------|---------|------------|
+| #20 | No provider abstraction in lib.sh | Go `sprite.SpriteCLI` interface |
+| #22 | N+1 remote calls in upload_dir | Go batches operations |
+| #26 | Command injection via crafted repo URL | Go validates via `url.Parse` + regex |
+| #38 | Global COMPOSITION mutation in lib.sh | Go passes composition path as flag |

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -17,7 +17,7 @@ Considerations when routing:
 ```
 1. Task arrives (GitHub issue, PR, manual request, cron)
 2. Kaylee decides which sprite to route to
-3. Kaylee dispatches: ./scripts/dispatch.sh <sprite> <prompt>
+3. Kaylee dispatches: bb dispatch <sprite> <prompt> --execute
 4. Sprite implements, commits, pushes to branch
 5. GitHub Action runs multi-model PR review (separate system)
 6. Kaylee logs observation in observations/OBSERVATIONS.md
@@ -28,17 +28,22 @@ Considerations when routing:
 
 ```bash
 # Simple task
-./scripts/dispatch.sh bramble "Build the REST API for user profiles"
+bb dispatch bramble "Build the REST API for user profiles" --execute
 
 # Task in a specific repo
-./scripts/dispatch.sh thorn --repo misty-step/heartbeat "Add integration tests for the alerting system"
+bb dispatch thorn --repo misty-step/heartbeat "Add integration tests for the alerting system" --execute
 
 # Complex prompt from file
-./scripts/dispatch.sh moss --file prompts/refactor-auth.md
+bb dispatch moss --file prompts/refactor-auth.md --execute
 
 # Long-running autonomous loop
-./scripts/dispatch.sh fern --ralph "Investigate flaky CI failures and ship a fix"
+bb dispatch fern --ralph "Investigate flaky CI failures and ship a fix" --execute
+
+# JSON output for programmatic consumption
+bb dispatch bramble "Fix the auth bug" --execute --json | jq '.data.state'
 ```
+
+All dispatch commands are dry-run by default. Omit `--execute` to preview the dispatch plan without side effects.
 
 ## Observing Results
 
@@ -74,18 +79,30 @@ When observations suggest changes:
 ## Fleet Management
 
 ```bash
-# Check fleet status
-./scripts/status.sh
+# Fleet status
+bb status --format text
+
+# Composition vs actual state
+bb compose status
+
+# Fleet health check (dead/stale/blocked detection)
+bb watchdog
+bb watchdog --execute    # auto-redispatch dead sprites
 
 # Sync config to all sprites after editing base/
-./scripts/sync.sh
+bb sync
 
 # Sync to just one sprite
-./scripts/sync.sh bramble
+bb sync bramble
 
 # Provision a new sprite
-./scripts/provision.sh <name>
+bb provision <name>
 
 # Decommission (exports MEMORY.md first)
-./scripts/teardown.sh <name>
+bb teardown <name>
+
+# Reconcile entire fleet to match composition
+bb compose apply --execute
 ```
+
+See [docs/CLI-REFERENCE.md](../docs/CLI-REFERENCE.md) for the full command reference.


### PR DESCRIPTION
## Summary

- Create `docs/CLI-REFERENCE.md` — complete `bb` subcommand reference with all flags, examples, and environment variables
- Create `docs/MIGRATION.md` — shell script → Go CLI mapping table with deprecation timeline and resolved issues
- Update `README.md` — lead with `bb` CLI examples, remove nonexistent `run-task`/`check-fleet` commands, add CLI reference link
- Update `openclaw/README.md` — show `bb dispatch` as primary interface for Kaylee's task dispatch
- Update `docs/QUALITY-GATEWAY.md` — replace shell+cron as long-term architecture with Go CLI commands
- Update `CLAUDE.md` — reflect Go CLI as primary interface, add command table

## Acceptance Criteria (from #44)

- [x] Docs provide copy/paste examples for agent workflows
- [x] Deprecated script paths and replacement commands explicitly mapped
- [x] Quality gateway docs no longer claim shell+cron as long-term architecture

Closes #44

## Test plan

- [ ] All Go tests pass (verified locally: 12/12 packages)
- [ ] CLI reference examples match actual `bb` subcommand flags
- [ ] Migration mapping covers all shell scripts in `scripts/`
- [ ] No broken links between docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to reflect the new bb CLI as the Go control plane for fleet lifecycle management
  * Added comprehensive CLI reference guide documenting commands, flags, and workflows
  * Added migration guide detailing the transition from legacy shell scripts to bb CLI commands
  * Reorganized architecture documentation to emphasize declarative configuration and control plane workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->