### PR TITLE
test: harden bb scaffold acceptance checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 
 test:
 	go test ./...
+	./scripts/test_legacy_wrappers.sh
 
 lint:
 	golangci-lint run

--- a/cmd/bb/main_test.go
+++ b/cmd/bb/main_test.go
@@ -70,7 +70,34 @@ func TestVersionSubcommandOutput(t *testing.T) {
 	}
 }
 
-func TestRootWiresDispatchAndWatchdog(t *testing.T) {
+func TestRootHelpListsCoreCommandGroups(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCommand()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute help command: %v", err)
+	}
+
+	help := out.String()
+	for _, want := range []string{
+		"dispatch",
+		"provision",
+		"sync",
+		"status",
+		"teardown",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help output missing %q:\n%s", want, help)
+		}
+	}
+}
+
+func TestRootWiresCoreCommands(t *testing.T) {
 	t.Parallel()
 
 	root := newRootCommand()
@@ -78,11 +105,22 @@ func TestRootWiresDispatchAndWatchdog(t *testing.T) {
 	for _, command := range root.Commands() {
 		names[command.Name()] = struct{}{}
 	}
-	if _, ok := names["dispatch"]; !ok {
-		t.Fatal("dispatch command not wired")
-	}
-	if _, ok := names["watchdog"]; !ok {
-		t.Fatal("watchdog command not wired")
+
+	for _, want := range []string{
+		"agent",
+		"compose",
+		"dispatch",
+		"logs",
+		"provision",
+		"status",
+		"sync",
+		"teardown",
+		"watch",
+		"watchdog",
+	} {
+		if _, ok := names[want]; !ok {
+			t.Fatalf("%s command not wired", want)
+		}
 	}
 }
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -44,6 +44,8 @@ while keeping legacy invocation shapes intact:
 - `scripts/status.sh`
 - `scripts/teardown.sh`
 
+Compatibility is enforced by `scripts/test_legacy_wrappers.sh` and runs in `make test`.
+
 Wrapper `bb` resolution order:
 
 1. `BB_BIN` override


### PR DESCRIPTION
## Summary
- add root command acceptance coverage for the scaffolded control-plane surface
- enforce legacy lifecycle wrapper compatibility as part of go test ./...
ok  	github.com/misty-step/bitterblossom/cmd/bb	(cached)
ok  	github.com/misty-step/bitterblossom/internal/agent	(cached)
ok  	github.com/misty-step/bitterblossom/internal/config	(cached)
ok  	github.com/misty-step/bitterblossom/internal/contracts	(cached)
ok  	github.com/misty-step/bitterblossom/internal/dispatch	(cached)
ok  	github.com/misty-step/bitterblossom/internal/fleet	(cached)
ok  	github.com/misty-step/bitterblossom/internal/lifecycle	(cached)
ok  	github.com/misty-step/bitterblossom/internal/monitor	(cached)
ok  	github.com/misty-step/bitterblossom/internal/provider	(cached)
ok  	github.com/misty-step/bitterblossom/internal/sprite	(cached)
ok  	github.com/misty-step/bitterblossom/internal/watchdog	(cached)
ok  	github.com/misty-step/bitterblossom/pkg/events	(cached)
ok  	github.com/misty-step/bitterblossom/pkg/fly	(cached)
./scripts/test_legacy_wrappers.sh
legacy wrapper tests passed
- document wrapper compatibility enforcement in migration docs

## Validation
- make test
- make build

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced command wiring validation to ensure all core commands are properly initialized and help text displays correctly.

* **Documentation**
  * Clarified how compatibility enforcement is validated through test execution.

* **Chores**
  * Updated build pipeline to run additional compatibility tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->