### PR TITLE
fix(dispatch): detect zero-work completions with exit code 3

### DIFF
--- a/cmd/bb/dispatch_test.go
+++ b/cmd/bb/dispatch_test.go
@@ -409,10 +409,13 @@ func TestDispatchCommandWithWait(t *testing.T) {
 	}
 
 	expectedResult := &waitResult{
-		State:    "completed",
-		Task:     "Implement feature",
-		Complete: true,
-		PRURL:    "https://github.com/misty-step/bitterblossom/pull/123",
+		State:      "completed",
+		Task:       "Implement feature",
+		Complete:   true,
+		PRURL:      "https://github.com/misty-step/bitterblossom/pull/123",
+		HasChanges: true,
+		Commits:    1,
+		PRs:        1,
 	}
 
 	pollCalled := false
@@ -552,9 +555,12 @@ func TestDispatchCommandWaitJSONOutput(t *testing.T) {
 	}
 
 	expectedResult := &waitResult{
-		State:    "completed",
-		Complete: true,
-		PRURL:    "https://github.com/misty-step/bitterblossom/pull/123",
+		State:      "completed",
+		Complete:   true,
+		PRURL:      "https://github.com/misty-step/bitterblossom/pull/123",
+		HasChanges: true,
+		Commits:    1,
+		PRs:        1,
 	}
 
 	deps := dispatchDeps{
@@ -1098,9 +1104,12 @@ func TestDispatchCommandWaitExitCodes(t *testing.T) {
 		{
 			name: "completed state returns exit 0",
 			waitResult: &waitResult{
-				State:    "completed",
-				Complete: true,
-				PRURL:    "https://github.com/misty-step/bitterblossom/pull/123",
+				State:      "completed",
+				Complete:   true,
+				PRURL:      "https://github.com/misty-step/bitterblossom/pull/123",
+				HasChanges: true,
+				Commits:    1,
+				PRs:        1,
 			},
 			wantExitCode: exitCodeSuccess,
 			wantErr:      false,
@@ -1205,10 +1214,16 @@ func TestWaitExitError(t *testing.T) {
 		wantExitCode int
 	}{
 		{
-			name:         "completed returns nil (exit 0)",
-			waitRes:      &waitResult{State: "completed", Complete: true},
+			name:         "completed with changes returns nil (exit 0)",
+			waitRes:      &waitResult{State: "completed", Complete: true, HasChanges: true},
 			wantErr:      false,
 			wantExitCode: exitCodeSuccess,
+		},
+		{
+			name:         "completed without changes returns exit 3",
+			waitRes:      &waitResult{State: "completed", Complete: true, HasChanges: false},
+			wantErr:      true,
+			wantExitCode: exitCodeNoNewWork,
 		},
 		{
 			name:         "blocked returns nil (exit 0)",
@@ -1276,6 +1291,11 @@ func TestDispatchWaitSkipsPollingWhenOneshotCompleted(t *testing.T) {
 				Sprite: "moss",
 				Mode:   "execute",
 				Steps:  []dispatchsvc.PlanStep{{Kind: dispatchsvc.StepStartAgent, Description: "start"}},
+			},
+			Work: dispatchsvc.WorkDelta{
+				HasChanges: true,
+				Commits:    1,
+				PRs:        1,
 			},
 		},
 	}
@@ -1361,8 +1381,11 @@ func TestDispatchWaitPollsWhenRalphMode(t *testing.T) {
 		pollSprite: func(ctx context.Context, remote *spriteCLIRemote, sprite string, timeout time.Duration, progress func(string)) (*waitResult, error) {
 			pollCalled = true
 			return &waitResult{
-				State:    "completed",
-				Complete: true,
+				State:      "completed",
+				Complete:   true,
+				HasChanges: true,
+				Commits:    1,
+				PRs:        1,
 			}, nil
 		},
 	}

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -162,10 +162,11 @@ func TestRunDryRunBuildsPlanWithoutSideEffects(t *testing.T) {
 func TestRunExecuteProvisionAndStartRalph(t *testing.T) {
 	remote := &fakeRemote{
 		execResponses: []string{
-			"",          // validate env (empty key = ok)
-			"",          // clean signals
-			"",          // setup repo
-			"PID: 4242", // start ralph
+			"",              // validate env (empty key = ok)
+			"",              // clean signals
+			"",              // setup repo
+			"not-a-valid-sha", // capture HEAD SHA (will fail validation)
+			"PID: 4242",     // start ralph
 		},
 		listSprites: []string{},
 	}
@@ -230,23 +231,26 @@ func TestRunExecuteProvisionAndStartRalph(t *testing.T) {
 	if !strings.Contains(remote.execCalls[2].command, "gh repo clone") {
 		t.Fatalf("expected repo setup command, got %q", remote.execCalls[2].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "sprite-agent") {
-		t.Fatalf("expected ralph start command, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[3].command, "git rev-parse HEAD") {
+		t.Fatalf("expected capture HEAD SHA command, got %q", remote.execCalls[3].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "BB_CLAUDE_FLAGS") {
-		t.Fatalf("expected ralph start to pass BB_CLAUDE_FLAGS to sprite-agent, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[4].command, "sprite-agent") {
+		t.Fatalf("expected ralph start command, got %q", remote.execCalls[4].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "MAX_TOKENS=200000") {
-		t.Fatalf("expected ralph start to pass MAX_TOKENS, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[4].command, "BB_CLAUDE_FLAGS") {
+		t.Fatalf("expected ralph start to pass BB_CLAUDE_FLAGS to sprite-agent, got %q", remote.execCalls[4].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "MAX_TIME_SEC=1800") {
-		t.Fatalf("expected ralph start to pass MAX_TIME_SEC, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[4].command, "MAX_TOKENS=200000") {
+		t.Fatalf("expected ralph start to pass MAX_TOKENS, got %q", remote.execCalls[4].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "--dangerously-skip-permissions") {
-		t.Fatalf("expected ralph start BB_CLAUDE_FLAGS to include dangerously-skip-permissions, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[4].command, "MAX_TIME_SEC=1800") {
+		t.Fatalf("expected ralph start to pass MAX_TIME_SEC, got %q", remote.execCalls[4].command)
 	}
-	if !strings.Contains(remote.execCalls[3].command, "--output-format stream-json") {
-		t.Fatalf("expected ralph start BB_CLAUDE_FLAGS to include stream-json output, got %q", remote.execCalls[3].command)
+	if !strings.Contains(remote.execCalls[4].command, "--dangerously-skip-permissions") {
+		t.Fatalf("expected ralph start BB_CLAUDE_FLAGS to include dangerously-skip-permissions, got %q", remote.execCalls[4].command)
+	}
+	if !strings.Contains(remote.execCalls[4].command, "--output-format stream-json") {
+		t.Fatalf("expected ralph start BB_CLAUDE_FLAGS to include stream-json output, got %q", remote.execCalls[4].command)
 	}
 }
 


### PR DESCRIPTION
Closes #340

## Problem
`bb dispatch --execute --wait` exits 0 with "Status: COMPLETE" even when the agent produced zero new commits. In the reported case, PR #339 for issue #338 was created 9 minutes before the dispatch. The agent detected existing work and wrote TASK_COMPLETE, but dispatch reported success — indistinguishable from genuine completion.

## Solution
1. Record HEAD SHA before agent start
2. Compare HEAD SHA after agent completes (oneshot mode)
3. Report work delta in completion output
4. Exit code 3 for "completed but no new work"
5. Display "COMPLETE (no new work)" when zero changes detected

## Changes
- `internal/dispatch/dispatch.go`: Add `WorkDelta` struct, `captureHeadSHA()`, `calculateWorkDelta()", integrate work tracking into `Run()`
- `cmd/bb/dispatch.go`: Add `exitCodeNoNewWork` (3), update `waitResult` with work fields, update `renderWaitResult()` and `waitExitError()`

## Acceptance Criteria
- [x] Dispatch records HEAD SHA before agent start
- [x] Dispatch compares HEAD SHA after agent completes  
- [x] Zero new commits shows "COMPLETE (no new work)" message
- [x] Exit code 3 when no new work produced
- [x] Exit code 0 when new work produced
- [x] Work delta shown in output (commits, PRs count)

## Testing
- All existing tests pass
- New test cases added for exit code 3 behavior