### PR TITLE
fix: improve expired-token hint on unauthorized token exchange

### DIFF
--- a/cmd/bb/main.go
+++ b/cmd/bb/main.go
@@ -116,12 +116,14 @@ func spriteToken() (string, error) {
 }
 
 // tokenExchangeErr wraps a CreateToken error with an actionable hint.
-// "unauthorized" almost always means an expired FLY_API_TOKEN.
+// Matches "unauthorized" case-insensitively — sprites-go doesn't expose typed
+// errors, so string matching is the only detection path. If the SDK changes
+// its error text, this degrades to the generic message (not silently wrong).
 func tokenExchangeErr(err error) error {
-	if strings.Contains(err.Error(), "unauthorized") {
+	if strings.Contains(strings.ToLower(err.Error()), "unauthorized") {
 		return fmt.Errorf("token exchange failed: %w\nHint: FLY_API_TOKEN may be expired. Try: export FLY_API_TOKEN=$(fly tokens create)", err)
 	}
-	return fmt.Errorf("token exchange failed: %w (set SPRITES_ORG if not 'personal')", err)
+	return fmt.Errorf("token exchange failed: %w", err)
 }
 
 // requireEnv returns the value of an environment variable or an error.

--- a/cmd/bb/main_test.go
+++ b/cmd/bb/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -20,12 +21,33 @@ func TestTokenExchangeErrUnauthorizedHint(t *testing.T) {
 	if !strings.Contains(msg, "fly tokens create") {
 		t.Errorf("error = %q, want 'fly tokens create' hint", msg)
 	}
-	if strings.Contains(msg, "set SPRITES_ORG") {
-		t.Errorf("error = %q, should not contain SPRITES_ORG hint for unauthorized", msg)
+}
+
+func TestTokenExchangeErrUnauthorizedCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	for _, text := range []string{"Unauthorized", "UNAUTHORIZED", "request unauthorized by server"} {
+		err := tokenExchangeErr(fmt.Errorf("%s", text))
+		msg := err.Error()
+		if !strings.Contains(msg, "FLY_API_TOKEN may be expired") {
+			t.Errorf("tokenExchangeErr(%q) = %q, want expired-token hint", text, msg)
+		}
 	}
 }
 
-func TestTokenExchangeErrOtherErrorOrgHint(t *testing.T) {
+func TestTokenExchangeErrPreservesWrappedError(t *testing.T) {
+	t.Parallel()
+
+	orig := fmt.Errorf("unauthorized")
+	wrapped := tokenExchangeErr(orig)
+
+	// %w wrapping must be unwrappable
+	if !errors.Is(wrapped, orig) {
+		t.Errorf("errors.Is(wrapped, orig) = false; want true")
+	}
+}
+
+func TestTokenExchangeErrOtherErrorNoOrgHint(t *testing.T) {
 	t.Parallel()
 
 	err := tokenExchangeErr(fmt.Errorf("connection refused"))
@@ -36,7 +58,25 @@ func TestTokenExchangeErrOtherErrorOrgHint(t *testing.T) {
 	if strings.Contains(msg, "FLY_API_TOKEN may be expired") {
 		t.Errorf("error = %q, should not contain expired hint for non-auth error", msg)
 	}
-	if !strings.Contains(msg, "set SPRITES_ORG") {
-		t.Errorf("error = %q, want SPRITES_ORG hint for generic error", msg)
+	if strings.Contains(msg, "SPRITES_ORG") {
+		t.Errorf("error = %q, should not contain misleading SPRITES_ORG hint for connection error", msg)
+	}
+	if !strings.Contains(msg, "connection refused") {
+		t.Errorf("error = %q, want original error preserved", msg)
+	}
+}
+
+// TestSpriteTokenMissingEnv verifies the error when neither token env var is set.
+func TestSpriteTokenMissingEnv(t *testing.T) {
+	// Not parallel: mutates process environment.
+	t.Setenv("FLY_API_TOKEN", "")
+	t.Setenv("SPRITE_TOKEN", "")
+
+	_, err := spriteToken()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "FLY_API_TOKEN must be set") {
+		t.Errorf("err = %q, want to contain %q", err.Error(), "FLY_API_TOKEN must be set")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #405

When `FLY_API_TOKEN` is expired, `sprites.CreateToken` returns an "unauthorized" error. Previously this showed a misleading "set SPRITES_ORG" hint. Now it shows an actionable hint: `FLY_API_TOKEN may be expired. Try: export FLY_API_TOKEN=$(fly tokens create)`.

## Changes

- `cmd/bb/main.go`: Extract `tokenExchangeErr()` — wraps CreateToken errors with context-appropriate hints
- `cmd/bb/main_test.go`: 5 tests covering unauthorized, case variants, error unwrapping, non-auth errors, missing env vars

## Polish Pass (hindsight review)

**Before:** Case-sensitive `strings.Contains(err.Error(), "unauthorized")` — would miss `Unauthorized` or `UNAUTHORIZED` from SDK. Non-auth errors showed misleading "set SPRITES_ORG" hint. Only 2 tests. No unwrap verification despite using `%w`.

**After:** Case-insensitive matching via `strings.ToLower`. Non-auth errors get a plain wrap (no misleading hint). 5 tests: unauthorized hint, case-insensitive variants (`Unauthorized`, `UNAUTHORIZED`, embedded substring), `errors.Is` unwrap chain, non-auth error, missing env vars. Comment documents string-matching fragility. Supersedes PR #417 (closed); cherry-picked its `TestSpriteTokenMissingEnv`.

## Test Coverage

```
TestTokenExchangeErrUnauthorizedHint         — authorized path fires hint
TestTokenExchangeErrUnauthorizedCaseInsensitive — Unauthorized, UNAUTHORIZED, embedded
TestTokenExchangeErrPreservesWrappedError    — errors.Is(wrapped, orig) = true
TestTokenExchangeErrOtherErrorNoOrgHint      — no misleading SPRITES_ORG
TestSpriteTokenMissingEnv                    — neither env var set
```