### PR TITLE
fix: configure git credentials for agent commit/push

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1423,6 +1423,8 @@ func buildSetupRepoScript(workspace, cloneURL, repoDir string) string {
 		"set -euo pipefail",
 		"mkdir -p " + shellutil.Quote(workspace),
 		"cd " + shellutil.Quote(workspace),
+		// Configure git credentials BEFORE any git operations that need auth
+		buildGitConfigScript(workspace),
 		"START_TIME=$(date +%s)",
 		"if [ -d " + shellutil.Quote(repoDir) + " ]; then",
 		"  echo \"[setup] pulling latest for " + shellutil.Quote(repoDir) + "...\"",
@@ -1443,6 +1445,37 @@ func buildSetupRepoScript(workspace, cloneURL, repoDir string) string {
 		"ELAPSED=$((END_TIME - START_TIME))",
 		"echo \"[setup] repo ready (${ELAPSED}s)\"",
 	}, "\n")
+}
+
+// buildGitConfigScript generates a script to configure git credentials using GITHUB_TOKEN.
+// This allows agents to commit and push without interactive authentication.
+// The token is stored in git's credential store so subsequent git operations use it automatically.
+func buildGitConfigScript(workspace string) string {
+	return strings.Join([]string{
+		"# Configure git credentials for non-interactive push/commit",
+		"GITHUB_TOKEN=\"${GITHUB_TOKEN:-${GH_TOKEN:-}}\"",
+		"if [ -n \"$GITHUB_TOKEN\" ]; then",
+		"  # Extract GitHub user from gh CLI if available, otherwise use 'sprite'",
+		"  GH_USER=\"$(gh api user -q .login 2>/dev/null || echo 'sprite')\"",
+		"  # Ensure credential store directory exists",
+		"  mkdir -p \"$HOME/.config/git\"",
+		"  # Store credentials for github.com",
+		"  printf 'protocol=https\\nhost=github.com\\nusername=%s\\npassword=%s\\n\\n' \"$GH_USER\" \"$GITHUB_TOKEN\" | git credential-store --file=\"$HOME/.git-credentials\" store",
+		"  # Configure git to use the credential store",
+		"  git config --global credential.helper 'store --file=\"$HOME/.git-credentials\"'",
+		"  git config --global user.email \"${GH_USER}@sprites.dev\"",
+		"  git config --global user.name \"${GH_USER}\"",
+		"  echo \"[setup] git credentials configured for $GH_USER\"",
+		"else",
+		"  echo \"[setup] warning: GITHUB_TOKEN not set, git push may fail\"",
+		"fi",
+	}, "\n")
+}
+
+// buildSetupRepoScriptWithGitConfig is a variant that explicitly includes git credential setup.
+// This is used for testing and ensures the git config is always included.
+func buildSetupRepoScriptWithGitConfig(workspace, cloneURL, repoDir string) string {
+	return buildSetupRepoScript(workspace, cloneURL, repoDir)
 }
 
 // buildOneShotScript generates a shell script for one-shot (non-Ralph) dispatch.

--- a/internal/dispatch/git_credential_test.go
+++ b/internal/dispatch/git_credential_test.go
@@ -1,0 +1,106 @@
+package dispatch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGitConfigScript_ConfiguresCredentialHelper(t *testing.T) {
+	t.Parallel()
+
+	script := buildGitConfigScript("/home/sprite/workspace")
+
+	// Must configure credential helper
+	if !strings.Contains(script, "git config --global credential.helper") {
+		t.Error("script must configure git credential helper")
+	}
+
+	// Must use store helper for non-interactive operation
+	if !strings.Contains(script, "store") {
+		t.Error("credential helper should use 'store' mode")
+	}
+}
+
+func TestBuildGitConfigScript_HandlesGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	script := buildGitConfigScript("/home/sprite/workspace")
+
+	// Must check for GITHUB_TOKEN or GH_TOKEN
+	if !strings.Contains(script, "GITHUB_TOKEN") && !strings.Contains(script, "GH_TOKEN") {
+		t.Error("script must reference GitHub token environment variables")
+	}
+
+	// Must configure credential store when token is present
+	if !strings.Contains(script, "git credential-store") {
+		t.Error("script must use git credential-store to cache credentials")
+	}
+}
+
+func TestBuildGitConfigScript_HandlesMissingToken(t *testing.T) {
+	t.Parallel()
+
+	script := buildGitConfigScript("/home/sprite/workspace")
+
+	// Should skip gracefully if no token is available
+	if !strings.Contains(script, "if") || !strings.Contains(script, "then") {
+		t.Error("script should check for token presence before configuring")
+	}
+
+	// Should not fail when token is missing
+	if !strings.Contains(script, "echo") {
+		t.Error("script should provide feedback about missing token")
+	}
+}
+
+func TestBuildSetupRepoScript_WithGitConfig(t *testing.T) {
+	t.Parallel()
+
+	// Test the combined script that includes git config
+	script := buildSetupRepoScriptWithGitConfig("/home/sprite/workspace", "https://github.com/misty-step/bb.git", "bb")
+
+	// Must include git credential configuration
+	if !strings.Contains(script, "credential.helper") {
+		t.Error("combined script must include git credential configuration")
+	}
+
+	// Must set up git config BEFORE any git operations that might need auth
+	credentialIdx := strings.Index(script, "credential.helper")
+	pushIdx := strings.Index(script, "git push")
+
+	// If there's a push operation, credential setup must come before it
+	if pushIdx != -1 && credentialIdx > pushIdx {
+		t.Error("git credential configuration must come before git push operations")
+	}
+
+	// Must include the original setup repo functionality
+	if !strings.Contains(script, "git clone") && !strings.Contains(script, "gh repo clone") {
+		t.Error("script must include repository cloning capability")
+	}
+}
+
+func TestBuildGitConfigScript_CreatesCredentialStore(t *testing.T) {
+	t.Parallel()
+
+	script := buildGitConfigScript("/home/sprite/workspace")
+
+	// Must ensure .git-credentials directory/file exists
+	if !strings.Contains(script, "mkdir -p") {
+		t.Error("script should ensure credential store path exists")
+	}
+
+	// Should configure credential store file
+	if !strings.Contains(script, ".git-credentials") {
+		t.Error("credential store should reference .git-credentials file")
+	}
+
+	// Should use git credential-store protocol
+	if !strings.Contains(script, "protocol=https") {
+		t.Error("credential store should use https protocol")
+	}
+
+	// Should target github.com
+	if !strings.Contains(script, "host=github.com") {
+		t.Error("credential store should target github.com")
+	}
+}


### PR DESCRIPTION
## Problem

Agents were completing code but failing to commit/push/PR (stranded work). Root cause: GITHUB_TOKEN was passed to the sprite environment, but git credential helper was not set up to use it. When agents ran 

git push

, git had no credentials and the push failed.

## Solution

Configure git credentials during repo setup so agents can push without interactive authentication:

1. Extract GitHub username from 
gh api user
 (falls back to 'sprite')
2. Store credentials in ~/.git-credentials using git credential-store
3. Configure git to use the credential store globally
4. Set git user.name and user.email for commits

## Changes

- Added 
buildGitConfigScript()
 to generate git credential configuration
- Integrated credential setup into 
buildSetupRepoScript()
 before any git operations
- Added comprehensive tests in 
git_credential_test.go

## Testing

All tests pass:
- Unit tests for credential helper configuration
- Tests for handling GITHUB_TOKEN presence/absence
- Tests for credential store creation
- Full test suite: 
go test ./...

## Fixes

Fixes #369
Related to #349 (stranded work detection)