### PR TITLE
docs: mention conductor make targets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,16 @@ GitHub Actions CI runs on pull requests and pushes to `master` with:
 - `ruff` + `pytest` for `base/hooks/`
 - `yamllint` for `compositions/`
 
-## Hook Testing
+## Python Tests and Lint
 
-Safety-critical hooks in `base/hooks/` are covered with pytest:
+Conductor operators can run the Python test suite and linter with two make targets:
 
 ```bash
-python3 -m pytest -q
+make test-python   # pytest: base/hooks + scripts/test_conductor.py
+make lint-python   # ruff: base/hooks + scripts/conductor.py + tests
 ```
+
+These cover safety-critical hooks and the conductor itself. Run both before pushing conductor changes.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Adds a **Python Tests and Lint** section to `README.md` for conductor operators
- Documents `make test-python` (pytest over hooks + conductor tests) and `make lint-python` (ruff)
- Replaces the narrower "Hook Testing" section that only showed the raw pytest invocation

## Test plan

- [ ] README renders correctly (no broken markdown)
- [ ] Both make targets mentioned match the `Makefile` definitions exactly
- [ ] No unrelated edits

Closes #464