### PR TITLE
docs: add Ralph-ready specification issue template (fixes #159)

### DIFF
--- a/.github/ISSUE_TEMPLATE/ralph-ready-spec.md
+++ b/.github/ISSUE_TEMPLATE/ralph-ready-spec.md
@@ -1,0 +1,74 @@
+---
+name: Ralph-Ready Specification
+about: Create a detailed specification ready for sprite dispatch via Ralph
+title: '[SPEC] Brief description of the feature/fix'
+labels: ['ralph-ready', 'enhancement']
+assignees: ''
+
+---
+
+## Summary
+One-line description of what this issue implements.
+
+## Background & Context
+Why is this needed? What problem does it solve?
+
+## Requirements
+
+### Functional Requirements
+- [ ] Specific behavior 1
+- [ ] Specific behavior 2
+- [ ] Specific behavior 3
+
+### Non-Functional Requirements
+- [ ] Performance criteria (if applicable)
+- [ ] Error handling requirements
+- [ ] Testing requirements
+
+## Implementation Details
+
+### Files to Modify
+| File | Changes |
+|------|---------|
+| `path/to/file.go` | Description of changes |
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `path/to/new_file.go` | Description |
+
+### Key Design Decisions
+- Decision 1: Rationale
+- Decision 2: Rationale
+
+## Interface Changes
+
+### New/Modified Types
+```go
+type NewType struct {
+    Field string
+}
+```
+
+### New/Modified Functions
+```go
+func NewFunction(param string) (Result, error)
+```
+
+## Testing Checklist
+- [ ] Unit tests added/modified
+- [ ] Integration tests (if applicable)
+- [ ] Tested locally with `go test ./...`
+
+## Acceptance Criteria
+- [ ] All requirements implemented
+- [ ] All tests passing
+- [ ] Code follows project conventions
+- [ ] Documentation updated (if applicable)
+
+## Related
+- Related issue: #XXX
+- Related PR: #XXX
+
+## Notes for Implementer
+Any specific implementation hints, pitfalls to avoid, or context that would help a sprite implement this correctly.


### PR DESCRIPTION
## Summary

Adds a GitHub issue template for creating Ralph-ready specifications.

## Changes

- New `.github/ISSUE_TEMPLATE/ralph-ready-spec.md` template
- Structured format for sprite-dispatchable issues

## Template includes:

- Summary and background sections  
- Functional and non-functional requirements
- Implementation details with file mappings
- Interface changes (types/functions)
- Testing checklist
- Acceptance criteria
- Notes for implementers

Fixes #159