### PR TITLE
feat: migrate issue validation from gh CLI to typed GitHub API client

### DIFF
--- a/internal/dispatch/issue_validation_github_test.go
+++ b/internal/dispatch/issue_validation_github_test.go
@@ -224,6 +224,8 @@ func TestParseRepoSlug(t *testing.T) {
 		{"", "", "", true},
 		{"invalid", "", "", true},
 		{"a/b/c", "", "", true},
+		{"/repo", "", "", true},
+		{"owner/", "", "", true},
 	}
 
 	for _, tc := range tests {
@@ -252,11 +254,12 @@ func TestToIssueData(t *testing.T) {
 	t.Parallel()
 
 	issue := &github.Issue{
-		Number: 123,
-		Title:  "Test Title",
-		Body:   "Test Body",
-		State:  "open",
-		URL:    "https://api.github.com/repos/o/r/issues/123",
+		Number:  123,
+		Title:   "Test Title",
+		Body:    "Test Body",
+		State:   "open",
+		URL:     "https://api.github.com/repos/o/r/issues/123",
+		HTMLURL: "https://github.com/o/r/issues/123",
 		Labels: []github.Label{
 			{Name: "bug", Description: "Something is broken", Color: "d73a4a"},
 		},

--- a/internal/dispatch/issue_validation_test.go
+++ b/internal/dispatch/issue_validation_test.go
@@ -621,6 +621,7 @@ func TestDefaultValidatorRalphReadyIsWarning(t *testing.T) {
 	t.Parallel()
 
 	validator := DefaultIssueValidator()
+	validator.GitHubClient = nil // Force CLI fallback path for testing
 	validator.RunGH = func(ctx context.Context, args ...string) ([]byte, error) {
 		json := `{
 			"number": 42,
@@ -689,6 +690,7 @@ func TestValidateIssueFromRequest_NonRalphMode_SuppressesRalphReadyWarning(t *te
 
 	// Test non-Ralph mode: should NOT warn about missing ralph-ready label
 	nonRalphValidator := IssueValidatorForRalphMode(false)
+	nonRalphValidator.GitHubClient = nil // Force CLI fallback path for testing
 	nonRalphValidator.RunGH = mockRunGH
 
 	result, err := nonRalphValidator.ValidateIssue(context.Background(), 200, "misty-step/test")
@@ -709,6 +711,7 @@ func TestValidateIssueFromRequest_NonRalphMode_SuppressesRalphReadyWarning(t *te
 
 	// Test Ralph mode: should still warn about missing ralph-ready label
 	ralphValidator := IssueValidatorForRalphMode(true)
+	ralphValidator.GitHubClient = nil // Force CLI fallback path for testing
 	ralphValidator.RunGH = mockRunGH
 
 	result2, err := ralphValidator.ValidateIssue(context.Background(), 200, "misty-step/test")

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -4,20 +4,20 @@ import "time"
 
 // Issue represents a GitHub issue as returned by the REST API.
 type Issue struct {
-	ID        int64     `json:"id"`
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	Body      string    `json:"body"`
-	State     string    `json:"state"`
-	StateReason string  `json:"state_reason,omitempty"`
-	URL       string    `json:"url"`
-	HTMLURL   string    `json:"html_url"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	ClosedAt  *time.Time `json:"closed_at,omitempty"`
-	Labels    []Label   `json:"labels"`
-	Assignees []User    `json:"assignees"`
-	User      User      `json:"user"`
+	ID          int64      `json:"id"`
+	Number      int        `json:"number"`
+	Title       string     `json:"title"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`
+	StateReason string     `json:"state_reason,omitempty"`
+	URL         string     `json:"url"`
+	HTMLURL     string     `json:"html_url"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	ClosedAt    *time.Time `json:"closed_at,omitempty"`
+	Labels      []Label    `json:"labels"`
+	Assignees   []User     `json:"assignees"`
+	User        User       `json:"user"`
 }
 
 // Closed returns whether the issue is closed, derived from State.
@@ -43,30 +43,10 @@ type User struct {
 	HTMLURL   string `json:"html_url,omitempty"`
 }
 
-// Repository represents a GitHub repository (minimal fields).
-type Repository struct {
-	ID       int64  `json:"id"`
-	Name     string `json:"name"`
-	FullName string `json:"full_name"`
-	Private  bool   `json:"private"`
-	HTMLURL  string `json:"html_url"`
-}
-
-// IssueListOptions contains query parameters for listing issues.
-type IssueListOptions struct {
-	State   string // "open", "closed", "all"
-	Labels  []string
-	Assignee string // username or "*" for any, "none" for no assignee
-	Sort    string // "created", "updated", "comments"
-	Direction string // "asc", "desc"
-	PerPage int    // pagination size
-	Page    int
-}
-
 // ErrorResponse represents GitHub's error response structure.
 type ErrorResponse struct {
-	Message         string        `json:"message"`
-	Errors          []FieldError  `json:"errors,omitempty"`
+	Message          string       `json:"message"`
+	Errors           []FieldError `json:"errors,omitempty"`
 	DocumentationURL string       `json:"documentation_url,omitempty"`
 }
 


### PR DESCRIPTION
Closes #261

Migrates issue validation from shelling out to `gh` CLI to a typed GitHub API client (`internal/github/`).

**Changes:**
- New `internal/github/` package with typed HTTP client, structured errors, and GitHub types
- Updated `IssueValidator` to use typed client via `GitHubIssueClient` interface
- Backward-compatible `gh` CLI fallback when `GITHUB_TOKEN` not set
- 25 new test cases covering client + validation

All tests pass, build clean, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct GitHub API integration for issue validation when GITHUB_TOKEN is set
  * More robust issue data handling and repository slug parsing
* **Improvements**
  * Expanded error classification and clearer user-facing messages (auth, not-found, rate-limit, server)
  * Seamless fallback to gh CLI when API credentials are unavailable
  * Deprecation notices recommending native GitHub types over legacy shapes
* **Tests**
  * Comprehensive test coverage for API and CLI validation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->