### PR TITLE
fix: P0 fixes - sprite CLI flags, upload exit 255, workspace mkdir, sync agent, registry error

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -724,6 +724,7 @@ func parsePID(output string) (int, bool) {
 func buildSetupRepoScript(workspace, cloneURL, repoDir string) string {
 	return strings.Join([]string{
 		"set -euo pipefail",
+		"mkdir -p " + shellQuote(workspace),
 		"cd " + shellQuote(workspace),
 		"if [ -d " + shellQuote(repoDir) + " ]; then",
 		"  cd " + shellQuote(repoDir),


### PR DESCRIPTION
Fixes 5 P0 issues:

- **#213**: Fix ExecWithEnv to use \-env\ flag instead of \-e\ (matches sprite CLI)
- **#214**: Handle exit code 255 gracefully in UploadFile - verifies file exists before failing
- **#215**: Add mkdir -p workspace before cd in buildSetupRepoScript
- **#216**: Deploy sprite-agent.sh during bb sync (copies to ~/.local/bin/)
- **#217**: Return clear ErrRegistryNotFound when registry file is missing

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing registry files with descriptive error messages.
  * Enhanced file upload reliability with better error detection and verification.

* **New Features**
  * Added optional agent script support for sprite provisioning and installation.

* **Improvements**
  * Ensured workspace directory is properly created during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->