### PR TITLE
docs: add troubleshooting note for bb kill recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ Safety-critical hooks in `base/hooks/` are covered with pytest:
 python3 -m pytest -q
 ```
 
+## Troubleshooting
+
+### Dispatch blocked by a stale Ralph loop
+
+If a previous dispatch was interrupted (Ctrl-C, network drop, timeout), the Ralph loop may still be running on the sprite. A live Ralph process blocks the next dispatch.
+
+```bash
+bb kill <sprite>
+```
+
+This terminates the Ralph loop and any associated agent processes, clearing the way for a fresh dispatch. Stale Claude-only processes (no active Ralph loop) are cleaned automatically by dispatch and don't require `bb kill`.
+
 ## Constraints
 
 - PR review is a separate GitHub Action (multi-model council), not done by sprites


### PR DESCRIPTION
## Summary

Adds a **Troubleshooting** section to the README explaining how to recover from a dispatch that was interrupted while Ralph was still running.

- Names `bb kill <sprite>` explicitly as the recovery command
- Explains it clears the stale Ralph loop so dispatch can run again
- Clarifies the distinction: a live Ralph loop blocks dispatch; stale Claude-only processes are auto-cleaned by dispatch

## Changes

- `README.md` — new Troubleshooting section, no code changes

## Test plan

- [ ] README renders correctly on GitHub
- [ ] No unrelated content modified

Closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting section with steps to recover from stale Ralph loops using the `bb kill` command.
  * Clarified that stale Claude-only processes are cleaned automatically by dispatch.
  * Documented that active Ralph processes block subsequent dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->