### PR TITLE
perf(dispatch): bound gh issue validation latency + avoid redundant registry load

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -142,7 +142,8 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 			}
 
 			// Pre-dispatch issue validation
-			if !opts.SkipValidation && opts.Issue > 0 {
+			// Skip validation for dry-run (Execute=false) to keep planning fast and offline.
+			if opts.Execute && !opts.SkipValidation && opts.Issue > 0 {
 				validationResult, err := dispatchsvc.ValidateIssueFromRequest(cmd.Context(), dispatchsvc.Request{
 					Sprite:  args[0],
 					Prompt:  prompt,


### PR DESCRIPTION
Follow-up optimization after merging PR #197.

Addresses VULCAN perf findings:
- Avoid redundant registry Load/ResolveSprite during dispatch (prepare() already resolves; needsProvision uses prepared MachineID)
- Add a safety timeout (15s) to `gh issue view` calls when caller context has no deadline
- Skip issue validation in dry-run (Execute=false) to keep planning fast/offline

Also reduces dispatch critical-path latency risk.