### PR TITLE
docs: prefer SPRITE_TOKEN over FLY_API_TOKEN for local auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ source .env.bb
 export GITHUB_TOKEN="$(gh auth token)"
 export OPENROUTER_API_KEY="..."
 
+# Local auth: prefer SPRITE_TOKEN when available — it skips the
+# FLY_API_TOKEN → Sprites token exchange that commonly fails locally.
+# export SPRITE_TOKEN="..."   # direct; no token exchange needed
+# FLY_API_TOKEN is the fallback if SPRITE_TOKEN is not set.
+
 # 2) Bootstrap one builder + three reviewers
 ./bin/bb setup noble-blue-serpent --repo misty-step/bitterblossom
 ./bin/bb setup council-fern-20260306 --repo misty-step/bitterblossom


### PR DESCRIPTION
## Summary

- Add a comment in the Quick Start env block noting that `SPRITE_TOKEN` is the preferred local auth path
- Explains that `SPRITE_TOKEN` skips the `FLY_API_TOKEN` → Sprites token exchange, which commonly fails locally
- `FLY_API_TOKEN` remains the documented fallback when `SPRITE_TOKEN` is not set

## Changes

README.md only. No code changes.

Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on local authentication configuration, specifying SPRITE_TOKEN as the preferred authentication method for local development and FLY_API_TOKEN as a fallback option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->