### PR TITLE
revert: fail Council Verdict on fork PRs

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -44,15 +44,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Fork PRs blocked (no secrets)
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        shell: bash
-        run: |
-          echo "::error::Cerberus Council does not run on fork PRs (secrets safety)."
-          echo "::error::Resolution: open PR from a branch in this repo, or have a maintainer re-home the branch."
-          exit 1
-
       - uses: misty-step/cerberus/verdict@v2
-        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts #147.

Rationale
- Don’t add repo-local Cerberus behavior.
- If fork/required-check semantics are a real problem, fix it upstream in `misty-step/cerberus` (issue filed).

Notes
- This returns `.github/workflows/cerberus.yml` to the v2 workflow without the extra fork-specific failure step.