### PR TITLE
refactor: route legacy lifecycle scripts through bb compatibility shims

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -34,6 +34,23 @@ The Go CLI provides: explicit state machines, dependency-injected tests, validat
 | `./scripts/tail-logs.sh <sprite> -n 120` | `bb agent logs --lines 120` (on-sprite) | Ported |
 | `./scripts/tail-logs.sh <sprite> --follow` | `bb agent logs --follow` (on-sprite) | Ported |
 
+### Compatibility Wrappers
+
+The ported lifecycle entrypoints below are now thin wrappers that delegate to `bb`
+while keeping legacy invocation shapes intact:
+
+- `scripts/provision.sh`
+- `scripts/sync.sh`
+- `scripts/status.sh`
+- `scripts/teardown.sh`
+
+Wrapper `bb` resolution order:
+
+1. `BB_BIN` override
+2. repo-local `./bb`
+3. `bb` from `PATH`
+4. fallback `go run ./cmd/bb`
+
 ### New Commands (no shell equivalent)
 
 | Go Command | Purpose |

--- a/scripts/lib_bb.sh
+++ b/scripts/lib_bb.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+_bb_script_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+_bb_repo_root() {
+    cd "$(_bb_script_dir)/.." && pwd
+}
+
+bb_exec() {
+    local repo_root
+    repo_root="$(_bb_repo_root)"
+
+    if [[ -n "${BB_BIN:-}" ]]; then
+        local bb_bin
+        bb_bin="$BB_BIN"
+        if [[ "$bb_bin" == */* && "$bb_bin" != /* ]]; then
+            bb_bin="$PWD/$bb_bin"
+        fi
+        if [[ "$bb_bin" != */* ]]; then
+            bb_bin="$(command -v "$bb_bin" || true)"
+        fi
+        if [[ -z "$bb_bin" ]]; then
+            echo "error: BB_BIN=$BB_BIN could not be resolved" >&2
+            return 127
+        fi
+        (
+            cd "$repo_root"
+            "$bb_bin" "$@"
+        )
+        return
+    fi
+
+    if [[ -x "$repo_root/bb" ]]; then
+        (
+            cd "$repo_root"
+            "$repo_root/bb" "$@"
+        )
+        return
+    fi
+
+    if command -v bb >/dev/null 2>&1; then
+        (
+            cd "$repo_root"
+            bb "$@"
+        )
+        return
+    fi
+
+    if command -v go >/dev/null 2>&1; then
+        (
+            cd "$repo_root"
+            go run ./cmd/bb "$@"
+        )
+        return
+    fi
+
+    echo "error: unable to find bb binary; set BB_BIN or install Go." >&2
+    return 127
+}

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,199 +1,61 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Provision a sprite on Fly.io from its definition.
-#
-# Creates the sprite, uploads base config + persona, configures Claude Code,
-# and takes an initial checkpoint.
-#
-# Usage:
-#   ./scripts/provision.sh <sprite-name>    # Provision single sprite
-#   ./scripts/provision.sh --all            # Provision all sprites
-
-LOG_PREFIX="provision"
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib_bb.sh"
 
 usage() {
     local exit_code="${1:-1}"
-    echo "Usage: $0 [--composition <path>] <sprite-name|--all>"
-    echo ""
-    echo "  sprite-name              Name of sprite (matches sprites/<name>.md)"
-    echo "  --all                    Provision all sprites from current composition"
-    echo "  --composition <path>     Use specific composition YAML (default: compositions/v1.yaml)"
-    echo ""
-    echo "Environment:"
-    echo "  SPRITE_CLI    Path to sprite CLI (default: sprite)"
-    echo "  FLY_ORG       Fly.io organization (default: misty-step)"
-    echo "  SPRITE_GITHUB_DEFAULT_USER   Shared sprite GitHub username (default: misty-step-sprites)"
-    echo "  SPRITE_GITHUB_DEFAULT_EMAIL  Shared sprite GitHub email (default: <user>@users.noreply.github.com)"
-    echo "  SPRITE_GITHUB_DEFAULT_TOKEN  Shared sprite GitHub token"
-    echo "  SPRITE_GITHUB_USER_<SPRITE>  Per-sprite GitHub username override"
-    echo "  SPRITE_GITHUB_EMAIL_<SPRITE> Per-sprite GitHub email override"
-    echo "  SPRITE_GITHUB_TOKEN_<SPRITE> Per-sprite GitHub token override"
-    echo "  GITHUB_TOKEN                 Legacy token fallback (if default/per-sprite token unset)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 bramble"
-    echo "  $0 --all"
-    echo "  $0 --composition compositions/v2.yaml --all"
+    cat <<'USAGE'
+Usage: ./scripts/provision.sh [--composition <path>] <sprite-name|--all>
+
+  sprite-name              Name of sprite (matches sprites/<name>.md)
+  --all                    Provision all sprites from current composition
+  --composition <path>     Use specific composition YAML (default: compositions/v1.yaml)
+USAGE
     exit "$exit_code"
 }
 
-provision_sprite() {
-    local name="$1"
-    local definition="$SPRITES_DIR/${name}.md"
-
-    validate_sprite_name "$name"
-
-    if [[ ! -f "$definition" ]]; then
-        err "No sprite definition found at $definition"
-        exit 1
-    fi
-
-    log "=== Provisioning sprite: $name ==="
-
-    # Step 1: Create the sprite (if it doesn't already exist)
-    if sprite_exists "$name"; then
-        log "Sprite '$name' already exists, skipping creation"
-    else
-        log "Creating sprite '$name'..."
-        "$SPRITE_CLI" create "$name" -o "$ORG" --skip-console
-        log "Sprite '$name' created"
-    fi
-
-    # Step 2: Create workspace directory
-    log "Setting up workspace..."
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- mkdir -p "$REMOTE_HOME/workspace"
-
-    # Step 3: Upload base config (CLAUDE.md, hooks, skills, commands, settings)
-    log "Uploading base config..."
-    push_config "$name"
-
-    # Step 4: Upload sprite persona definition
-    log "Uploading persona: $name.md..."
-    upload_file "$name" "$definition" "$REMOTE_HOME/workspace/PERSONA.md"
-
-    # Step 5: Create initial MEMORY.md
-    log "Creating initial MEMORY.md..."
-    local composition_label
-    composition_label="$(basename "$COMPOSITION" .yaml)"
-    local timestamp
-    timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- bash -c \
-        'cat > '"$REMOTE_HOME"'/workspace/MEMORY.md << MEMEOF
-# MEMORY.md — $1
-
-Sprite: $1
-Provisioned: $2
-Composition: $3
-
-## Learnings
-
-_No observations yet. Update after completing work._
-MEMEOF' _ "$name" "$timestamp" "$composition_label"
-
-    # Step 6: Set up git config + credentials (sprites cannot push without this)
-    local gh_auth
-    gh_auth="$(resolve_sprite_github_auth "$name")" || exit 1
-    local gh_user gh_email gh_token
-    IFS=$'\t' read -r gh_user gh_email gh_token <<< "$gh_auth"
-
-    log "Configuring git identity + credentials (account: $gh_user)..."
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- bash -c \
-        'git config --global user.name "$1 ($2 sprite)" && \
-         git config --global user.email "$3" && \
-         git config --global credential.helper store && \
-         printf "https://%s:%s@github.com\n" "$4" "$5" > /home/sprite/.git-credentials && \
-         echo "Git credentials configured for $4"' _ "$name" "$gh_user" "$gh_email" "$gh_user" "$gh_token"
-
-    # Verify git auth works (define errors out of existence — fail here, not at push time)
-    log "Verifying git push access..."
-    local push_test
-    push_test=$("$SPRITE_CLI" exec -o "$ORG" -s "$name" -- bash -c \
-        'cd /tmp && rm -rf _git_test && mkdir _git_test && cd _git_test && \
-         git init -q && git remote add origin https://github.com/misty-step/cerberus.git && \
-         git ls-remote origin HEAD >/dev/null 2>&1 && echo GIT_AUTH_OK || echo GIT_AUTH_FAIL' 2>&1)
-    if [[ "$push_test" != *"GIT_AUTH_OK"* ]]; then
-        err "Git auth verification FAILED on sprite '$name'."
-        err "The sprite will not be able to push code. Fix credentials before dispatching."
-        exit 1
-    fi
-    log "Git auth verified ✅"
-
-    # Step 7: Bootstrap sprite environment (tools, dirs, sprite-agent)
-    local bootstrap_script="$ROOT_DIR/scripts/sprite-bootstrap.sh"
-    local agent_script="$ROOT_DIR/scripts/sprite-agent.sh"
-    if [[ ! -f "$bootstrap_script" || ! -f "$agent_script" ]]; then
-        err "Missing bootstrap assets. Expected:"
-        err "  $bootstrap_script"
-        err "  $agent_script"
-        exit 1
-    fi
-
-    log "Running sprite bootstrap..."
-    upload_file "$name" "$bootstrap_script" "/tmp/sprite-bootstrap.sh"
-    upload_file "$name" "$agent_script" "/tmp/sprite-agent.sh"
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- bash /tmp/sprite-bootstrap.sh --agent-source /tmp/sprite-agent.sh
-
-    # Step 8: Create initial checkpoint
-    log "Creating initial checkpoint..."
-    "$SPRITE_CLI" checkpoint create -o "$ORG" -s "$name" 2>&1 || log "Checkpoint creation skipped (may already exist)"
-
-    log "=== Done: $name ==="
-    log ""
-    log "Verify with:"
-    log "  sprite exec -o $ORG -s $name -- ls -la $REMOTE_HOME/workspace/"
-    log "  sprite exec -o $ORG -s $name -- cat $REMOTE_HOME/.claude/settings.json"
-}
-
-if [[ $# -eq 0 ]]; then
-    usage
-fi
-
-# Parse args
-PROVISION_ALL=false
-TARGETS=()
+args=()
+has_all=false
+target_count=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --help|-h)
+            usage 0
+            ;;
         --composition)
             if [[ -z "${2:-}" ]]; then
-                err "--composition requires a value"
-                usage
+                echo "error: --composition requires a value" >&2
+                usage 1
             fi
-            set_composition_path "$2" || exit 1
+            args+=("$1" "$2")
             shift 2
             ;;
-        --all) PROVISION_ALL=true; shift ;;
-        --help|-h) usage 0 ;;
-        *) TARGETS+=("$1"); shift ;;
+        --all)
+            has_all=true
+            args+=("$1")
+            shift
+            ;;
+        --*)
+            args+=("$1")
+            shift
+            ;;
+        *)
+            target_count=$((target_count + 1))
+            args+=("$1")
+            shift
+            ;;
     esac
 done
 
-if [[ "$PROVISION_ALL" == false ]] && [[ ${#TARGETS[@]} -eq 0 ]]; then
-    usage
-fi
-if [[ "$PROVISION_ALL" == true ]] && [[ ${#TARGETS[@]} -gt 0 ]]; then
-    err "Use either --all or explicit sprite names, not both."
-    usage
+if [[ ${#args[@]} -eq 0 ]]; then
+    usage 1
 fi
 
-trap lib_cleanup EXIT
-prepare_settings
-
-if [[ "$PROVISION_ALL" == true ]]; then
-    log "Provisioning sprites from composition: $COMPOSITION"
-    sprite_list=$(composition_sprites --strict) || exit 1
-    if [[ -z "$sprite_list" ]]; then
-        err "No sprites found in composition: $COMPOSITION"
-        exit 1
-    fi
-    while IFS= read -r name; do
-        provision_sprite "$name"
-        echo ""
-    done <<< "$sprite_list"
-    log "All sprites provisioned."
-else
-    for name in "${TARGETS[@]}"; do
-        provision_sprite "$name"
-    done
+if [[ "$has_all" == true && "$target_count" -gt 0 ]]; then
+    echo "error: use either --all or explicit sprite names, not both" >&2
+    usage 1
 fi
+
+bb_exec provision "${args[@]}"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,174 +1,77 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Show status of the sprite fleet.
-#
-# Usage:
-#   ./scripts/status.sh              # Fleet overview
-#   ./scripts/status.sh <sprite>     # Detailed sprite status
-
-LOG_PREFIX="status"
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib_bb.sh"
 
 usage() {
     local exit_code="${1:-1}"
-    echo "Usage: $0 [--composition <path>] [sprite-name]"
-    echo ""
-    echo "  No args: fleet overview"
-    echo "  --composition <path>  Use specific composition YAML"
-    echo "  sprite-name: detailed status for one sprite"
+    cat <<'USAGE'
+Usage: ./scripts/status.sh [--composition <path>] [sprite-name]
+
+  No args: fleet overview
+  --composition <path>  Use specific composition YAML
+  sprite-name: detailed status for one sprite
+USAGE
     exit "$exit_code"
 }
 
-fleet_status() {
-    echo "=== Bitterblossom Fleet Status ==="
-    echo ""
+args=()
+format_set=false
+target=""
 
-    # Get live sprite list from Fly.io
-    local live_sprites
-    live_sprites=$("$SPRITE_CLI" api -o "$ORG" /sprites 2>/dev/null | \
-        python3 -c "import sys,json; data=json.load(sys.stdin); [print(f\"{s['name']}\t{s['status']}\t{s.get('url','n/a')}\") for s in data.get('sprites',[])]" 2>/dev/null || echo "")
-
-    local sprite_list
-    sprite_list=$(composition_sprites) || sprite_list=""
-
-    if [[ -z "$live_sprites" ]]; then
-        echo "No sprites found (or API call failed)."
-        echo ""
-        echo "Composition sprites ($COMPOSITION):"
-        if [[ -n "$sprite_list" ]]; then
-            while IFS= read -r name; do
-                validate_sprite_name "$name" || continue
-                echo "  - $name (not provisioned)"
-            done <<< "$sprite_list"
-        fi
-        return
-    fi
-
-    # Show live sprites
-    printf "%-15s %-8s %s\n" "SPRITE" "STATUS" "URL"
-    printf "%-15s %-8s %s\n" "------" "------" "---"
-    echo "$live_sprites" | while IFS=$'\t' read -r name status url; do
-        if [[ -z "$name" || -z "$status" ]]; then
-            err "Malformed sprite data from API; skipping row."
-            continue
-        fi
-        printf "%-15s %-8s %s\n" "$name" "$status" "$url"
-    done
-
-    # Show composition sprites vs provisioned
-    echo ""
-    if [[ -n "$sprite_list" ]]; then
-        echo "Composition sprites ($COMPOSITION):"
-        while IFS= read -r name; do
-            validate_sprite_name "$name" || continue
-            if echo "$live_sprites" | grep -qF "${name}	"; then
-                echo "  ✓ $name (provisioned)"
-            else
-                echo "  ○ $name (not provisioned)"
-            fi
-        done <<< "$sprite_list"
-    fi
-
-    # Show orphan sprites (live but not in composition)
-    if [[ -n "$sprite_list" ]]; then
-        local orphans=""
-        while IFS=$'\t' read -r name status url; do
-            if [[ -z "$name" || -z "$status" ]]; then
-                err "Malformed sprite data from API; skipping row."
-                continue
-            fi
-            if ! echo "$sprite_list" | grep -qxF "$name"; then
-                orphans+="  ? $name ($status, not in composition)"$'\n'
-            fi
-        done <<< "$live_sprites"
-        if [[ -n "$orphans" ]]; then
-            echo ""
-            echo "Orphan sprites (live but not in composition):"
-            printf "%s" "$orphans"
-        fi
-    fi
-
-    # Show checkpoints
-    echo ""
-    echo "Checkpoints:"
-    echo "$live_sprites" | while IFS=$'\t' read -r name status url; do
-        if [[ -z "$name" ]]; then
-            err "Malformed sprite data from API; skipping checkpoint lookup."
-            continue
-        fi
-        local checkpoints
-        checkpoints=$("$SPRITE_CLI" checkpoint list -o "$ORG" -s "$name" 2>/dev/null || echo "  (none)")
-        echo "  $name: $checkpoints"
-    done
-}
-
-sprite_detail() {
-    local name="$1"
-    validate_sprite_name "$name"
-    echo "=== Sprite: $name ==="
-    echo ""
-
-    # API info
-    "$SPRITE_CLI" api -o "$ORG" -s "$name" / 2>/dev/null | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for k, v in data.items():
-    if isinstance(v, dict):
-        print(f'{k}:')
-        for kk, vv in v.items():
-            print(f'  {kk}: {vv}')
-    else:
-        print(f'{k}: {v}')
-" 2>/dev/null || echo "(API call failed)"
-
-    echo ""
-
-    # Check workspace contents
-    echo "Workspace:"
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- ls -la "$REMOTE_HOME/workspace/" 2>/dev/null || echo "  (no workspace)"
-
-    echo ""
-
-    # Show MEMORY.md summary
-    echo "MEMORY.md (first 20 lines):"
-    "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- head -20 "$REMOTE_HOME/workspace/MEMORY.md" 2>/dev/null || echo "  (no MEMORY.md)"
-
-    echo ""
-
-    # Checkpoints
-    echo "Checkpoints:"
-    "$SPRITE_CLI" checkpoint list -o "$ORG" -s "$name" 2>/dev/null || echo "  (none)"
-}
-
-# Parse args
-TARGET=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --composition)
-            if [[ -z "${2:-}" ]]; then
-                err "--composition requires a value"
-                exit 1
-            fi
-            set_composition_path "$2" || exit 1
-            shift 2
-            ;;
         --help|-h)
             usage 0
             ;;
-        *)
-            if [[ -n "$TARGET" ]]; then
-                err "Only one sprite name can be provided."
-                usage
+        --composition)
+            if [[ -z "${2:-}" ]]; then
+                echo "error: --composition requires a value" >&2
+                usage 1
             fi
-            TARGET="$1"
+            args+=("$1" "$2")
+            shift 2
+            ;;
+        --format)
+            if [[ -z "${2:-}" ]]; then
+                echo "error: --format requires a value" >&2
+                usage 1
+            fi
+            format_set=true
+            args+=("$1" "$2")
+            shift 2
+            ;;
+        --json)
+            format_set=true
+            args+=("$1")
+            shift
+            ;;
+        --*)
+            args+=("$1")
+            shift
+            ;;
+        *)
+            if [[ -n "$target" ]]; then
+                echo "error: only one sprite name can be provided" >&2
+                usage 1
+            fi
+            target="$1"
             shift
             ;;
     esac
 done
 
-if [[ -z "$TARGET" ]]; then
-    fleet_status
-else
-    sprite_detail "$TARGET"
+if [[ "$format_set" == false ]]; then
+    if [[ ${#args[@]} -eq 0 ]]; then
+        args=(--format text)
+    else
+        args=(--format text "${args[@]}")
+    fi
 fi
+
+if [[ -n "$target" ]]; then
+    args+=("$target")
+fi
+
+bb_exec status "${args[@]}"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,94 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync config updates to running sprites.
-#
-# Pushes updated base config, hooks, skills, commands, and optionally
-# sprite persona definitions to running sprites.
-#
-# Usage:
-#   ./scripts/sync.sh              # Sync all sprites
-#   ./scripts/sync.sh <sprite>     # Sync specific sprite
-#   ./scripts/sync.sh --base-only  # Only sync base config (no persona)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib_bb.sh"
 
-LOG_PREFIX="sync"
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+usage() {
+    local exit_code="${1:-1}"
+    cat <<'USAGE'
+Usage: ./scripts/sync.sh [--base-only] [--composition <path>] [sprite-name ...]
 
-BASE_ONLY=false
-
-sync_sprite() {
-    local name="$1"
-
-    validate_sprite_name "$name"
-
-    log "=== Syncing: $name ==="
-
-    if ! sprite_exists "$name"; then
-        err "Sprite '$name' does not exist. Run provision.sh first."
-        return 1
-    fi
-
-    # Sync base config (CLAUDE.md, hooks, skills, commands, settings)
-    log "Syncing base config..."
-    push_config "$name"
-
-    # Sync persona definition (unless --base-only)
-    if [[ "$BASE_ONLY" == false ]]; then
-        local definition="$SPRITES_DIR/${name}.md"
-        if [[ -f "$definition" ]]; then
-            log "Syncing persona definition..."
-            upload_file "$name" "$definition" "$REMOTE_HOME/workspace/PERSONA.md"
-        else
-            log "No persona definition found at $definition, skipping"
-        fi
-    fi
-
-    log "=== Done: $name ==="
+  --base-only          Only sync shared base config (skip persona definitions)
+  --composition <path> Use specific composition YAML (default: compositions/v1.yaml)
+  sprite-name          Sync specific sprite(s). Default: all from composition.
+USAGE
+    exit "$exit_code"
 }
 
-# Parse args
-TARGETS=()
+args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --base-only) BASE_ONLY=true; shift ;;
+        --help|-h)
+            usage 0
+            ;;
         --composition)
             if [[ -z "${2:-}" ]]; then
-                err "--composition requires a value"
-                exit 1
+                echo "error: --composition requires a value" >&2
+                usage 1
             fi
-            set_composition_path "$2" || exit 1
+            args+=("$1" "$2")
             shift 2
             ;;
-        --help|-h)
-            echo "Usage: $0 [--base-only] [--composition <path>] [sprite-name ...]"
-            echo ""
-            echo "  --base-only          Only sync shared base config (skip persona definitions)"
-            echo "  --composition <path> Use specific composition YAML (default: compositions/v1.yaml)"
-            echo "  sprite-name          Sync specific sprite(s). Default: all from composition."
-            exit 0
+        *)
+            args+=("$1")
+            shift
             ;;
-        *) TARGETS+=("$1"); shift ;;
     esac
 done
 
-trap lib_cleanup EXIT
-prepare_settings
-
-if [[ ${#TARGETS[@]} -eq 0 ]]; then
-    log "Syncing sprites from composition: $COMPOSITION"
-    sprite_list=$(composition_sprites --strict) || exit 1
-    if [[ -z "$sprite_list" ]]; then
-        err "No sprites found in composition: $COMPOSITION"
-        exit 1
-    fi
-    while IFS= read -r name; do
-        sync_sprite "$name"
-        echo ""
-    done <<< "$sprite_list"
-    log "All sprites synced."
+if [[ ${#args[@]} -eq 0 ]]; then
+    bb_exec sync
 else
-    for name in "${TARGETS[@]}"; do
-        sync_sprite "$name"
-        echo ""
-    done
+    bb_exec sync "${args[@]}"
 fi

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,127 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Decommission a sprite.
-#
-# Exports MEMORY.md and CLAUDE.md (sprite's self-modified config) before
-# destroying the sprite. Preserves the sprite definition file.
-#
-# Usage:
-#   ./scripts/teardown.sh <sprite-name>
-#   ./scripts/teardown.sh --force <sprite-name>   # Skip confirmation
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib_bb.sh"
 
-LOG_PREFIX="teardown"
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+usage() {
+    local exit_code="${1:-1}"
+    cat <<'USAGE'
+Usage: ./scripts/teardown.sh [--force] <sprite-name>
 
-ARCHIVE_DIR="$ROOT_DIR/observations/archives"
-FORCE=false
-
-teardown_sprite() {
-    local name="$1"
-    local timestamp
-    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-    local archive_path="$ARCHIVE_DIR/${name}-${timestamp}"
-
-    validate_sprite_name "$name"
-
-    log "=== Tearing down sprite: $name ==="
-
-    if ! sprite_exists "$name"; then
-        err "Sprite '$name' does not exist"
-        exit 1
-    fi
-
-    # Confirmation
-    if [[ "$FORCE" == false ]]; then
-        echo ""
-        echo "  This will DESTROY sprite '$name' and its disk."
-        echo "  MEMORY.md and workspace CLAUDE.md will be exported first."
-        echo ""
-        read -rp "  Continue? [y/N] " confirm
-        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-            log "Aborted."
-            exit 0
-        fi
-    fi
-
-    # Step 1: Export learnings
-    log "Exporting sprite data..."
-    mkdir -p "$archive_path"
-
-    # Export MEMORY.md
-    if "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- cat "$REMOTE_HOME/workspace/MEMORY.md" \
-        > "$archive_path/MEMORY.md" 2>/dev/null; then
-        log "Exported MEMORY.md → $archive_path/MEMORY.md"
-    else
-        log "No MEMORY.md found (or empty)"
-    fi
-
-    # Export the sprite's self-modified CLAUDE.md
-    if "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- cat "$REMOTE_HOME/workspace/CLAUDE.md" \
-        > "$archive_path/CLAUDE.md" 2>/dev/null; then
-        log "Exported CLAUDE.md → $archive_path/CLAUDE.md"
-    else
-        log "No workspace CLAUDE.md found"
-    fi
-
-    # Export the sprite's modified settings.json (strip auth token)
-    if "$SPRITE_CLI" exec -o "$ORG" -s "$name" -- cat "$REMOTE_HOME/.claude/settings.json" \
-        2>/dev/null | python3 -c "
-import sys, json
-try:
-    data = json.load(sys.stdin)
-    env = data.get('env', {})
-    if 'ANTHROPIC_AUTH_TOKEN' in env:
-        env['ANTHROPIC_AUTH_TOKEN'] = '__REDACTED__'
-    json.dump(data, sys.stdout, indent=2)
-except: sys.exit(1)
-" > "$archive_path/settings.json"; then
-        log "Exported settings.json → $archive_path/settings.json (token redacted)"
-    else
-        log "No settings.json found (or parse error)"
-    fi
-
-    # Step 2: Create a final checkpoint (safety net)
-    log "Creating final checkpoint before destruction..."
-    "$SPRITE_CLI" checkpoint create -o "$ORG" -s "$name" 2>&1 || log "Final checkpoint failed (continuing)"
-
-    # Step 3: Destroy the sprite
-    log "Destroying sprite '$name'..."
-    "$SPRITE_CLI" destroy "$name" -o "$ORG" --force
-
-    log ""
-    log "Sprite '$name' destroyed."
-    log "Archives saved to: $archive_path/"
-    log "Sprite definition preserved at: $SPRITES_DIR/${name}.md"
-    log ""
-    log "=== Done: $name ==="
+  --force   Skip confirmation prompt
+USAGE
+    exit "$exit_code"
 }
 
-# Parse args
-SPRITE_NAME=""
-for arg in "$@"; do
-    case "$arg" in
-        --force|-f) FORCE=true ;;
+args=()
+sprite_name=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --help|-h)
-            echo "Usage: $0 [--force] <sprite-name>"
-            echo ""
-            echo "  --force   Skip confirmation prompt"
-            exit 0
+            usage 0
+            ;;
+        --force|-f)
+            args+=(--force)
+            shift
+            ;;
+        --*)
+            args+=("$1")
+            shift
             ;;
         *)
-            if [[ -z "$SPRITE_NAME" ]]; then
-                SPRITE_NAME="$arg"
-            else
-                err "Too many arguments"
-                exit 1
+            if [[ -n "$sprite_name" ]]; then
+                echo "error: too many arguments" >&2
+                usage 1
             fi
+            sprite_name="$1"
+            shift
             ;;
     esac
 done
 
-if [[ -z "$SPRITE_NAME" ]]; then
-    echo "Usage: $0 [--force] <sprite-name>"
-    exit 1
+if [[ -z "$sprite_name" ]]; then
+    usage 1
 fi
 
-teardown_sprite "$SPRITE_NAME"
+bb_exec teardown "${args[@]}" "$sprite_name"

--- a/scripts/test_legacy_wrappers.sh
+++ b/scripts/test_legacy_wrappers.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CALLS_FILE="$TMP_DIR/calls.log"
+FAKE_BB="$TMP_DIR/fake-bb"
+
+cat > "$FAKE_BB" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+calls_file="${BB_WRAPPER_CALLS_FILE:?missing BB_WRAPPER_CALLS_FILE}"
+printf '%s\n' "$*" >> "$calls_file"
+FAKE
+chmod +x "$FAKE_BB"
+
+assert_call() {
+    local expected="$1"
+    local actual
+    actual="$(tail -n 1 "$CALLS_FILE")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "expected: $expected" >&2
+        echo "actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+run_case() {
+    local expected="$1"
+    shift
+    : > "$CALLS_FILE"
+    BB_BIN="$FAKE_BB" \
+    BB_WRAPPER_CALLS_FILE="$CALLS_FILE" \
+        "$@"
+    assert_call "$expected"
+}
+
+run_case "provision --composition compositions/v2.yaml --all" \
+    "$ROOT_DIR/scripts/provision.sh" --composition compositions/v2.yaml --all
+
+run_case "sync --base-only willow" \
+    "$ROOT_DIR/scripts/sync.sh" --base-only willow
+
+run_case "status --format text bramble" \
+    "$ROOT_DIR/scripts/status.sh" bramble
+
+run_case "status --format json bramble" \
+    "$ROOT_DIR/scripts/status.sh" --format json bramble
+
+run_case "status --json bramble" \
+    "$ROOT_DIR/scripts/status.sh" --json bramble
+
+run_case "teardown --force fern" \
+    "$ROOT_DIR/scripts/teardown.sh" --force fern
+
+echo "legacy wrapper tests passed"


### PR DESCRIPTION
## Summary
- add `scripts/lib_bb.sh` to resolve and execute `bb` consistently (`BB_BIN` -> `./bb` -> PATH -> `go run ./cmd/bb`)
- convert legacy lifecycle entrypoints (`scripts/provision.sh`, `scripts/sync.sh`, `scripts/status.sh`, `scripts/teardown.sh`) into thin wrappers that preserve invocation shape and delegate to `bb`
- keep `status.sh` human-readable by default (`--format text`) while respecting explicit `--format`/`--json`
- add `scripts/test_legacy_wrappers.sh` to validate wrapper argument mapping
- document wrapper behavior in `docs/MIGRATION.md`

## Validation
- `./scripts/test_legacy_wrappers.sh`
- `find scripts -type f -name "*.sh" -print0 | xargs -0 shellcheck -x -S error`
- `go test ./...`

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added compatibility wrappers section detailing unified script behavior and binary resolution order.

* **Refactor**
  * Simplified provision, sync, status, and teardown scripts with centralized binary resolution and consistent invocation patterns.

* **Tests**
  * Added legacy wrapper test suite to validate script behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->