### PR TITLE
fix: update STATUS.json on completion to fix stale status (#367)

### DIFF
--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -355,11 +355,14 @@ func TestRunExecuteOneShotCompletes(t *testing.T) {
 	if len(flyClient.createReqs) != 0 {
 		t.Fatalf("unexpected create calls: %d", len(flyClient.createReqs))
 	}
-	if len(remote.uploads) != 2 {
-		t.Fatalf("upload calls = %d, want 2", len(remote.uploads))
+	if len(remote.uploads) != 3 {
+		t.Fatalf("upload calls = %d, want 3", len(remote.uploads))
 	}
 	if remote.uploads[0].path != "/home/sprite/workspace/.dispatch-prompt.md" {
 		t.Fatalf("oneshot prompt path = %q", remote.uploads[0].path)
+	}
+	if remote.uploads[2].path != "/home/sprite/workspace/STATUS.json" {
+		t.Fatalf("final status path = %q", remote.uploads[2].path)
 	}
 	if len(remote.execCalls) != 3 {
 		t.Fatalf("exec calls = %d, want 3", len(remote.execCalls))
@@ -435,13 +438,18 @@ func TestRunCleanSignalsBeforePromptUpload(t *testing.T) {
 		t.Fatal("expected clean signals exec call not found")
 	}
 
-	if len(remote.uploads) != 2 {
-		t.Fatalf("upload calls = %d, want 2", len(remote.uploads))
+	if len(remote.uploads) != 3 {
+		t.Fatalf("upload calls = %d, want 3", len(remote.uploads))
 	}
 
 	// Verify the first upload is the prompt (after clean signals)
 	if remote.uploads[0].path != "/home/sprite/workspace/.dispatch-prompt.md" {
 		t.Fatalf("expected prompt upload first, got %q", remote.uploads[0].path)
+	}
+
+	// Verify the final upload is the updated STATUS.json
+	if remote.uploads[2].path != "/home/sprite/workspace/STATUS.json" {
+		t.Fatalf("expected final status upload, got %q", remote.uploads[2].path)
 	}
 
 	// Verify clean signals removes signal files but NOT PID files
@@ -906,8 +914,8 @@ machine_id = "m-def456"
 	if remote.execCalls[0].sprite != "fern" {
 		t.Fatalf("exec sprite = %q, want name %q (not machine ID)", remote.execCalls[0].sprite, "fern")
 	}
-	if len(remote.uploads) != 2 {
-		t.Fatalf("upload calls = %d, want 2", len(remote.uploads))
+	if len(remote.uploads) != 3 {
+		t.Fatalf("upload calls = %d, want 3", len(remote.uploads))
 	}
 	if remote.uploads[0].sprite != "fern" {
 		t.Fatalf("upload sprite = %q, want name %q (not machine ID)", remote.uploads[0].sprite, "fern")

--- a/internal/watchdog/probe.go
+++ b/internal/watchdog/probe.go
@@ -24,11 +24,14 @@ type probe struct {
 }
 
 type statusFile struct {
-	Repo    string `json:"repo,omitempty"`
-	Issue   int    `json:"issue,omitempty"`
-	Started string `json:"started,omitempty"`
-	Mode    string `json:"mode,omitempty"`
-	Task    string `json:"task,omitempty"`
+	Repo      string `json:"repo,omitempty"`
+	Issue     int    `json:"issue,omitempty"`
+	Started   string `json:"started,omitempty"`
+	Completed string `json:"completed,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	Task      string `json:"task,omitempty"`
+	Status    string `json:"status,omitempty"`
+	ExitCode  int    `json:"exit_code,omitempty"`
 }
 
 func parseProbeOutput(output string) (probe, error) {

--- a/internal/watchdog/state_machine.go
+++ b/internal/watchdog/state_machine.go
@@ -16,12 +16,13 @@ const (
 )
 
 type stateInput struct {
-	AgentRunning  bool
-	HasComplete   bool
-	HasBlocked    bool
-	HasTask       bool
-	Elapsed       time.Duration
-	CommitsLast2h int
+	AgentRunning   bool
+	HasComplete    bool
+	HasBlocked     bool
+	HasTask        bool
+	Elapsed        time.Duration
+	CommitsLast2h  int
+	StatusComplete bool // true if STATUS.json has Completed timestamp (dispatch finished)
 }
 
 // evaluateState classifies a sprite's health from probe data.
@@ -30,7 +31,8 @@ type stateInput struct {
 // hitting a block (the block is stale context from an earlier attempt).
 func evaluateState(input stateInput, staleAfter time.Duration) State {
 	switch {
-	case input.HasComplete:
+	case input.HasComplete || input.StatusComplete:
+		// STATUS.json Completed field indicates dispatch finished (#367)
 		return StateComplete
 	case input.HasBlocked:
 		return StateBlocked

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -200,12 +200,13 @@ func (s *Service) inspectSprite(ctx context.Context, sprite string, execute bool
 	task := composeTaskLabel(probe)
 	hasTask := task != "" || strings.TrimSpace(probe.CurrentTaskID) != ""
 	input := stateInput{
-		AgentRunning:  probe.AgentRunning || probe.ClaudeCount > 0,
-		HasComplete:   probe.HasComplete,
-		HasBlocked:    probe.HasBlocked,
-		HasTask:       hasTask || probe.HasPrompt,
-		Elapsed:       time.Duration(elapsedMinutes) * time.Minute,
-		CommitsLast2h: probe.CommitsLast2h,
+		AgentRunning:   probe.AgentRunning || probe.ClaudeCount > 0,
+		HasComplete:    probe.HasComplete,
+		HasBlocked:     probe.HasBlocked,
+		HasTask:        hasTask || probe.HasPrompt,
+		Elapsed:        time.Duration(elapsedMinutes) * time.Minute,
+		CommitsLast2h:  probe.CommitsLast2h,
+		StatusComplete: strings.TrimSpace(probe.Status.Completed) != "", // dispatch finished (#367)
 	}
 	state := evaluateState(input, s.staleAfter)
 	actionType := decideAction(state, probe.HasPrompt)


### PR DESCRIPTION
## Summary

Fixes #367 - watchdog shows 'active' after dispatch completes (stale STATUS.json)

## Problem

After dispatch completed (exit 4, PARTIAL — uncommitted changes), running `bb watchdog --sprite fern` still showed `state=active`. The dispatch pipeline returned, but watchdog reported the sprite as still actively working.

## Root Cause

Dispatch writes STATUS.json on the sprite at the start of execution but does not update it on completion. Watchdog reads STATUS.json to determine sprite state, so it reported stale 'active' state indefinitely.

## Changes

- Added `Completed`, `Status`, `ExitCode` fields to `statusFile` struct in both dispatch and watchdog
- Added `writeFinalStatus()` method in dispatch to update STATUS.json on oneshot completion  
- Updated watchdog state machine to check `StatusComplete` from STATUS.json (when `Completed` field is set)
- Updated tests to expect 3 uploads (prompt, initial status, final status) for oneshot mode

## Acceptance Criteria

- [x] Dispatch pipeline updates STATUS.json on completion (success, partial, or failure)
- [x] Watchdog reflects actual state within one probe cycle after dispatch ends
- [x] Existing watchdog tests pass
- [x] Build, lint, and all tests pass

## Testing

```
make test  # all pass
make lint  # 0 issues
make build # succeeds
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced task completion tracking now captures completion timestamp and exit code information for more comprehensive status reporting.
  * Improved status persistence ensures final task status is reliably recorded.
  * Better completion detection in the state machine for more accurate task lifecycle tracking.

* **Tests**
  * Updated test coverage to validate new completion status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->