### PR TITLE
fix: EXIT trap prevents zombie Claude on ralph death

### DIFF
--- a/internal/lifecycle/sprite_agent_script_linux_test.go
+++ b/internal/lifecycle/sprite_agent_script_linux_test.go
@@ -268,14 +268,13 @@ func TestSpriteAgentExitTrapKillsClaude(t *testing.T) {
 	_ = cmd.Process.Signal(syscall.SIGTERM)
 	_ = cmd.Wait()
 
-	// Give a moment for cleanup.
-	time.Sleep(500 * time.Millisecond)
+	// cmd.Wait() blocks until the EXIT trap completes, so no sleep needed.
 
 	// Verify Claude process is dead.
 	checkCmd := exec.Command("kill", "-0", claudePID)
 	if checkCmd.Run() == nil {
 		// Process still alive — cleanup failed.
-		_ = exec.Command("kill", "-9", claudePID).Run()
+		_ = exec.Command("kill", "-9", claudePID).Run() // best-effort cleanup; test already failing
 		t.Fatal("Claude process survived ralph death — EXIT trap failed to kill it")
 	}
 


### PR DESCRIPTION
## Summary
- Adds EXIT trap to `sprite-agent.sh` that kills Claude process, emits `task_failed` event, and cleans up PID file on any ralph exit (signal, `set -e`, bug)
- Guards `run_periodic_tasks` calls with `|| true` to prevent non-critical failures from killing ralph via `set -e`
- Writes `.ralph.pid` file at startup for external tools to detect ralph death (stale PID file = dead ralph)

## Root Cause
`set -euo pipefail` + no EXIT trap meant any error in periodic tasks (health check, git metrics, auto-push) silently killed ralph. Claude continued running as a zombie with no orchestration.

## Test plan
- [x] `bash -n` syntax check passes
- [x] Smoke test: fake claude, 1 iteration, PID file cleaned up, terminal event emitted
- [x] `go test ./...` all pass
- [x] New tests: `TestSpriteAgentPIDFileCleanup`, `TestSpriteAgentExitTrapKillsClaude` (linux-only)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent PID tracking and guaranteed cleanup on script exit; script now fails fast if required prompt is missing.

* **Bug Fixes**
  * Improved cleanup to ensure background processes are terminated and PID files removed on any exit.
  * Periodic task execution hardened to avoid unexpected script interruption.

* **Tests**
  * Added Linux-specific tests validating shutdown, PID cleanup, and failure-event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->