### PR TITLE
feat(proxy): store OPENROUTER_API_KEY in secure file instead of env

### DIFF
--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -908,6 +908,7 @@ func TestRunExecuteWithOpenRouterKey_EnsuresProxy(t *testing.T) {
 			"000",  // proxy health check (not running)
 			"",     // kill existing process on port (cleanup)
 			"",     // mkdir -p
+			"",     // write API key file
 			"",     // start proxy
 			"200",  // proxy health check (now running)
 			"done", // oneshot agent

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -44,6 +44,7 @@ func StartCommand(model, port string) []string {
 }
 
 // StartEnv returns the environment variables needed to run the proxy.
+// Deprecated: Use StartEnvWithKeyFile instead to avoid exposing API keys in process environment.
 func StartEnv(model, port, openRouterAPIKey string) map[string]string {
 	if model == "" {
 		model = DefaultModel
@@ -58,6 +59,26 @@ func StartEnv(model, port, openRouterAPIKey string) map[string]string {
 		"UPSTREAM_BASE":      "https://openrouter.ai",
 		"UPSTREAM_PATH":      "/api/v1/chat/completions",
 		"OPENROUTER_API_KEY": openRouterAPIKey,
+	}
+}
+
+// StartEnvWithKeyFile returns the environment variables needed to run the proxy.
+// The API key is passed via a file path instead of the key itself to avoid
+// exposure in /proc/<pid>/environ.
+func StartEnvWithKeyFile(model, port, keyFilePath string) map[string]string {
+	if model == "" {
+		model = DefaultModel
+	}
+	if port == "" {
+		port = strconv.Itoa(ProxyPort)
+	}
+
+	return map[string]string{
+		"PROXY_PORT":              port,
+		"TARGET_MODEL":            model,
+		"UPSTREAM_BASE":           "https://openrouter.ai",
+		"UPSTREAM_PATH":           "/api/v1/chat/completions",
+		"OPENROUTER_API_KEY_FILE": keyFilePath,
 	}
 }
 


### PR DESCRIPTION
Closes #247

## Acceptance Criteria
- [x] OPENROUTER_API_KEY not visible in process environment (/proc/<pid>/environ)
- [x] Proxy still authenticates to OpenRouter successfully
- [x] All tests pass
- [x] Lint passes

## Summary
Avoids exposure in /proc/<pid>/environ by writing the API key to
/home/sprite/.bb/openrouter.key with 600 permissions, then having
the proxy read it from the file at startup.

This addresses the security concern raised in issue #247 where
the API key was visible in the process environment.

### Changes
- **lifecycle.go**: Write API key to secure file before starting proxy
- **proxy.go**: Add StartEnvWithKeyFile function that passes file path
- **anthropic-proxy.mjs**: Read API key from file if OPENROUTER_API_KEY_FILE is set
- Update tests to match new flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved API key handling by transitioning from direct environment variables to secure file-based storage with restricted permissions (600).
  * OpenRouter API key is now read from a dedicated secure file, with fallback to environment variable for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->