### PR TITLE
fix(dispatch): pass GH_TOKEN to sprite for GitHub CLI auth

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -213,6 +213,8 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 				"XAI_API_KEY",
 				"GEMINI_API_KEY",
 				"OPENAI_API_KEY",
+				"GH_TOKEN",
+				"GITHUB_TOKEN",
 			} {
 				if value := os.Getenv(key); value != "" {
 					envVars[key] = value


### PR DESCRIPTION
## Summary

Sprites couldn't run `gh` CLI commands (issue view, pr create, etc.) because dispatch forwarded AI provider API keys but never forwarded `GH_TOKEN`/`GITHUB_TOKEN`. This blocked sprites from opening PRs or interacting with GitHub. Closes #243

## Changes

- Added `GH_TOKEN` and `GITHUB_TOKEN` to the env var collection list in `cmd/bb/dispatch.go`
- Added `TestDispatchCollectsGHToken` verifying both tokens are forwarded to the service config

## Acceptance Criteria

- [x] `GH_TOKEN` passed to sprite during dispatch
- [x] `GITHUB_TOKEN` passed to sprite during dispatch
- [x] Test coverage for GH_TOKEN/GITHUB_TOKEN inclusion in env vars

## Manual QA

```bash
# Set tokens and run dry-run dispatch
export GH_TOKEN=$(gh auth token)
bb dispatch bramble "test" --app bb-app
# Verify in plan output that env vars are collected

# Live test: dispatch with --execute and verify gh CLI works on sprite
bb dispatch bramble --issue 243 --execute --app bb-app
```

## Test Coverage

- `cmd/bb/dispatch_test.go:TestDispatchCollectsGHToken` — sets both `GH_TOKEN` and `GITHUB_TOKEN` via `t.Setenv`, runs dispatch command, asserts both appear in captured `Config.EnvVars`

🤖 Generated with [Claude Code](https://claude.com/claude-code)