### PR TITLE
fix: allow status during active dispatch

### DIFF
--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -25,13 +25,18 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
+func statusClient(token string) *sprites.Client {
+	client := sprites.New(token, sprites.WithDisableControl())
+	return client
+}
+
 func fleetStatus(ctx context.Context) error {
 	token, err := spriteToken()
 	if err != nil {
 		return err
 	}
 
-	client := sprites.New(token)
+	client := statusClient(token)
 	defer func() { _ = client.Close() }()
 
 	all, err := client.ListAllSprites(ctx, "")
@@ -73,7 +78,7 @@ func spriteStatus(ctx context.Context, spriteName string) error {
 		return err
 	}
 
-	client := sprites.New(token)
+	client := statusClient(token)
 	defer func() { _ = client.Close() }()
 	s := client.Sprite(spriteName)
 


### PR DESCRIPTION
Closes #390

## Summary
Use a dedicated Sprites client for `bb status` with control transport disabled so status checks use direct WebSockets and don’t compete with dispatch’s long-running control connection pool.

## Change
- Add `statusClient(token string) *sprites.Client` in `cmd/bb/status.go` using `sprites.WithDisableControl()`.
- Route `fleetStatus` and `spriteStatus` through `statusClient`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to enhance maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->