### PR TITLE
fix: correct Landfall input parameter name (llm-api-key)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          llm-api-key: ${{ secrets.MOONSHOT_API_KEY }}


### PR DESCRIPTION
## Problem

The release workflow was using `moonshot-api-key` as the input parameter for Landfall, but Landfall expects `llm-api-key`. This caused synthesis to be skipped on every release with the warning: `Landfall synthesis skipped; llm-api-key is empty.`

This explains the ~10+ "[Landfall] Synthesis failed" issues (#198, #196, #194, #189, #187, #185, #184, #172, #171, #170, #167, #166).

## Fix

Changed the input parameter from `moonshot-api-key` to `llm-api-key`. The secret name `MOONSHOT_API_KEY` remains the same - only the input parameter name needed to match what Landfall's action.yml expects.

## Verification

- [x] Parameter name matches Landfall's action.yml input definition
- [x] Secret reference remains unchanged (MOONSHOT_API_KEY)

## Closes

Fixes all Landfall synthesis failures caused by empty llm-api-key.