### PR TITLE
fix: use os.LookupEnv and distinguish unset vs empty env vars

### DIFF
--- a/internal/dispatch/secrets.go
+++ b/internal/dispatch/secrets.go
@@ -75,8 +75,11 @@ func (r *SecretResolver) Resolve(reference string) (string, error) {
 	if strings.HasPrefix(reference, "${env:") && strings.HasSuffix(reference, "}") {
 		varName := reference[len("${env:") : len(reference)-1]
 		value, ok := os.LookupEnv(varName)
-		if !ok || value == "" {
-			return "", fmt.Errorf("environment variable %q is not set or is empty", varName)
+		if !ok {
+			return "", fmt.Errorf("environment variable %q is not set", varName)
+		}
+		if value == "" {
+			return "", fmt.Errorf("environment variable %q is set but empty", varName)
 		}
 		return value, nil
 	}


### PR DESCRIPTION
From PR #313 review feedback:

- Use os.LookupEnv to properly distinguish between unset and empty env vars  
- Provide specific error messages: "not set" vs "set but empty"

Fixes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error messages for environment variable configuration by distinguishing between missing and empty variables, providing clearer diagnostics for configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->