### PR TITLE
fix: bb status lists dirty file paths, not just count

### DIFF
--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -135,7 +135,12 @@ echo "=== git ==="
 if [ -d "$WS" ]; then
   cd "$WS"
   echo "branch: $(git branch --show-current 2>/dev/null || echo 'n/a')"
-  echo "status: $(git status --porcelain 2>/dev/null | wc -l | tr -d ' ') dirty files"
+  dirty=$(git status --porcelain 2>/dev/null)
+  dirty_count=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  echo "status: $dirty_count dirty files"
+  if [ -n "$dirty" ]; then
+    printf '%s\n' "$dirty" | sed 's/^/  /'
+  fi
   echo ""
   echo "recent commits:"
   git log --oneline -5 2>/dev/null || echo "(no commits)"


### PR DESCRIPTION
Closes #427

When a sprite workspace has uncommitted changes, `bb status <sprite>` now lists the modified file paths below the count line (matching `git status --short` format), instead of only showing the count.

**Before:**
```
=== git ===
branch: fix/my-branch
status: 2 dirty files
```

**After:**
```
=== git ===
branch: fix/my-branch
status: 2 dirty files
   M cmd/bb/dispatch.go
  ?? cmd/bb/new_file.go
```

Clean sprites continue to show `status: 0 dirty files` with no extra output.

**Verification:** `go build ./...` ✅ `go test ./... -count=1` ✅ `go vet ./...` ✅