### PR TITLE
fix: bb sprite-cli auth fallback when Fly token exchange is unauthorized (closes #422)

### DIFF
--- a/cmd/bb/main.go
+++ b/cmd/bb/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
-	sprites "github.com/superfly/sprites-go"
-
 	"github.com/spf13/cobra"
+	sprites "github.com/superfly/sprites-go"
 )
 
 var (
@@ -88,32 +90,41 @@ func spriteToken() (string, error) {
 	}
 
 	flyToken := os.Getenv("FLY_API_TOKEN")
-	if flyToken == "" {
-		return "", fmt.Errorf("SPRITE_TOKEN or FLY_API_TOKEN must be set")
+	if flyToken != "" {
+		macaroon := strings.TrimPrefix(flyToken, "FlyV1 ")
+		org := os.Getenv("SPRITES_ORG")
+		if org == "" {
+			org = os.Getenv("FLY_ORG")
+		}
+		if org == "" {
+			org = "personal"
+		}
+		fmt.Fprintf(os.Stderr, "exchanging FLY_API_TOKEN for sprites token (org=%s)...\n", org)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if token, err := sprites.CreateToken(ctx, macaroon, org, ""); err == nil {
+			return token, nil
+		} else {
+			fmt.Fprintf(os.Stderr, "FLY_API_TOKEN exchange failed (%v); trying sprite CLI...\n", err)
+		}
+	} else {
+		fmt.Fprint(os.Stderr, "no SPRITE_TOKEN or FLY_API_TOKEN; trying sprite CLI...\n")
 	}
-
-	// Strip "FlyV1 " prefix — CreateToken prepends it
-	macaroon := strings.TrimPrefix(flyToken, "FlyV1 ")
-
-	org := os.Getenv("SPRITES_ORG")
-	if org == "" {
-		org = os.Getenv("FLY_ORG") // fall back to FLY_ORG from .env.bb
+	flyTokenCLI, orgCLI, err := getSpriteCLIFlyToken()
+	if err != nil {
+		return "", fmt.Errorf("SPRITE_TOKEN, FLY_API_TOKEN, or sprite CLI auth required: %w", err)
 	}
-	if org == "" {
-		org = "personal"
-	}
-
-	_, _ = fmt.Fprintf(os.Stderr, "exchanging fly token for sprites token (org=%s)...\n", org)
+	macaroon := strings.TrimPrefix(flyTokenCLI, "FlyV1 ")
+	fmt.Fprintf(os.Stderr, "exchanging sprite CLI token for sprites token (org=%s)...\n", orgCLI)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-
-	token, err := sprites.CreateToken(ctx, macaroon, org, "")
+	token, err := sprites.CreateToken(ctx, macaroon, orgCLI, "")
 	if err != nil {
 		return "", tokenExchangeErr(err)
 	}
-
 	return token, nil
 }
+
 
 // tokenExchangeErr wraps a CreateToken error with an actionable hint.
 // Matches "unauthorized" case-insensitively — sprites-go doesn't expose typed
@@ -133,4 +144,55 @@ func requireEnv(name string) (string, error) {
 		return "", fmt.Errorf("%s must be set", name)
 	}
 	return v, nil
+}
+
+func getSpriteCLIFlyToken() (string, string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", "", errors.New("HOME unset")
+	}
+	configPath := filepath.Join(home, ".sprites", "sprites.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", "", fmt.Errorf("read sprites.json: %w", err)
+	}
+	var c struct {
+		Current struct {
+			URL string `json:"url"`
+			Org string `json:"org"`
+		} `json:"current_selection"`
+		URLs map[string]struct {
+			Orgs map[string]struct {
+				KeyringKey string `json:"keyring_key"`
+			} `json:"orgs"`
+		} `json:"urls"`
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return "", "", fmt.Errorf("parse sprites.json: %w", err)
+	}
+	url := c.Current.URL
+	org := c.Current.Org
+	if url == "" || org == "" {
+		return "", "", errors.New("missing current_selection in sprites.json")
+	}
+	urlEntry, ok := c.URLs[url]
+	if !ok {
+		return "", "", fmt.Errorf("no %s in urls", url)
+	}
+	for _, o := range urlEntry.Orgs {
+		if o.KeyringKey == "" {
+			continue
+		}
+		cmd := exec.Command("security", "find-generic-password", "-s", o.KeyringKey, "-w")
+		cmd.Env = []string{"LC_ALL=C"}
+		out, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		flyToken := strings.TrimSpace(string(out))
+		if flyToken != "" && strings.HasPrefix(flyToken, "FlyV1 ") {
+			return flyToken, org, nil
+		}
+	}
+	return "", "", errors.New("no valid Fly token in sprite CLI keyring")
 }


### PR DESCRIPTION
Implements #422. Restructures spriteToken() to try FLY_API_TOKEN exchange first, then fall back to sprite-cli keychain auth. Self-verified: build ✅ vet ✅ tests ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FLY_API_TOKEN exchange with automatic organization detection (from SPRITES_ORG or FLY_ORG).
  * Enhanced authentication with sprite CLI token retrieval via system keychain as additional fallback path.
  * Improved error messaging to distinguish between different authentication failures.

* **Tests**
  * Added comprehensive test coverage for sprite CLI token retrieval error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->