### PR TITLE
fix: GitHub API client cleanup from PR #305 review

### DIFF
--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -4,6 +4,7 @@ package github
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Common errors for GitHub API operations.
@@ -61,7 +62,17 @@ func (e *APIError) IsNotFound() bool {
 
 // IsRateLimited returns true if this error represents rate limiting.
 func (e *APIError) IsRateLimited() bool {
-	return e.StatusCode == 429 || (e.StatusCode == 403 && e.Type == "RATE_LIMITED")
+	if e.StatusCode == 429 {
+		return true
+	}
+	if e.StatusCode == 403 && e.Type == "RATE_LIMITED" {
+		return true
+	}
+	// Also check message content for "rate limit" substring
+	if e.StatusCode == 403 && strings.Contains(strings.ToLower(e.Message), "rate limit") {
+		return true
+	}
+	return false
 }
 
 // IsServerError returns true if this error represents a server-side failure.


### PR DESCRIPTION
## Context

Consolidated follow-up from PR #305 review feedback (gemini-code-assist, coderabbitai).

## Changes

### IsRateLimited fix
- Added check for "rate limit" substring in error message content
- Handles cases where GitHub returns 403 with rate limit message but without RATE_LIMITED type

### TestNewIssueValidator fix
- Refactored from environment-dependent test to explicit tests using t.Setenv
- Now tests both cases: GITHUB_TOKEN unset (falls back to gh CLI) and set (creates GitHubClient)
- Removed t.Parallel() since t.Setenv cannot be used with parallel tests

## Files
- internal/github/errors.go
- internal/dispatch/issue_validation_github_test.go

## Testing
- go test ./internal/github/... ./internal/dispatch/...
- make lint

Closes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit detection for GitHub API responses to better identify rate limiting (including additional status/message patterns), reducing false negatives and improving resilience.

* **Tests**
  * Reworked environment-based tests into explicit sequential subtests to clearly verify behavior when the GitHub token is present or absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->