### PR TITLE
docs: mention conductor make targets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,13 @@ GitHub Actions CI runs on pull requests and pushes to `master` with:
 - `ruff` + `pytest` for `base/hooks/`
 - `yamllint` for `compositions/`
 
-## Hook Testing
+## Python Testing (Hooks + Conductor)
 
-Safety-critical hooks in `base/hooks/` are covered with pytest:
+Safety-critical hooks in `base/hooks/` and the conductor script are covered with pytest and ruff. Use the Makefile targets:
 
 ```bash
-python3 -m pytest -q
+make test-python   # pytest: base/hooks + scripts/test_conductor.py
+make lint-python   # ruff:   base/hooks + scripts/conductor.py + tests
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Add `make test-python` and `make lint-python` to the Python testing section of the README so conductor operators know these targets exist.

## Changes

- Rename "Hook Testing" → "Python Testing (Hooks + Conductor)"
- Show `make test-python` and `make lint-python` with inline comments explaining what each runs

Closes #464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized testing documentation section title and scope to comprehensively reflect Python-based testing and code validation processes.
  * Updated testing instructions with standardized command patterns in place of direct command examples, improving documentation consistency and usability.
  * Enhanced documentation with clearer descriptions of testing and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->