### PR TITLE
fix(dispatch): reject dispatch to orphan sprites not in composition

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -53,6 +53,7 @@ type dispatchOptions struct {
 	MaxTime              time.Duration
 	WebhookURL           string
 	AllowAnthropicDirect bool
+	AllowOrphan          bool
 	Issue                int
 	SkipValidation       bool
 	Strict               bool
@@ -373,6 +374,7 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 				Execute:              opts.Execute,
 				WebhookURL:           opts.WebhookURL,
 				AllowAnthropicDirect: opts.AllowAnthropicDirect,
+				AllowOrphan:          opts.AllowOrphan,
 				MaxTokens:            opts.MaxTokens,
 				MaxTime:              opts.MaxTime,
 			})
@@ -480,6 +482,7 @@ func newDispatchCmdWithDeps(deps dispatchDeps) *cobra.Command {
 	command.Flags().DurationVar(&opts.MaxTime, "max-time", opts.MaxTime, "Ralph stuck-loop runtime safety cap (only with --ralph)")
 	command.Flags().StringVar(&opts.WebhookURL, "webhook-url", opts.WebhookURL, "Optional sprite-agent webhook URL")
 	command.Flags().BoolVar(&opts.AllowAnthropicDirect, "allow-anthropic-direct", false, "Allow dispatch even if sprite has a real ANTHROPIC_API_KEY")
+	command.Flags().BoolVar(&opts.AllowOrphan, "allow-orphan", false, "Allow dispatch to sprites not in the loaded composition")
 	command.Flags().IntVar(&opts.Issue, "issue", 0, "GitHub issue number to validate before dispatch")
 	command.Flags().BoolVar(&opts.SkipValidation, "skip-validation", false, "Skip policy validation (safety checks still run)")
 	command.Flags().BoolVar(&opts.Strict, "strict", false, "Fail on any validation warning (legacy: use --validation-profile=strict)")

--- a/internal/dispatch/validation.go
+++ b/internal/dispatch/validation.go
@@ -313,3 +313,20 @@ func ValidateCommandNoSecrets(command, context string) error {
 	}
 	return nil
 }
+
+// ErrOrphanSprite indicates dispatch was attempted to a sprite that exists
+// remotely but is not in the loaded composition. Orphan sprites lack persistent
+// workspace volumes, so dispatches run in void and produce no durable work.
+type ErrOrphanSprite struct {
+	Sprite      string
+	Composition []string
+}
+
+func (e *ErrOrphanSprite) Error() string {
+	return fmt.Sprintf(
+		"sprite %q is not in the loaded composition — it may lack a persistent workspace volume. "+
+			"Dispatch to orphan sprites runs in void and produces no durable work. "+
+			"Use a composition sprite (%s) or pass --allow-orphan to override",
+		e.Sprite, strings.Join(e.Composition, ", "),
+	)
+}


### PR DESCRIPTION
## Summary

Closes #347. Orphan sprites (exist in Fly but not in the loaded composition) lack persistent workspace volumes. Dispatching to them runs agents in void — everything appears to succeed but nothing persists, producing zero durable work while reporting success.

## Changes

- **`internal/dispatch/validation.go`** — New `ErrOrphanSprite` error type with actionable guidance (lists composition sprites)
- **`internal/dispatch/dispatch.go`** — Composition membership check in `Run()` after `needsProvision()`. If composition is loaded and sprite is not in it, dispatch is rejected. New `StepValidateWorkspace` step in `buildPlan()` for dry-run visibility. `AllowOrphan` field on `Request` and `preparedRequest`.
- **`cmd/bb/dispatch.go`** — `--allow-orphan` CLI flag wired through to `Request.AllowOrphan`
- **`internal/dispatch/dispatch_test.go`** — 5 new tests

## Acceptance Criteria

- [x] Dispatch to orphan sprite (not in composition) returns `ErrOrphanSprite` with clear message
- [x] `--allow-orphan` flag bypasses the check
- [x] Without composition loaded, orphan check is skipped (no false positives)
- [x] Composition sprites pass through normally
- [x] Dry-run plan shows `validate_workspace` step when composition is loaded
- [x] All existing tests pass unchanged

## Manual QA

```bash
# Should fail with orphan error:
bb dispatch sage "test" --repo misty-step/bitterblossom

# Should succeed (bypass):
bb dispatch sage "test" --repo misty-step/bitterblossom --allow-orphan

# Should succeed (composition sprite):
bb dispatch bramble "test" --repo misty-step/bitterblossom
```

## Test Coverage

- `TestRunRejectsOrphanSprite` — orphan detected, error type and message correct
- `TestRunAllowsOrphanWhenFlagSet` — AllowOrphan=true bypasses check
- `TestRunOrphanCheckSkippedWithoutComposition` — no composition = no check
- `TestRunCompositionSpritePasses` — composition member passes
- `TestDryRunPlanIncludesValidateWorkspaceStep` — plan visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-orphan` flag to dispatch command to override sprite composition validation

* **Improvements**
  * Dispatch operations now validate that target sprites exist in the loaded composition, rejecting orphan sprites unless the flag is enabled and displaying available sprite options in error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->