### PR TITLE
fix(setup): add persona fallback and --persona flag (closes #418)

### DIFF
--- a/cmd/bb/setup_test.go
+++ b/cmd/bb/setup_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupSpritesDir creates a temp directory with sprite persona files and
+// changes the working directory to it so resolvePersona can find sprites/.
+func setupSpritesDir(t *testing.T, files []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	spritesDir := filepath.Join(dir, "sprites")
+	if err := os.MkdirAll(spritesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		path := filepath.Join(spritesDir, f)
+		if err := os.WriteFile(path, []byte("# persona: "+f), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}
+
+func TestResolvePersonaExactMatch(t *testing.T) {
+	setupSpritesDir(t, []string{"bramble.md", "willow.md"})
+
+	got, err := resolvePersona("bramble", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "sprites/bramble.md" {
+		t.Errorf("got %q, want %q", got, "sprites/bramble.md")
+	}
+}
+
+func TestResolvePersonaFallbackWhenNoExactMatch(t *testing.T) {
+	setupSpritesDir(t, []string{"bramble.md", "willow.md"})
+
+	got, err := resolvePersona("e2e-0219123628", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should fall back to first available (alphabetical: bramble.md)
+	if got != "sprites/bramble.md" {
+		t.Errorf("got %q, want %q", got, "sprites/bramble.md")
+	}
+}
+
+func TestResolvePersonaExplicitPersonaFlag(t *testing.T) {
+	setupSpritesDir(t, []string{"bramble.md", "willow.md"})
+
+	got, err := resolvePersona("e2e-0219123628", "willow")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "sprites/willow.md" {
+		t.Errorf("got %q, want %q", got, "sprites/willow.md")
+	}
+}
+
+func TestResolvePersonaExplicitPersonaWithExtension(t *testing.T) {
+	setupSpritesDir(t, []string{"bramble.md"})
+
+	got, err := resolvePersona("worker-1", "bramble.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "sprites/bramble.md" {
+		t.Errorf("got %q, want %q", got, "sprites/bramble.md")
+	}
+}
+
+func TestResolvePersonaExplicitDirectPath(t *testing.T) {
+	dir := t.TempDir()
+	personaPath := filepath.Join(dir, "custom-persona.md")
+	if err := os.WriteFile(personaPath, []byte("# custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// No sprites/ dir needed — direct path resolves first
+	setupSpritesDir(t, nil)
+
+	got, err := resolvePersona("worker-1", personaPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != personaPath {
+		t.Errorf("got %q, want %q", got, personaPath)
+	}
+}
+
+func TestResolvePersonaErrorWhenNoPersonasAvailable(t *testing.T) {
+	setupSpritesDir(t, nil) // empty sprites/
+
+	_, err := resolvePersona("e2e-0219123628", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--persona") {
+		t.Errorf("error should mention --persona flag, got: %v", err)
+	}
+}
+
+func TestResolvePersonaErrorWhenExplicitPersonaNotFound(t *testing.T) {
+	setupSpritesDir(t, []string{"bramble.md"})
+
+	_, err := resolvePersona("worker-1", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention the missing persona name, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`bb setup <sprite>` failed with `persona not found: sprites/<sprite>.md` for any sprite name without a matching persona file. Fresh/ephemeral sprite names (e.g. `e2e-0219123628`) always hit this.

## Solution

Three-level resolution with graceful fallback:
1. `--persona <name|path>`: explicit override (sprite name or direct file path)
2. `sprites/<spriteName>.md`: exact match (existing behavior)
3. First available file in `sprites/` alphabetically (new fallback, prints warning)

Actionable error if none of the above resolves.

## Files Changed

- `cmd/bb/setup.go`: added `--persona` flag, `resolvePersona()` function, updated `runSetup` signature
- `cmd/bb/setup_test.go`: 7 tests covering all resolution paths

## Verification

```
go build ./... ✅
go test ./cmd/bb/ ✅ (all tests pass, 7 new for resolvePersona)
```

## Acceptance Criteria

- [x] `bb setup <new-sprite>` works without matching persona file (fallback)
- [x] CLI supports explicit persona selection via `--persona`
- [x] Error message is actionable when no persona found at all
- [x] Behavior documented in `--help` output

Co-Authored-By: bramble <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--persona` flag to the setup command for configuring custom personas, with intelligent resolution supporting explicit file paths, sprite name lookups, and automatic fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->