### PR TITLE
ux(dispatch): unify FLY_APP and FLY_API_TOKEN validation (fixes #180)

### DIFF
--- a/cmd/bb/compose.go
+++ b/cmd/bb/compose.go
@@ -232,11 +232,10 @@ func loadFleetState(ctx context.Context, opts composeOptions, deps composeDeps) 
 		return fleet.Composition{}, nil, nil, err
 	}
 
-	if strings.TrimSpace(opts.App) == "" {
-		return fleet.Composition{}, nil, nil, errors.New("--app (or FLY_APP) is required")
-	}
-	if strings.TrimSpace(opts.Token) == "" {
-		return fleet.Composition{}, nil, nil, errors.New("--token (or FLY_API_TOKEN/FLY_TOKEN) is required")
+	appMissing := strings.TrimSpace(opts.App) == ""
+	tokenMissing := strings.TrimSpace(opts.Token) == ""
+	if appMissing || tokenMissing {
+		return fleet.Composition{}, nil, nil, errors.New("Error: FLY_APP and FLY_API_TOKEN are required for sprite operations.\n  export FLY_APP=your-app\n  export FLY_API_TOKEN=your-token")
 	}
 
 	client, err := deps.newClient(opts.Token, opts.APIURL)

--- a/cmd/bb/compose_extra_test.go
+++ b/cmd/bb/compose_extra_test.go
@@ -116,14 +116,14 @@ func TestLoadFleetStateErrors(t *testing.T) {
 	_, _, _, err = loadFleetState(context.Background(), composeOptions{Token: "token"}, composeDeps{
 		parseComposition: func(string) (fleet.Composition, error) { return testComposition(), nil },
 	})
-	if err == nil || !strings.Contains(err.Error(), "--app") {
+	if err == nil || !strings.Contains(err.Error(), "FLY_APP and FLY_API_TOKEN are required") {
 		t.Fatalf("missing app error = %v", err)
 	}
 
 	_, _, _, err = loadFleetState(context.Background(), composeOptions{App: "app"}, composeDeps{
 		parseComposition: func(string) (fleet.Composition, error) { return testComposition(), nil },
 	})
-	if err == nil || !strings.Contains(err.Error(), "--token") {
+	if err == nil || !strings.Contains(err.Error(), "FLY_APP and FLY_API_TOKEN are required") {
 		t.Fatalf("missing token error = %v", err)
 	}
 

--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -94,11 +94,10 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 				return err
 			}
 
-			if strings.TrimSpace(opts.App) == "" {
-				return errors.New("dispatch: --app (or FLY_APP) is required")
-			}
-			if strings.TrimSpace(opts.Token) == "" {
-				return errors.New("dispatch: --token (or FLY_API_TOKEN/FLY_TOKEN) is required")
+			appMissing := strings.TrimSpace(opts.App) == ""
+			tokenMissing := strings.TrimSpace(opts.Token) == ""
+			if appMissing || tokenMissing {
+				return errors.New("Error: FLY_APP and FLY_API_TOKEN are required for sprite operations.\n  export FLY_APP=your-app\n  export FLY_API_TOKEN=your-token")
 			}
 
 			flyClient, err := deps.newFlyClient(opts.Token, opts.APIURL)


### PR DESCRIPTION
Closes #180

**Problem:**
BB validates FLY_APP and FLY_API_TOKEN separately, showing errors one at a time. Users get a frustrating loop.

**Solution:**
Unified validation with single helpful error message showing both required env vars.

**Changes:**
- cmd/bb/dispatch.go: Unified env validation
- cmd/bb/compose.go: Same for fleet operations  
- Updated tests for new error format

**Before:**
```
FLY_APP environment variable is required
# (user sets it, tries again)
FLY_API_TOKEN environment variable is required
```

**After:**
```
Error: FLY_APP and FLY_API_TOKEN are required for sprite operations.
  export FLY_APP=your-app
  export FLY_API_TOKEN=your-token
```

**Testing:**
- All tests pass\n- Manually verified error message