### PR TITLE
fix: avoid false off-rails abort during CI polling waits

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -315,7 +315,6 @@ exit 1`
 // prChecksScript checks whether all PR CI checks for the current HEAD have passed.
 // Exits 0 when all checks pass, 1 when checks are still pending, 2 on error (no PR, no git, etc.).
 const prChecksScript = `
-export GH_TOKEN="$GH_TOKEN"
 cd "$WORKSPACE" 2>/dev/null || exit 2
 gh pr checks HEAD --exit-status 2>&1
 exit_code=$?


### PR DESCRIPTION
## Summary

Closes #416.

Dispatch was exiting with failure even when the agent had produced valid work (commits, PR, green CI). The off-rails silence detector kept running during the post-ralph verify/poll phase — a period where no output is expected — and aborted the dispatch as if the agent had gone silent.

Two fixes:
1. **Stop the silence detector immediately after `ralph.Run()` returns.** Post-ralph work is intentional; it should never trigger off-rails.
2. **Add `--pr-check-timeout`** so operators can optionally wait for PR CI checks to pass after the agent finishes, with proper progress heartbeats that prevent any future silence detection from misfiring.

## Changes

- `cmd/bb/dispatch.go`
  - `detector.stop()` called immediately after `ralphCmd.Run()` returns (before verify/poll)
  - Added `--pr-check-timeout` flag (default `0` = skip)
  - Added `waitForPRChecksWithRunner` — polls `gh pr checks HEAD` on the sprite, emits `[dispatch] PR checks: pending` heartbeat each interval
  - Added `prChecksScript` — shell fragment run on sprite to query check status
  - Threaded `prCheckTimeout` through `runDispatch` and `newDispatchCmd`
- `cmd/bb/dispatch_test.go`
  - 7 new tests covering: flag registration, zero-timeout no-op, immediate pass, timeout expiry, context cancellation, progress output, workspace/token injection into script

## Acceptance Criteria

- [x] Long-running wait loops emit heartbeat/progress at < silence threshold
- [x] off-rails does not fire for legitimate long-wait states
- [x] A dispatch that produced commits/PR and green CI does not fail solely due to silent sleep windows

## Manual QA

**Reproduce the original bug (before fix):**
```bash
# Dispatch a task that takes >defaultSilenceAbortThreshold to poll CI.
# Before: dispatch exits failure with "off-rails" despite TASK_COMPLETE present.
```

**Verify the fix:**
```bash
go build -o bin/bb ./cmd/bb

# Confirm --pr-check-timeout flag exists
./bin/bb dispatch --help | grep pr-check-timeout
# Expected: --pr-check-timeout duration   After task complete, wait up to this long for PR CI checks...

# Dispatch with PR check polling enabled
ANTHROPIC_API_KEY="" ./bin/bb dispatch <sprite> "<prompt>" \
  --repo misty-step/bitterblossom \
  --pr-check-timeout 10m
# Expected: after ralph exits, output shows:
#   === waiting for PR checks (timeout 10m0s) ===
#   [dispatch] PR checks: pending — next poll in 30s   (repeated until pass)
#   === PR checks passed ===
```

**Run tests:**
```bash
go test ./cmd/bb/... -run TestWaitForPRChecks -v
go test ./cmd/bb/... -run TestDispatchCmdHasPRCheckTimeoutFlag -v
```
Expected: all 7 new tests pass.

## Before / After

**Before:** Off-rails detector continued running through the post-ralph verify phase. A single 30s+ sleep (e.g. CI poll interval inside the agent) after `ralph.Run()` returned would trigger the silence detector and abort dispatch with failure — even when `TASK_COMPLETE` was present and the PR had green CI.

```
=== work produced ===
...commits and PR found...
[off-rails] no output for 5m — aborting   ← false positive
dispatch: exit 4
```

**After:** Detector is stopped the instant `ralph.Run()` returns. Post-ralph phases (verify, optional PR check polling) are silent by design and never trigger off-rails. With `--pr-check-timeout`, the operator gets live heartbeats:

```
=== work produced ===
...commits and PR found...
=== waiting for PR checks (timeout 10m0s) ===
[dispatch] PR checks: pending — next poll in 30s
[dispatch] PR checks: pending — next poll in 30s
=== PR checks passed ===
```

## Test Coverage

**New tests in `cmd/bb/dispatch_test.go`:**
- `TestDispatchCmdHasPRCheckTimeoutFlag` — flag registered with correct default
- `TestWaitForPRChecksReturnsNilWhenDisabled` — zero timeout is no-op, runner not called
- `TestWaitForPRChecksReturnsNilOnImmediatePass` — exit 0 on first poll → returns nil
- `TestWaitForPRChecksTimesOut` — always-pending runner → timeout error with "pr-check-timeout" in message
- `TestWaitForPRChecksEmitsProgress` — first poll pending, second pass → progress contains `[dispatch]`
- `TestWaitForPRChecksContextCancelled` — pre-cancelled ctx → returns error
- `TestWaitForPRChecksUsesWorkspaceAndToken` — workspace path and GH token injected into script

**Not tested:** actual `gh pr checks` behavior on a live sprite (integration-level; covered by e2e shakedowns). The `detector.stop()` call timing is not unit-tested — verified by code inspection and the e2e evidence from the issue.

---

## Before / After (review feedback)

**Before:** `prChecksScript` mapped all non-zero `gh pr checks` exit codes to `exit 1` (pending), so fatal errors (missing `gh`, auth failures, no PR for HEAD) were silently retried until timeout with misleading pending logs. The polling loop also waited for the first tick (30s default) before executing any check, making `--pr-check-timeout` values shorter than 30s deterministically expire without ever polling.

**After:** `prChecksScript` now preserves exit 0/1 from `gh` and maps all other codes to exit 2 (error). The polling loop runs an immediate check at loop entry before the ticker wait, so short `--pr-check-timeout` values get at least one check. Exit code 2 causes fast failure with a clear error message instead of retry-until-timeout.

---

## Before / After (polish pass)

**Before:** Working PR with 9 tests. Minor dead code in test (`fakeSpriteScriptRunner` created then discarded), redundant `export GH_TOKEN="$GH_TOKEN"` in `prChecksScript` (caller already exports it), and two untested paths: runner error retry behavior and script content validation.

**After:** Dead code removed, redundant export removed, 2 new tests added:
- `TestWaitForPRChecksRetriesOnRunnerError` — transient runner errors are retried (not fatal), progress emits "runner error"
- `TestPRChecksScriptContainsExpectedCommands` — guards that `prChecksScript` contains `gh pr checks HEAD`, `--exit-status`, and fatal exit 2

Total: 11 tests covering the PR check polling feature (up from 9).
