### PR TITLE
fix(dispatch): suppress secrets directory warning when path is not a directory

### DIFF
--- a/internal/dispatch/secrets.go
+++ b/internal/dispatch/secrets.go
@@ -160,11 +160,19 @@ func resolveOnePassword(ref string) (string, error) {
 // LoadSecretsFromDir loads secrets from files in a directory.
 // Each file's name becomes the secret name, and its content becomes the value.
 func LoadSecretsFromDir(dir string) (map[string]string, error) {
-	entries, err := os.ReadDir(dir)
+	info, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil // Empty if directory doesn't exist
+			return nil, nil
 		}
+		return nil, fmt.Errorf("read secrets directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, nil // Path exists but is not a directory — skip silently
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
 		return nil, fmt.Errorf("read secrets directory: %w", err)
 	}
 


### PR DESCRIPTION
Closes #342

## Summary
- `LoadSecretsFromDir` now uses `os.Stat` before `os.ReadDir` to handle the case where `~/.secrets` exists as a regular file or doesn't exist at all
- Both cases return `nil, nil` silently instead of propagating an error that triggers a warning on every `bb` command

## Changes
- `internal/dispatch/secrets.go`: Add `os.Stat` + `IsDir()` guard before `os.ReadDir`
- `internal/dispatch/secrets_test.go`: Four new test cases covering nonexistent path, regular file, valid directory, and empty directory

## Test plan
- [x] `go test ./internal/dispatch/...` passes
- [x] `go vet ./internal/dispatch/...` clean
- [x] Manual verification: `bb status` no longer prints secrets warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of secret path handling—system now gracefully handles non-existent or invalid paths without errors.
  * Enhanced error messages for directory read operations.

* **Tests**
  * Added comprehensive test coverage for secret path validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->