### PR TITLE
fix: satisfy staticcheck in workspace metadata test

### DIFF
--- a/cmd/bb/workspace_metadata_test.go
+++ b/cmd/bb/workspace_metadata_test.go
@@ -78,7 +78,7 @@ func TestWorkspaceDiscoveryScriptPrefersMetadata(t *testing.T) {
 	if metaIdx == -1 || promptIdx == -1 || logIdx == -1 {
 		t.Fatalf("script missing expected discovery checks")
 	}
-	if !(metaIdx < promptIdx && promptIdx < logIdx) {
+	if metaIdx >= promptIdx || promptIdx >= logIdx {
 		t.Fatalf("expected metadata -> prompt -> log order, got script:\n%s", script)
 	}
 }


### PR DESCRIPTION
## Summary
- apply the De Morgan simplification staticcheck expects in workspace metadata ordering test
- keep Go lint green after the conductor MVP merge

## Verification
- golangci-lint run
- go test ./cmd/bb/...