### PR TITLE
docs: deprecate ralph-loop-v2.md

### DIFF
--- a/base/prompts/deprecated/ralph-loop-v2.md
+++ b/base/prompts/deprecated/ralph-loop-v2.md
@@ -1,4 +1,17 @@
-# Ralph Loop v2 — Self-Healing PR Workflow
+# [DEPRECATED] Ralph Loop v2 — Self-Healing PR Workflow
+
+> ⚠️ **DEPRECATED**: This template contains stale patterns that no longer match current Bitterblossom behavior.
+>
+> Use the canonical template instead: `scripts/ralph-prompt-template.md`
+>
+> Known issues in this file:
+> - Step 6 references `TASK_COMPLETE` print to stdout — completion detection expects a **file**, not stdout
+> - Git config references outdated `kaylee-mistystep` identity (superseded by per-sprite credentials)
+> - Missing required flags: `--dangerously-skip-permissions` and `--output-format stream-json`
+>
+> This file is preserved for historical reference only. Do not use for new dispatches.
+
+---
 
 ## Overview
 Sprites don't just open PRs — they **shepherd them to merge-ready**.


### PR DESCRIPTION
## Summary

Moves \ to \ and adds a deprecation notice pointing to the canonical template.

## Changes

- File relocated to deprecated/ subdirectory
- Added deprecation header documenting known stale patterns:
  - stdout TASK_COMPLETE print vs file detection mismatch
  - Outdated kaylee-mistystep git identity reference
  - Missing required flags for modern dispatch
- Preserved original content for historical reference

## Verification

- [x] Build passes: \"go build -o bin/bb ./cmd/bb\"
- [x] Tests pass: \"go test ./...\"
- [x] Lint passes: \"golangci-lint run\"

## Acceptance Criteria

Per issue #290:
- [x] Document that the file contains stale detection patterns
- [x] Point users to the canonical template at \"scripts/ralph-prompt-template.md\"
- [x] Move to deprecated/ subdirectory (clearer than in-place deprecation)

Fixes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Marked a workflow template as deprecated with clear notice indicating it's preserved for historical reference only and should not be used for new work.
- Documented three known issues associated with the deprecated template.
- Updated guidance to direct users to the canonical template for new workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->