### PR TITLE
fix(release): use OPENROUTER_API_KEY for Landfall synthesis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          llm-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Problem

Landfall synthesis has been failing with 401 errors since v1.6.0:

```
401 Client Error: Unauthorized for url: https://openrouter.ai/api/v1/chat/completions
{"error":{"message":"No cookie auth credentials found","code":401}}
```

## Root Cause

The Landfall action defaults to OpenRouter's API endpoint (`https://openrouter.ai/api/v1/chat/completions`), but this workflow was passing `MOONSHOT_API_KEY` which doesn't authenticate against OpenRouter.

## Fix

Switch to `OPENROUTER_API_KEY` which is already configured in repo secrets and verified working.

## Testing

The OPENROUTER_API_KEY in `~/.secrets` on phyrexia returns HTTP 200 from the OpenRouter models endpoint.

Fixes misty-step/landfall#43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use a different API provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->