### PR TITLE
fix: map API 'warm' status to idle state in fleet overview

### DIFF
--- a/internal/lifecycle/status.go
+++ b/internal/lifecycle/status.go
@@ -401,8 +401,8 @@ func deriveSpriteState(state, status string) SpriteState {
 
 	// Derive from status
 	switch status {
-	case "running":
-		// If running but no explicit state, assume idle (conservative)
+	case "running", "warm":
+		// "warm" = API status for running+idle; "running" = generic running
 		return StateIdle
 	case "starting", "provisioning":
 		return StateOperational
@@ -413,7 +413,7 @@ func deriveSpriteState(state, status string) SpriteState {
 
 func isRunningStatus(status string) bool {
 	s := strings.ToLower(status)
-	return s == "running" || s == "starting" || s == "provisioning"
+	return s == "running" || s == "warm" || s == "starting" || s == "provisioning"
 }
 
 func calculateFleetSummary(sprites []SpriteStatus, orphans []SpriteStatus) FleetSummary {

--- a/internal/lifecycle/status_test.go
+++ b/internal/lifecycle/status_test.go
@@ -310,6 +310,7 @@ func TestDeriveSpriteState(t *testing.T) {
 		{"", "error", StateOffline},
 		{"", "dead", StateOffline},
 		{"", "running", StateIdle},
+		{"", "warm", StateIdle},     // API returns "warm" for idle sprites
 		{"", "starting", StateOperational},
 		{"", "provisioning", StateOperational},
 		{"", "unknown", StateUnknown},
@@ -413,6 +414,7 @@ func TestIsRunningStatus(t *testing.T) {
 		expected bool
 	}{
 		{"running", true},
+		{"warm", true},        // API "warm" status indicates running sprite
 		{"starting", true},
 		{"provisioning", true},
 		{"RUNNING", true},


### PR DESCRIPTION
## Problem

`bb status` showed "⚪ unknown" in the State column for every sprite, including those the API reports as "warm".

## Root Cause

The API returns `"warm"` status for running sprites that are idle, but the code only recognized `"running"`, `"starting"`, and `"provisioning"` as running statuses.

When status is `"warm"`:
1. `deriveSpriteState("", "warm")` returned `StateUnknown` (not handled)
2. `isRunningStatus("warm")` returned `false`, so detail was never fetched
3. State remained `"unknown"` even though API reported `"warm"`

## Changes

1. **deriveSpriteState()**: Added `"warm"` case mapping to `StateIdle`
2. **isRunningStatus()**: Added `"warm"` to running status checks

## Testing

- Added test cases for `"warm"` status in both `TestDeriveSpriteState` and `TestIsRunningStatus`
- All existing tests pass
- Follows TDD: test first, then implementation

## Verification

```bash
go test ./internal/lifecycle/... -v
go build ./...
go vet ./...
```

Closes #295