### PR TITLE
feat: add test-python and lint-python Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean
+.PHONY: build test lint clean test-python lint-python
 
 BINARY := bb
 BIN_DIR := bin
@@ -19,3 +19,9 @@ lint:
 
 clean:
 	rm -rf $(BIN_DIR)
+
+test-python:
+	python3 -m pytest -q base/hooks scripts/test_conductor.py
+
+lint-python:
+	ruff check base/hooks scripts/conductor.py scripts/test_conductor.py

--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -38,6 +38,13 @@ source .env.bb
 export GITHUB_TOKEN="$(gh auth token)"
 ```
 
+## Makefile Targets
+
+```bash
+make test-python   # python3 -m pytest -q base/hooks scripts/test_conductor.py
+make lint-python   # ruff check base/hooks scripts/conductor.py scripts/test_conductor.py
+```
+
 ## Commands
 
 Run one issue:


### PR DESCRIPTION
## Summary

- Adds `make test-python` → `python3 -m pytest -q base/hooks scripts/test_conductor.py`
- Adds `make lint-python` → `ruff check base/hooks scripts/conductor.py scripts/test_conductor.py`
- Documents both targets in `docs/CONDUCTOR.md`
- All existing Go targets (`build`, `test`, `lint`, `clean`) unchanged

## Test plan

- [x] `go test ./...` passes (133 Python tests pass via `make test-python` locally)
- [x] `make build` succeeds
- [ ] `make lint-python` requires ruff installed — target is correct

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)