### PR TITLE
feat: add progress indicators for repo setup during dispatch

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1155,7 +1155,9 @@ func buildSetupRepoScript(workspace, cloneURL, repoDir string) string {
 		"set -euo pipefail",
 		"mkdir -p " + shellutil.Quote(workspace),
 		"cd " + shellutil.Quote(workspace),
+		"START_TIME=$(date +%s)",
 		"if [ -d " + shellutil.Quote(repoDir) + " ]; then",
+		"  echo \"[setup] pulling latest for " + shellutil.Quote(repoDir) + "...\"",
 		"  cd " + shellutil.Quote(repoDir),
 		// Reset to clean state: discard changes, checkout default branch, pull latest.
 		// This prevents stale feature branches from polluting new dispatches.
@@ -1166,8 +1168,12 @@ func buildSetupRepoScript(workspace, cloneURL, repoDir string) string {
 		"  git fetch origin >/dev/null 2>&1 || true",
 		`  git reset --hard "origin/$(git rev-parse --abbrev-ref HEAD)" 2>/dev/null || true`,
 		"else",
+		"  echo \"[setup] cloning " + shellutil.Quote(cloneURL) + " (first time, may take a few minutes)...\"",
 		"  gh repo clone " + shellutil.Quote(cloneURL) + " " + shellutil.Quote(repoDir) + " >/dev/null 2>&1 || git clone " + shellutil.Quote(cloneURL) + " " + shellutil.Quote(repoDir) + " >/dev/null 2>&1",
 		"fi",
+		"END_TIME=$(date +%s)",
+		"ELAPSED=$((END_TIME - START_TIME))",
+		"echo \"[setup] repo ready (${ELAPSED}s)\"",
 	}, "\n")
 }
 

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1134,6 +1134,38 @@ func TestBuildSetupRepoScriptFreshClone(t *testing.T) {
 	}
 }
 
+func TestBuildSetupRepoScriptProgressIndicators(t *testing.T) {
+	t.Parallel()
+
+	script := buildSetupRepoScript("/workspace", "https://github.com/org/repo.git", "repo")
+
+	// Must show progress message for existing repo (pull path)
+	if !strings.Contains(script, "[setup] pulling latest for") {
+		t.Error("script missing progress message for existing repo")
+	}
+
+	// Must show progress message for fresh clone
+	if !strings.Contains(script, "[setup] cloning") {
+		t.Error("script missing progress message for fresh clone")
+	}
+	if !strings.Contains(script, "(first time, may take a few minutes)") {
+		t.Error("script missing 'first time' hint for cold start")
+	}
+
+	// Must track timing
+	if !strings.Contains(script, "START_TIME=$(date +%s)") {
+		t.Error("script missing START_TIME")
+	}
+	if !strings.Contains(script, "END_TIME=$(date +%s)") {
+		t.Error("script missing END_TIME")
+	}
+
+	// Must show completion with elapsed time
+	if !strings.Contains(script, "[setup] repo ready (${ELAPSED}s)") {
+		t.Error("script missing completion message with elapsed time")
+	}
+}
+
 func TestResolveSkillMountsEnforcesMaxMounts(t *testing.T) {
 	// Create temp skill directories
 	skillRoot := t.TempDir()


### PR DESCRIPTION
## Summary

Add clear progress output during repo setup to address the 5-minute silent wait on cold sprites.

## Changes

- Show "[setup] cloning <url> (first time, may take a few minutes)..." before fresh clone operations
- Show "[setup] pulling latest for <repo>..." for existing repos  
- Track elapsed time with START_TIME/END_TIME
- Show "[setup] repo ready (${ELAPSED}s)" on completion

This differentiates clone vs pull operations and gives users feedback during long-running setup operations.

## Testing

- Added TestBuildSetupRepoScriptProgressIndicators to verify new behavior
- All existing tests pass

Closes #297