### PR TITLE
fix(dispatch): detect uncommitted changes in work delta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ __pycache__/
 *.pyc
 base/hooks/__pycache__/
 bin/
+
+e2e-reports/


### PR DESCRIPTION
## Summary

Closes #349. When an agent modifies files but the session terminates before committing, dispatch now detects the uncommitted changes instead of reporting "no new work."

Discovered during e2e shakedown 2026-02-14: agent on bramble ran 21 turns, made correct code edits for #329, passed build+tests, but session died before `git commit`. Dispatch reported exit 3 "COMPLETE (no new work)" — technically true (zero commits) but misleading since the fix was sitting right there uncommitted.

## Changes

- `internal/dispatch/dispatch.go`: Add `DirtyFiles` field to `WorkDelta`. When SHA unchanged, run `git status --porcelain | wc -l` to detect uncommitted changes
- `cmd/bb/dispatch.go`: Add exit code 4 (`exitCodePartialWork`). Render "PARTIAL (uncommitted changes in N file(s))" status. Pass `DirtyFiles` through oneshot skip-polling path
- `cmd/bb/dispatch_test.go`: Table test case for exit code 4, full e2e test for partial work rendering

## Acceptance Criteria

- [x] `calculateWorkDelta` checks `git status --porcelain` when HEAD SHA unchanged
- [x] New `DirtyFiles` field in `WorkDelta` struct
- [x] Exit code 4 distinguishes partial work from exit code 3 (no work)
- [x] `renderWaitResult` shows "PARTIAL (uncommitted changes in N file(s))"
- [x] Existing tests unaffected
- [x] Linter clean

## Manual QA

```bash
# Build
go build -o ./bin/bb ./cmd/bb

# Dispatch to a sprite, kill the agent before it commits
# Verify output shows "PARTIAL" instead of "COMPLETE (no new work)"
# Verify exit code is 4 (not 3)
echo $?
```

## Test Coverage

- `TestWaitExitError/completed_with_dirty_files_returns_exit_4` — unit test for exit code routing
- `TestDispatchWaitPartialWorkDirtyFiles` — full dispatch command e2e with dirty files in WorkDelta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch now detects and reports uncommitted file changes when work completes, displaying a PARTIAL status with the count of modified files.
  * Added new exit code to distinguish partial work completion from standard completion states.

* **Tests**
  * Added test coverage for partial work scenarios with uncommitted changes.

* **Chores**
  * Updated .gitignore to exclude e2e-reports directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->