### PR TITLE
fix: GitHub API Issue.Closed field doesn't exist in REST response

### DIFF
--- a/internal/dispatch/issue_validation.go
+++ b/internal/dispatch/issue_validation.go
@@ -285,7 +285,7 @@ func (v *IssueValidator) fetchIssueViaGH(ctx context.Context, issue int, repo st
 	args := []string{
 		"issue", "view", strconv.Itoa(issue),
 		"--repo", repo,
-		"--json", "number,title,body,state,labels,url,closed",
+		"--json", "number,title,body,state,labels,url,html_url,created_at,updated_at,closed_at",
 	}
 
 	output, err := v.RunGH(ctx, args...)
@@ -297,6 +297,9 @@ func (v *IssueValidator) fetchIssueViaGH(ctx context.Context, issue int, repo st
 	if err := json.Unmarshal(output, &issueData); err != nil {
 		return nil, fmt.Errorf("parse issue JSON: %w", err)
 	}
+
+	// Derive closed status from state (GitHub API doesn't have a boolean 'closed' field)
+	issueData.Closed = issueData.State == "closed"
 
 	return &issueData, nil
 }


### PR DESCRIPTION
## Problem

GitHub REST API doesn't return a boolean 'closed' field. The API uses:
- 'state': 'open' or 'closed' 
- 'closed_at': ISO 8601 timestamp or null

The old code queried gh CLI for field 'closed' which doesn't exist, causing the Closed status to always be false (zero value) even for closed issues.

## Fix

- Remove 'closed' from gh CLI query in fetchIssueViaGH()
- Derive Closed status from State field after unmarshaling: issueData.Closed = issueData.State == "closed"
- Updated tests to use real GitHub API response format (no 'closed' field)

## Verification

- All tests pass
- Build successful
- Lint clean (0 issues)

Fixes #329