### PR TITLE
fix: wait for fresh checks after readying PRs

### DIFF
--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -636,6 +636,44 @@ def wait_for_pr_checks(runner: Runner, repo: str, pr_number: int, timeout_minute
     return (proc.returncode == 0, output.strip())
 
 
+def status_check_snapshot(payload: dict[str, Any]) -> tuple[tuple[str, str, str, str], ...]:
+    snapshot: list[tuple[str, str, str, str]] = []
+    for item in payload.get("statusCheckRollup", []):
+        typename = str(item.get("__typename", ""))
+        if typename == "CheckRun":
+            name = str(item.get("name", ""))
+            status = str(item.get("status", ""))
+            started = str(item.get("startedAt", ""))
+            completed = str(item.get("completedAt", ""))
+        elif typename == "StatusContext":
+            name = str(item.get("context", ""))
+            status = str(item.get("state", ""))
+            started = str(item.get("startedAt", ""))
+            completed = ""
+        else:
+            continue
+        snapshot.append((name, status, started, completed))
+    return tuple(sorted(snapshot))
+
+
+def wait_for_check_refresh(
+    runner: Runner,
+    repo: str,
+    pr_number: int,
+    before: tuple[tuple[str, str, str, str], ...],
+    *,
+    timeout_seconds: int = 60,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        pr = gh_json(runner, ["pr", "view", str(pr_number), "--repo", repo, "--json", "statusCheckRollup"])
+        after = status_check_snapshot(pr)
+        if after != before:
+            return
+        time.sleep(5)
+    raise CmdError(f"timed out waiting for PR #{pr_number} checks to refresh after marking ready")
+
+
 def required_status_checks(runner: Runner, repo: str, base_branch: str) -> list[str]:
     try:
         payload = json.loads(runner.run(["gh", "api", f"repos/{repo}/branches/{base_branch}/protection"], timeout=60))
@@ -714,11 +752,14 @@ def merge_pr(runner: Runner, repo: str, pr_number: int) -> None:
     wait_for_pr_merged(runner, repo, pr_number)
 
 
-def ensure_pr_ready(runner: Runner, repo: str, pr_number: int) -> None:
-    pr = gh_json(runner, ["pr", "view", str(pr_number), "--repo", repo, "--json", "isDraft"])
+def ensure_pr_ready(runner: Runner, repo: str, pr_number: int) -> bool:
+    pr = gh_json(runner, ["pr", "view", str(pr_number), "--repo", repo, "--json", "isDraft,statusCheckRollup"])
     if not pr["isDraft"]:
-        return
+        return False
+    before = status_check_snapshot(pr)
     runner.run(["gh", "pr", "ready", str(pr_number), "--repo", repo], timeout=60)
+    wait_for_check_refresh(runner, repo, pr_number, before)
+    return True
 
 
 def best_effort_issue_comment(

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -202,14 +202,55 @@ def test_dispatch_does_not_depend_on_wait_flag() -> None:
 
 
 def test_ensure_pr_ready_only_marks_drafts_ready() -> None:
-    runner = _RunnerSpy(['{"isDraft": true}', ""])
+    runner = _RunnerSpy(
+        [
+            '{"isDraft": true, "statusCheckRollup": [{"__typename": "CheckRun", "name": "merge-gate", "status": "COMPLETED", "startedAt": "2026-03-06T18:00:00Z", "completedAt": "2026-03-06T18:01:00Z"}]}',
+            "",
+            '{"statusCheckRollup": [{"__typename": "CheckRun", "name": "merge-gate", "status": "IN_PROGRESS", "startedAt": "2026-03-06T18:02:00Z", "completedAt": null}]}',
+        ]
+    )
 
-    conductor.ensure_pr_ready(runner, "misty-step/bitterblossom", 42)
+    changed = conductor.ensure_pr_ready(runner, "misty-step/bitterblossom", 42)
+
+    assert changed is True
 
     assert runner.calls == [
-        ["gh", "pr", "view", "42", "--repo", "misty-step/bitterblossom", "--json", "isDraft"],
+        ["gh", "pr", "view", "42", "--repo", "misty-step/bitterblossom", "--json", "isDraft,statusCheckRollup"],
         ["gh", "pr", "ready", "42", "--repo", "misty-step/bitterblossom"],
+        ["gh", "pr", "view", "42", "--repo", "misty-step/bitterblossom", "--json", "statusCheckRollup"],
     ]
+
+
+def test_ensure_pr_ready_skips_non_drafts() -> None:
+    runner = _RunnerSpy(['{"isDraft": false, "statusCheckRollup": []}'])
+
+    changed = conductor.ensure_pr_ready(runner, "misty-step/bitterblossom", 42)
+
+    assert changed is False
+    assert runner.calls == [
+        ["gh", "pr", "view", "42", "--repo", "misty-step/bitterblossom", "--json", "isDraft,statusCheckRollup"],
+    ]
+
+
+def test_wait_for_check_refresh_times_out_when_rollup_never_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = _RunnerSpy(
+        [
+            '{"statusCheckRollup": [{"__typename": "CheckRun", "name": "merge-gate", "status": "COMPLETED", "startedAt": "2026-03-06T18:00:00Z", "completedAt": "2026-03-06T18:01:00Z"}]}',
+            '{"statusCheckRollup": [{"__typename": "CheckRun", "name": "merge-gate", "status": "COMPLETED", "startedAt": "2026-03-06T18:00:00Z", "completedAt": "2026-03-06T18:01:00Z"}]}',
+        ]
+    )
+    ticks = iter([0.0, 30.0, 61.0])
+
+    monkeypatch.setattr(conductor.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(conductor.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(conductor.CmdError, match="timed out waiting for PR #42 checks to refresh"):
+        conductor.wait_for_check_refresh(
+            runner,
+            "misty-step/bitterblossom",
+            42,
+            (("merge-gate", "COMPLETED", "2026-03-06T18:00:00Z", "2026-03-06T18:01:00Z"),),
+        )
 
 
 def test_dispatch_until_artifact_reaps_sprite_when_artifact_arrives_first(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- wait for a refreshed status-check rollup after marking a draft PR ready
- stop the conductor from trusting stale draft-era green checks
- cover the refreshed and timeout paths in conductor tests

## Testing
- python3 -m pytest -q scripts/test_conductor.py
- ruff check scripts/conductor.py scripts/test_conductor.py
- go test ./cmd/bb/...
