### PR TITLE
fix(ci): fail Council Verdict on fork PRs

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -44,6 +44,15 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Fork PRs blocked (no secrets)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        shell: bash
+        run: |
+          echo "::error::Cerberus Council does not run on fork PRs (secrets safety)."
+          echo "::error::Resolution: open PR from a branch in this repo, or have a maintainer re-home the branch."
+          exit 1
+
       - uses: misty-step/cerberus/verdict@v2
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #121: make `Council Verdict` deterministic on fork PRs.

Problem
- `review` job is skipped on forks to protect secrets.
- `Council Verdict` is a required check (see `docs/QUALITY-GATEWAY.md`), so forks need an explicit failure mode.

Change
- In `verdict` job, fail fast on fork PRs with a clear error.
- Only run `misty-step/cerberus/verdict@v2` on same-repo PRs.

Result
- Fork PRs can’t merge without being re-homed into this repo.
- Same-repo PRs unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security by preventing fork pull requests from running Cerberus verification checks. Security gates now apply conditionally based on pull request source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->