### PR TITLE
fix: reconcile fleet status display for idle sprites

### DIFF
--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -310,7 +310,7 @@ func writeFleetStatusText(out io.Writer, status lifecycle.FleetStatus, compositi
 			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 				item.Name,
 				spriteStateLabel(item),
-				item.Status,
+				formatSpriteStatus(item),
 				taskInfo,
 				uptime,
 				truncateString(url, 35),
@@ -527,4 +527,18 @@ func truncateString(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// formatSpriteStatus reconciles the API status with the task state.
+// If the API reports "running" but no task is assigned, display "warm"
+// to accurately reflect the operational state (idle but warm).
+func formatSpriteStatus(item lifecycle.SpriteStatus) string {
+	status := strings.ToLower(item.Status)
+
+	// If status is "running" but no task is assigned, show "warm" instead
+	if status == "running" && item.CurrentTask == nil {
+		return "warm"
+	}
+
+	return item.Status
 }

--- a/cmd/bb/status_test.go
+++ b/cmd/bb/status_test.go
@@ -319,6 +319,65 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
+func TestFormatSpriteStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		currentTask *lifecycle.TaskInfo
+		want        string
+	}{
+		{
+			name:        "running with task shows running",
+			status:      "running",
+			currentTask: &lifecycle.TaskInfo{Description: "Implement feature"},
+			want:        "running",
+		},
+		{
+			name:        "running without task shows warm",
+			status:      "running",
+			currentTask: nil,
+			want:        "warm",
+		},
+		{
+			name:        "warm status unchanged",
+			status:      "warm",
+			currentTask: nil,
+			want:        "warm",
+		},
+		{
+			name:        "stopped status unchanged",
+			status:      "stopped",
+			currentTask: nil,
+			want:        "stopped",
+		},
+		{
+			name:        "error status unchanged",
+			status:      "error",
+			currentTask: &lifecycle.TaskInfo{Description: "Failed task"},
+			want:        "error",
+		},
+		{
+			name:        "starting status unchanged even without task",
+			status:      "starting",
+			currentTask: nil,
+			want:        "starting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := lifecycle.SpriteStatus{
+				Status:      tt.status,
+				CurrentTask: tt.currentTask,
+			}
+			got := formatSpriteStatus(item)
+			if got != tt.want {
+				t.Errorf("formatSpriteStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWatchModeInvalidInterval(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When the Fly.io API reports 'running' status but no task is assigned,
display 'warm' instead of 'running' to accurately reflect the sprite's
operational state. This prevents confusion where 'running' implied active
task execution but the task column was empty.

- Add formatSpriteStatus() helper to reconcile API status with task state
- Update writeFleetStatusText() to use the formatted status
- Add comprehensive tests for status formatting logic

Fixes #352
