### PR TITLE
fix: bb status lists dirty files (closes #427)

### DIFF
--- a/cmd/bb/status_test.go
+++ b/cmd/bb/status_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParsePorcelainStatus_Empty(t *testing.T) {
+	t.Parallel()
+
+	lines := parsePorcelainStatus("")
+	if lines != nil {
+		t.Fatalf("expected nil for empty input, got %v", lines)
+	}
+}
+
+func TestParsePorcelainStatus_Clean(t *testing.T) {
+	t.Parallel()
+
+	// A clean repo produces no porcelain output.
+	lines := parsePorcelainStatus("")
+	if len(lines) != 0 {
+		t.Fatalf("expected 0 lines for clean repo, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestParsePorcelainStatus_ModifiedFile(t *testing.T) {
+	t.Parallel()
+
+	input := " M cmd/bb/status.go\n"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != " M cmd/bb/status.go" {
+		t.Errorf("line[0] = %q, want %q", lines[0], " M cmd/bb/status.go")
+	}
+}
+
+func TestParsePorcelainStatus_UntrackedFile(t *testing.T) {
+	t.Parallel()
+
+	input := "?? newfile.go\n"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "?? newfile.go" {
+		t.Errorf("line[0] = %q, want %q", lines[0], "?? newfile.go")
+	}
+}
+
+func TestParsePorcelainStatus_MultipleFiles(t *testing.T) {
+	t.Parallel()
+
+	input := " M cmd/bb/dispatch.go\n?? cmd/bb/newfile.go\nA  cmd/bb/added.go\n"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %v", len(lines), lines)
+	}
+	want := []string{
+		" M cmd/bb/dispatch.go",
+		"?? cmd/bb/newfile.go",
+		"A  cmd/bb/added.go",
+	}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("line[%d] = %q, want %q", i, lines[i], w)
+		}
+	}
+}
+
+func TestParsePorcelainStatus_NoTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	// Some environments may omit trailing newline.
+	input := " M cmd/bb/status.go"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != " M cmd/bb/status.go" {
+		t.Errorf("line[0] = %q, want %q", lines[0], " M cmd/bb/status.go")
+	}
+}
+
+func TestParsePorcelainStatus_StagedAndUnstaged(t *testing.T) {
+	t.Parallel()
+
+	// MM means staged modification + unstaged modification.
+	input := "MM cmd/bb/status.go\n"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "MM cmd/bb/status.go" {
+		t.Errorf("line[0] = %q, want %q", lines[0], "MM cmd/bb/status.go")
+	}
+}
+
+func TestParsePorcelainStatus_CountMatchesLines(t *testing.T) {
+	t.Parallel()
+
+	input := " M a.go\n?? b.go\nD  c.go\n"
+	lines := parsePorcelainStatus(input)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines (matching dirty count), got %d", len(lines))
+	}
+}


### PR DESCRIPTION
Lists modified/untracked files below count line, formatted as `git status --short`. Tests added.

## Changes

- `statusScript` upgraded to `--porcelain=v1` (stable machine-readable format per git docs)
- Capture porcelain output once; derive dirty count and file list from same variable (no double `git status` call)
- Print indented file list below count line when dirty count > 0
- Clean sprites: output unchanged (`status: 0 dirty files`, no file list)
- Added `parsePorcelainStatus()` Go helper + 8 unit tests covering empty, clean, modified, untracked, staged+unstaged, no-trailing-newline, and count-match cases

## Before / After

**Before:**
```
=== git ===
branch: fix/my-branch
status: 2 dirty files
```

**After:**
```
=== git ===
branch: fix/my-branch
status: 2 dirty files
   M cmd/bb/dispatch.go
  ?? cmd/bb/newfile.go
```

## Verification
`go build ./...` ✅ `go test ./... -count=1` ✅ `go vet ./...` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved status output with accurate dirty file counts and inline display of modified and untracked files.

* **Tests**
  * Comprehensive test coverage for status parsing functionality, including edge cases for empty repos, staged/unstaged changes, and trailing newline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->