### PR TITLE
fix(sprite): Upload uses bash for proper shell redirection

### DIFF
--- a/internal/sprite/cli.go
+++ b/internal/sprite/cli.go
@@ -241,8 +241,10 @@ func (c CLI) UploadFile(ctx context.Context, name, org, localPath, remotePath st
 
 // Upload writes content directly to a sprite path.
 func (c CLI) Upload(ctx context.Context, name, remotePath string, content []byte) error {
+	// Use bash -c to properly handle shell redirection
+	// Without this, the ">" is treated as a literal argument to cat
 	args := withOrgArgs(
-		[]string{"exec", "-s", name, "--", "cat", ">", remotePath},
+		[]string{"exec", "-s", name, "--", "bash", "-ceu", fmt.Sprintf("cat > %q", remotePath)},
 		c.resolvedOrg(""),
 	)
 	if _, err := c.run(ctx, args, content); err != nil {


### PR DESCRIPTION
## Problem
The `Upload` function was passing `>` as a literal argument to `cat`, causing provisioning to fail when uploading the anthropic-proxy script.

Error: `cat > /home/sprite/anthropic-proxy.mjs` - the `>` was treated as an argument, not a redirect.

## Fix
Use `bash -ceu` with a quoted string to properly handle shell redirection:
```go
bash -ceu fmt.Sprintf("cat > %q", remotePath)
```

## Impact
This unblocks sprite provisioning. Without this fix, `bb add` fails consistently.

## Testing
- Unit tests pass
- The redirection is now handled by bash instead of being passed as literal args

**P0 - Blocking all fleet operations**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload command execution to properly handle shell operations, ensuring remote write commands process correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->