### PR TITLE
docs: add README troubleshooting note for bb kill recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,17 @@ python3 -m pytest -q
 - Sprite GitHub identity is env-configurable (shared bot by default, per-sprite overrides supported)
 - Human approval required for composition changes
 - Fae/fairy naming convention throughout
+
+## Troubleshooting
+
+### Dispatch fails with stale Ralph or Claude processes
+
+If a previous dispatch was interrupted (Ctrl+C, timeout, crash), the sprite may still have a running ralph loop or claude process. The next dispatch will refuse to start until these are cleared.
+
+Run:
+
+```bash
+bb kill <sprite>
+```
+
+This terminates any stale ralph loop and agent processes on the sprite, freeing it for a fresh dispatch.


### PR DESCRIPTION
## Summary

Adds a **Troubleshooting** section to the README explaining how to recover a sprite that has stale Ralph or Claude processes after an interrupted dispatch.

- Mentions `bb kill <sprite>` explicitly
- Explains it clears stale ralph loop and agent processes so dispatch can run again
- Concise, focused section with a code example

## Changes

- `README.md`: new `## Troubleshooting` section at end of file

Closes #450