### PR TITLE
docs: prefer SPRITE_TOKEN for local Bitterblossom auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ source .env.bb
 export GITHUB_TOKEN="$(gh auth token)"
 export OPENROUTER_API_KEY="..."
 
-# Local auth: prefer SPRITE_TOKEN when available.
-# It authenticates directly with Sprites and avoids Fly-to-Sprites
-# token exchange failures. FLY_API_TOKEN still works but is more fragile.
+# Prefer SPRITE_TOKEN for local auth. It connects directly to Sprites,
+# avoiding token exchange failures.
+# FLY_API_TOKEN is a more fragile fallback.
 export SPRITE_TOKEN="..."  # from https://sprites.dev/settings
 
 # 2) Bootstrap one builder + three reviewers


### PR DESCRIPTION
## Summary

- Add a concise note in the Quick Start env block explaining that `SPRITE_TOKEN` is preferred over `FLY_API_TOKEN` for local auth
- Notes that `SPRITE_TOKEN` authenticates directly with Sprites and avoids Fly-to-Sprites token exchange failures
- `FLY_API_TOKEN` is noted as still functional but more fragile

## Changes

README only — no code changes.

Closes #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication setup documentation to clarify environment variable configuration options, with clear guidance on recommended and alternative settings for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->