### PR TITLE
fix: clean up stale TASK_COMPLETE/BLOCKED.md in oneshot mode

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1086,6 +1086,7 @@ func buildOneShotScript(workspace, promptPath string) string {
 		"set -euo pipefail",
 		"mkdir -p " + shellutil.Quote(workspace),
 		"cd " + shellutil.Quote(workspace),
+		"rm -f TASK_COMPLETE BLOCKED.md",
 		"# Start anthropic proxy if available",
 		"if [ -f " + shellutil.Quote(proxy.ProxyScriptPath) + " ] && [ -n \"${OPENROUTER_API_KEY:-}\" ] && command -v node >/dev/null 2>&1; then",
 		"  PROXY_PID=\"\"",


### PR DESCRIPTION
## Summary

Fixes #277

The `buildOneShotScript` function was not cleaning up stale `TASK_COMPLETE` or `BLOCKED.md` files before starting. The Ralph script already did this cleanup, so oneshot mode was inconsistent.

## Changes

- Add `rm -f TASK_COMPLETE BLOCKED.md` right after `cd workspace` in `buildOneShotScript`, before the proxy startup section
- Add test `TestBuildOneShotScriptCleansStatusFiles` that verifies the oneshot start script contains the cleanup command

## Verification

- `go test ./internal/dispatch/` passes
- New test specifically validates the cleanup command is present and positioned before proxy startup

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup cleanup to remove leftover state files before process initialization.

* **Tests**
  * Added test coverage for startup cleanup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->