### PR TITLE
fix(dispatch): auto-strip ANTHROPIC_API_KEY from sprite env

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -214,6 +214,13 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 				}
 			}
 
+			// Strip ANTHROPIC_API_KEY to prevent proxy bypass.
+			// The sprite should only receive ANTHROPIC_AUTH_TOKEN (OpenRouter key)
+			// and ANTHROPIC_BASE_URL (set by the proxy lifecycle manager).
+			// This fixes the issue where Claude Code's ANTHROPIC_API_KEY would
+			// trigger safety validation failures when dispatching to sprites.
+			delete(envVars, "ANTHROPIC_API_KEY")
+
 			// Resolve and inject secrets passed via --secret flags
 			if len(opts.Secrets) > 0 {
 				resolver := dispatchsvc.DefaultSecretResolver()


### PR DESCRIPTION
Closes #341

## Problem
Running bb dispatch --execute from within a Claude Code session fails because Claude Code sets ANTHROPIC_API_KEY in the environment. The safety validation correctly rejects forwarding this to sprites (billing risk), but the most common dispatch context IS a Claude Code session.

Current workaround: ANTHROPIC_API_KEY="" bb dispatch ...

## Solution
Explicitly strip ANTHROPIC_API_KEY from envVars after loading from the environment but before passing to the dispatch service. Sprites should only receive ANTHROPIC_AUTH_TOKEN (OpenRouter key) and ANTHROPIC_BASE_URL (proxy URL).

## Changes
- Added delete(envVars, "ANTHROPIC_API_KEY") in cmd/bb/dispatch.go
- Added TestDispatchStripsAnthropicAPIKey to verify the fix

## Testing
- [x] Unit test passes
- [x] All dispatch tests pass
- [x] Full test suite passes
- [x] Build succeeds
- [x] Lint passes

## Acceptance Criteria
- [ ] Dispatch from Claude Code session works without requiring manual key unset
- [ ] ANTHROPIC_API_KEY is not present in the env vars passed to sprites
- [ ] OPENROUTER_API_KEY and other LLM keys are still forwarded correctly
- [ ] GitHub tokens are still forwarded correctly
- [ ] Safety validation no longer fails due to Claude Code's ANTHROPIC_API_KEY