### PR TITLE
docs: prefer SPRITE_TOKEN for local Bitterblossom auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ make build
 source .env.bb
 export GITHUB_TOKEN="$(gh auth token)"
 export OPENROUTER_API_KEY="..."
+```
 
+> **Local auth:** Prefer `SPRITE_TOKEN` over `FLY_API_TOKEN` when running locally. Setting `SPRITE_TOKEN` directly skips the Fly-to-Sprites token exchange and avoids the auth failures that stale Fly tokens cause. See [docs/CLI-REFERENCE.md](docs/CLI-REFERENCE.md) for details.
+
+```bash
 # 2) Bootstrap one builder + three reviewers
 ./bin/bb setup noble-blue-serpent --repo misty-step/bitterblossom
 ./bin/bb setup council-fern-20260306 --repo misty-step/bitterblossom


### PR DESCRIPTION
## Summary

Add a concise callout in the Quick Start section of the README noting that `SPRITE_TOKEN` should be preferred over `FLY_API_TOKEN` when running locally. Setting it directly skips the Fly-to-Sprites token exchange and avoids the auth failures that stale Fly tokens cause.

## Changes

- README.md: added blockquote note in Quick Start section pointing to `docs/CLI-REFERENCE.md` for full auth details

## Test plan

- [ ] README renders correctly with the blockquote callout
- [ ] Note is concise, local-auth focused, and mentions token exchange failure avoidance
- [ ] No code changes, no unrelated docs edits

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local authentication guidance in README.md recommending SPRITE_TOKEN for local development to improve reliability and prevent token staleness issues.
  * Included reference to CLI documentation and sample bootstrap commands for streamlined setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->