### PR TITLE
fix(dispatch): clear error messages for missing FLY_APP/FLY_API_TOKEN

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -94,10 +94,11 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 				return err
 			}
 
-			appMissing := strings.TrimSpace(opts.App) == ""
-			tokenMissing := strings.TrimSpace(opts.Token) == ""
-			if appMissing || tokenMissing {
-				return errors.New("Error: FLY_APP and FLY_API_TOKEN are required for sprite operations.\n  export FLY_APP=your-app\n  export FLY_API_TOKEN=your-token")
+			if strings.TrimSpace(opts.App) == "" {
+				return errors.New("Error: FLY_APP environment variable is required. Set it to your Fly.io app name (e.g., export FLY_APP=sprites-main)")
+			}
+			if strings.TrimSpace(opts.Token) == "" {
+				return errors.New("Error: FLY_API_TOKEN environment variable is required. Get one from https://fly.io/user/personal_access_tokens")
 			}
 
 			flyClient, err := deps.newFlyClient(opts.Token, opts.APIURL)

--- a/cmd/bb/dispatch_test.go
+++ b/cmd/bb/dispatch_test.go
@@ -96,6 +96,82 @@ func TestDispatchCommandJSONOutput(t *testing.T) {
 	}
 }
 
+func TestDispatchCommandMissingFLY_APP(t *testing.T) {
+	t.Parallel()
+
+	deps := dispatchDeps{
+		readFile: func(string) ([]byte, error) { return nil, nil },
+		newFlyClient: func(token, apiURL string) (fly.MachineClient, error) {
+			return fakeFlyClient{}, nil
+		},
+		newRemote: func(binary, org string) *spriteCLIRemote {
+			return &spriteCLIRemote{}
+		},
+		newService: func(cfg dispatchsvc.Config) (dispatchRunner, error) {
+			return &fakeDispatchRunner{}, nil
+		},
+	}
+
+	cmd := newDispatchCmdWithDeps(deps)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"bramble",
+		"test prompt",
+		"--token", "tok",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing FLY_APP, got nil")
+	}
+	if !strings.Contains(err.Error(), "FLY_APP environment variable is required") {
+		t.Fatalf("error = %q, expected FLY_APP error message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "export FLY_APP=sprites-main") {
+		t.Fatalf("error = %q, expected example export command", err.Error())
+	}
+}
+
+func TestDispatchCommandMissingFLY_API_TOKEN(t *testing.T) {
+	t.Parallel()
+
+	deps := dispatchDeps{
+		readFile: func(string) ([]byte, error) { return nil, nil },
+		newFlyClient: func(token, apiURL string) (fly.MachineClient, error) {
+			return fakeFlyClient{}, nil
+		},
+		newRemote: func(binary, org string) *spriteCLIRemote {
+			return &spriteCLIRemote{}
+		},
+		newService: func(cfg dispatchsvc.Config) (dispatchRunner, error) {
+			return &fakeDispatchRunner{}, nil
+		},
+	}
+
+	cmd := newDispatchCmdWithDeps(deps)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"bramble",
+		"test prompt",
+		"--app", "bb-app",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing FLY_API_TOKEN, got nil")
+	}
+	if !strings.Contains(err.Error(), "FLY_API_TOKEN environment variable is required") {
+		t.Fatalf("error = %q, expected FLY_API_TOKEN error message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "fly.io/user/personal_access_tokens") {
+		t.Fatalf("error = %q, expected URL to token page", err.Error())
+	}
+}
+
 func TestDispatchCommandUsesPromptFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #177

## Changes
- Split combined FLY_APP/FLY_API_TOKEN validation into separate checks
- Added clear, actionable error messages:
  - FLY_APP: Includes example export command (export FLY_APP=sprites-main)
  - FLY_API_TOKEN: Includes link to token generation page
- Added tests for both validation cases
- Errors appear BEFORE any Fly API calls are made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for required environment variables now returns separate, specific error messages when FLY_APP or FLY_API_TOKEN is missing, providing clearer guidance for resolution in each scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->