### PR TITLE
feat: suppress blocked issues from backlog retry

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,53 @@
-# Issue #29 Plan
+# PLAN: Issue #478 — Prevent blocked issues from immediate retry in backlog loop
 
-## Execution
+## Problem
 
-- [x] Add PTY-flush logging path in `scripts/sprite-agent.sh` with safe fallback.
-- [x] Update Go dispatch launch script in `internal/dispatch/dispatch.go` to prefer PTY-flush logging.
-- [x] Extend output classification in `internal/agent/progress.go` for tool/file/command/error snippets.
-- [x] Improve human-readable log rendering in `cmd/bb/logs.go` for progress snippets.
-- [x] Add/adjust tests in `internal/dispatch/dispatch_test.go`, `internal/agent/progress_test.go`, `cmd/bb/logs_extra_test.go`.
-- [x] Add `--follow` to `scripts/tail-logs.sh` for live remote tails.
-- [x] Run validation (`go test ./...`, `shellcheck scripts/*.sh`) and fix regressions.
+When `run_once` exits with `rc=2` (blocked), the `finally` block calls
+`release_lease`, which frees the issue for immediate re-pick on the next poll.
+A blocked issue gets re-leased, re-run, and spams repeated blocker comments.
+
+## Root Cause
+
+`release_lease` is called unconditionally in `run_once`'s `finally` block.
+Blocked runs need their lease kept active (not released) until an operator
+explicitly re-queues the issue.
+
+## Solution
+
+Treat `blocked` as a scheduler state in the lease table:
+
+1. Add `blocked_at` column to `leases`.
+2. New `block_lease()` sets `blocked_at = now, lease_expires_at = null`.
+3. `run_once` tracks `block_on_release = True` at each `return 2` point,
+   and the `finally` calls `block_lease` instead of `release_lease`.
+4. `pick_issue` already skips issues where `released_at is null` — so blocked
+   issues (with `released_at = null`) are excluded automatically.
+5. `acquire_lease` already returns False for active leases — blocked leases
+   have `released_at = null`, `lease_expires_at = null`, so they block re-acquisition.
+6. `reap_expired_leases` skips `lease_expires_at = null` leases — no change needed.
+7. New `requeue-issue` command clears `blocked_at`, sets `released_at = now`.
+
+## Affected Files
+
+- `scripts/conductor.py`
+- `scripts/test_conductor.py`
+- `docs/CONDUCTOR.md`
+
+## Steps
+
+- [x] Plan written and verified
+- [x] Create branch `factory/478-p1-conductor-prevent-blocked-iss-1772842172`
+- [ ] `init_db`: add `ensure_column(conn, "leases", "blocked_at", "text")`
+- [ ] Add `block_lease(conn, repo, issue_number)` function
+- [ ] Modify `run_once`: track `block_on_release`, conditional finally
+- [ ] Add `requeue_issue(args)` function
+- [ ] Add `requeue-issue` subparser
+- [ ] Write tests (AC1: not re-picked, AC3: re-queue, unit tests for block_lease)
+- [ ] Update `docs/CONDUCTOR.md`
+- [ ] Run `python3 -m pytest -q scripts/test_conductor.py`
+- [ ] Push branch, open draft PR
+- [ ] Write builder artifact
 
 ## Review
 
-- Real-time path now prefers PTY-backed `script -qefc` with fallback when unavailable.
-- Progress events now emit `tool_call`, `file_edit`, `command_run`, and existing `error`.
-- Human `bb logs` output now includes progress activity/detail snippets.
-- Validation:
-  - `go test ./...`
-  - `make test`
-  - `make build`
-  - `find scripts -type f -name '*.sh' -print0 | xargs -0 shellcheck -x -S error`
-  - `python3 -m pytest -q base/hooks`
+(To be filled in after implementation)

--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -173,6 +173,42 @@ sprite exec coordinator -- bash -lc 'tail -f ~/.bb/conductor.log'
 
 Every run writes immediately to `.bb/conductor.db` and `.bb/events.jsonl` on the coordinator. State survives loop restarts. If the conductor process dies, restart it — already-completed runs won't be re-processed because their leases have been released.
 
+## Blocked Runs
+
+A run exits with `rc=2` (blocked) when the conductor cannot proceed without human input — examples:
+
+- reviewer council blocked after max revision rounds
+- an untrusted PR review thread requires maintainer review
+- PR review threads remain unresolved after a revision pass
+
+When a run is blocked the conductor **does not release the issue's lease**. Instead it marks the lease as blocked (`blocked_at` in the leases table and `lease_expires_at = null`). The blocked issue is excluded from backlog selection on all subsequent polls — it will not be re-tried automatically.
+
+### Identifying blocked issues
+
+```bash
+python3 scripts/conductor.py show-runs --limit 20
+```
+
+Blocked runs show `phase=blocked` and `status=blocked`. The associated issue also has a GitHub comment from Bitterblossom explaining why it was blocked.
+
+### Re-queuing a blocked issue
+
+After reviewing the blocking reason and making any necessary adjustments (e.g., resolving the PR thread manually, updating the issue body), re-queue the issue:
+
+```bash
+python3 scripts/conductor.py requeue-issue \
+  --repo misty-step/bitterblossom \
+  --issue-number <N>
+```
+
+This clears the blocked state and releases the lease. The issue becomes eligible on the next backlog poll.
+
+To inspect the blocked run's events before re-queuing:
+
+```bash
+python3 scripts/conductor.py show-events --run-id <run-id>
+```
+
 ## Operator Recovery
 
 ### Loop Died

--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -187,6 +187,7 @@ def init_db(conn: sqlite3.Connection) -> None:
     ensure_column(conn, "runs", "heartbeat_at", "text")
     ensure_column(conn, "leases", "heartbeat_at", "text")
     ensure_column(conn, "leases", "lease_expires_at", "text")
+    ensure_column(conn, "leases", "blocked_at", "text")
     conn.commit()
 
 
@@ -278,6 +279,19 @@ def acquire_lease(conn: sqlite3.Connection, repo: str, issue_number: int, run_id
 def release_lease(conn: sqlite3.Connection, repo: str, issue_number: int) -> None:
     conn.execute(
         "update leases set released_at = ? where repo = ? and issue_number = ? and released_at is null",
+        (now_utc(), repo, issue_number),
+    )
+    conn.commit()
+
+
+def block_lease(conn: sqlite3.Connection, repo: str, issue_number: int) -> None:
+    """Mark a lease as blocked, preventing immediate re-pick until explicitly re-queued."""
+    conn.execute(
+        """
+        update leases
+        set blocked_at = ?, lease_expires_at = null
+        where repo = ? and issue_number = ? and released_at is null
+        """,
         (now_utc(), repo, issue_number),
     )
     conn.commit()
@@ -1542,6 +1556,7 @@ def run_once(args: argparse.Namespace) -> int:
 
     create_run(conn, run_id, args.repo, issue, args.builder_profile)
     merged = False
+    block_on_release = False
     max_pr_feedback_rounds = getattr(args, "max_pr_feedback_rounds", 1)
 
     try:
@@ -1644,6 +1659,7 @@ def run_once(args: argparse.Namespace) -> int:
                         f"Bitterblossom blocked `{run_id}` after review.",
                         event_type="issue_comment_failed",
                     )
+                    block_on_release = True
                     return 2
 
                 feedback = summarize_reviews(blocks + fixes)
@@ -1703,6 +1719,7 @@ def run_once(args: argparse.Namespace) -> int:
                             f"Bitterblossom blocked `{run_id}` because an untrusted PR review thread requires manual maintainer review.",
                             event_type="issue_comment_failed",
                         )
+                        block_on_release = True
                         return 2
                     if pr_feedback_rounds > 0 and thread_ids == last_pr_feedback_thread_ids:
                         update_run(conn, run_id, phase="blocked", status="blocked")
@@ -1727,6 +1744,7 @@ def run_once(args: argparse.Namespace) -> int:
                             f"Bitterblossom blocked `{run_id}` because PR review threads remained unresolved after revision and need human confirmation.",
                             event_type="issue_comment_failed",
                         )
+                        block_on_release = True
                         return 2
                     if trusted_threads:
                         if pr_feedback_rounds >= max_pr_feedback_rounds:
@@ -1752,6 +1770,7 @@ def run_once(args: argparse.Namespace) -> int:
                                 f"Bitterblossom blocked `{run_id}` because PR review threads still require resolution.",
                                 event_type="issue_comment_failed",
                             )
+                            block_on_release = True
                             return 2
 
                         feedback = summarize_review_threads(trusted_threads)
@@ -1885,7 +1904,10 @@ def run_once(args: argparse.Namespace) -> int:
         )
         return 1
     finally:
-        release_lease(conn, args.repo, issue.number)
+        if block_on_release:
+            block_lease(conn, args.repo, issue.number)
+        else:
+            release_lease(conn, args.repo, issue.number)
 
 
 def loop(args: argparse.Namespace) -> int:
@@ -2002,6 +2024,37 @@ def reconcile_run(args: argparse.Namespace) -> int:
     return 0
 
 
+def requeue_issue(args: argparse.Namespace) -> int:
+    conn = open_db(pathlib.Path(args.db))
+    event_log = pathlib.Path(args.event_log)
+    row = conn.execute(
+        """
+        select run_id from leases
+        where repo = ? and issue_number = ? and blocked_at is not null and released_at is null
+        """,
+        (args.repo, args.issue_number),
+    ).fetchone()
+    if row is None:
+        print(
+            f"issue #{args.issue_number} in {args.repo} is not currently blocked",
+            file=sys.stderr,
+        )
+        return 1
+    run_id = row["run_id"]
+    conn.execute(
+        """
+        update leases
+        set blocked_at = null, released_at = ?
+        where repo = ? and issue_number = ? and blocked_at is not null
+        """,
+        (now_utc(), args.repo, args.issue_number),
+    )
+    conn.commit()
+    record_event(conn, event_log, run_id, "requeued", {"issue_number": args.issue_number, "repo": args.repo})
+    print(f"issue #{args.issue_number} re-queued: eligible for new run on next backlog poll")
+    return 0
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Bitterblossom conductor MVP")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -2051,6 +2104,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     reconcile_p.add_argument("--event-log", default=str(DEFAULT_EVENT_LOG))
     reconcile_p.add_argument("--run-id", required=True)
     reconcile_p.set_defaults(func=reconcile_run)
+
+    requeue_p = sub.add_parser("requeue-issue", help="Re-queue a blocked issue for retry")
+    requeue_p.add_argument("--repo", required=True)
+    requeue_p.add_argument("--issue-number", type=int, required=True)
+    requeue_p.add_argument("--db", default=str(DEFAULT_DB))
+    requeue_p.add_argument("--event-log", default=str(DEFAULT_EVENT_LOG))
+    requeue_p.set_defaults(func=requeue_issue)
 
     check_p = sub.add_parser("check-env", help="Validate coordinator runtime environment and tools")
     check_p.set_defaults(func=check_env)

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -1447,3 +1447,176 @@ def test_main_prints_clean_error_on_missing_env(monkeypatch: pytest.MonkeyPatch,
     err = capsys.readouterr().err
     assert "error:" in err
     assert "GITHUB_TOKEN" in err
+
+
+# --- Blocked issue suppression tests (issue #478) ---
+
+
+def test_block_lease_prevents_acquire(tmp_path: pathlib.Path) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-1") is True
+
+    conductor.block_lease(conn, "misty-step/bitterblossom", 42)
+
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-2") is False
+
+
+def test_block_lease_prevents_pick_issue(tmp_path: pathlib.Path) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-1") is True
+    conductor.block_lease(conn, "misty-step/bitterblossom", 42)
+
+    issues = [
+        conductor.Issue(number=42, title="blocked", body="", url="u42", labels=["autopilot"], updated_at="2026-03-06T00:00:00Z"),
+    ]
+
+    picked = conductor.pick_issue(conn, issues, "misty-step/bitterblossom")
+    assert picked is None
+
+
+def test_block_lease_not_reaped_as_expired(tmp_path: pathlib.Path) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-1") is True
+    conductor.block_lease(conn, "misty-step/bitterblossom", 42)
+
+    # Reaping should not touch blocked leases (lease_expires_at is null)
+    reaped = conductor.reap_expired_leases(conn)
+    assert reaped == 0
+
+    # Still blocked
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-2") is False
+
+
+def test_requeue_issue_makes_blocked_issue_eligible(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    issue = conductor.Issue(number=42, title="test", body="", url="u42", labels=["autopilot"], updated_at="2026-03-06T00:00:00Z")
+
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", 42, "run-42-1") is True
+    conductor.create_run(conn, "run-42-1", "misty-step/bitterblossom", issue, "default")
+    conductor.block_lease(conn, "misty-step/bitterblossom", 42)
+
+    # Blocked: should not be pickable
+    assert conductor.pick_issue(conn, [issue], "misty-step/bitterblossom") is None
+
+    args = argparse.Namespace(
+        repo="misty-step/bitterblossom",
+        issue_number=42,
+        db=str(tmp_path / "conductor.db"),
+        event_log=str(tmp_path / "events.jsonl"),
+    )
+    rc = conductor.requeue_issue(args)
+
+    assert rc == 0
+    assert "re-queued" in capsys.readouterr().out
+
+    # Now issue is eligible again
+    picked = conductor.pick_issue(conn, [issue], "misty-step/bitterblossom")
+    assert picked is not None
+    assert picked.number == 42
+
+    # And the event was recorded
+    event_rows = conn.execute(
+        "select event_type from events where run_id = 'run-42-1' order by id"
+    ).fetchall()
+    assert any(row["event_type"] == "requeued" for row in event_rows)
+
+
+def test_requeue_issue_fails_when_not_blocked(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")  # noqa: F841
+
+    args = argparse.Namespace(
+        repo="misty-step/bitterblossom",
+        issue_number=99,
+        db=str(tmp_path / "conductor.db"),
+        event_log=str(tmp_path / "events.jsonl"),
+    )
+    rc = conductor.requeue_issue(args)
+
+    assert rc == 1
+    assert "not currently blocked" in capsys.readouterr().err
+
+
+def _make_run_once_args(tmp_path: pathlib.Path, *, issue_number: int = 447) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo="misty-step/bitterblossom",
+        issue=issue_number,
+        label="autopilot",
+        limit=20,
+        db=str(tmp_path / "conductor.db"),
+        event_log=str(tmp_path / "events.jsonl"),
+        builder_profile="default",
+        worker=["noble-blue-serpent"],
+        builder_template=str(pathlib.Path("scripts/prompts/conductor-builder-template.md")),
+        reviewer=["fern", "sage", "thorn"],
+        reviewer_template=str(pathlib.Path("scripts/prompts/conductor-reviewer-template.md")),
+        builder_timeout=10,
+        review_timeout=10,
+        ci_timeout=10,
+        review_quorum=2,
+        max_revision_rounds=1,
+        max_ci_rounds=1,
+        max_pr_feedback_rounds=1,
+    )
+
+
+def test_run_once_blocks_issue_so_next_poll_cannot_re_lease(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    """AC1: Given rc=2, the same issue must not be immediately re-leaseable."""
+    issue = conductor.Issue(number=447, title="test", body="body", url="https://example.com/447", labels=["autopilot"])
+    builder = conductor.BuilderResult(
+        status="ready_for_review",
+        branch="factory/447-test-123",
+        pr_number=448,
+        pr_url="https://github.com/misty-step/bitterblossom/pull/448",
+        summary="done",
+        tests=[],
+    )
+    # All reviewers block: triggers council_blocked path after max_revision_rounds
+    reviews_all_block = [
+        conductor.ReviewResult(reviewer="fern", verdict="block", summary="no", findings=[]),
+        conductor.ReviewResult(reviewer="sage", verdict="block", summary="no", findings=[]),
+        conductor.ReviewResult(reviewer="thorn", verdict="block", summary="no", findings=[]),
+    ]
+
+    monkeypatch.setattr(conductor, "get_issue", lambda *_a, **_kw: issue)
+    monkeypatch.setattr(conductor, "select_worker", lambda *_a, **_kw: "noble-blue-serpent")
+    monkeypatch.setattr(conductor, "run_builder", lambda *_a, **_kw: (builder, {"status": "ready_for_review"}))
+    monkeypatch.setattr(conductor, "run_review_round", lambda *_a, **_kw: reviews_all_block)
+    monkeypatch.setattr(conductor, "comment_pr", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "comment_issue", lambda *_a, **_kw: None)
+
+    args = _make_run_once_args(tmp_path)
+    rc = conductor.run_once(args)
+
+    assert rc == 2
+
+    # Next poll: same issue must not be pickable
+    conn = conductor.open_db(pathlib.Path(args.db))
+    picked = conductor.pick_issue(conn, [issue], args.repo)
+    assert picked is None, "blocked issue must not be re-picked on next backlog poll"
+
+    # Explicit re-lease also fails
+    assert conductor.acquire_lease(conn, args.repo, issue.number, "run-447-new") is False
+
+
+def test_run_once_normal_failure_does_release_lease(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    """rc=1 (failure) must still release the lease so it can be retried."""
+    issue = conductor.Issue(number=447, title="test", body="body", url="https://example.com/447", labels=["autopilot"])
+
+    monkeypatch.setattr(conductor, "get_issue", lambda *_a, **_kw: issue)
+    monkeypatch.setattr(conductor, "comment_issue", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "select_worker", lambda *_a, **_kw: (_ for _ in ()).throw(conductor.CmdError("worker gone")))
+
+    args = _make_run_once_args(tmp_path)
+    rc = conductor.run_once(args)
+
+    assert rc == 1
+
+    # Lease must be released so the issue can be retried
+    conn = conductor.open_db(pathlib.Path(args.db))
+    lease = conn.execute(
+        "select released_at, blocked_at from leases where repo = ? and issue_number = ?",
+        (args.repo, issue.number),
+    ).fetchone()
+    assert lease is not None
+    assert lease["released_at"] is not None
+    assert lease["blocked_at"] is None


### PR DESCRIPTION
## Summary

- `run_once` now calls `block_lease` instead of `release_lease` when exiting with `rc=2` (blocked). The lease stays active (`released_at = null`) with `blocked_at` set and `lease_expires_at` cleared.
- `pick_issue` and `acquire_lease` already skip active leases — no picker logic changes needed.
- `reap_expired_leases` already skips null `lease_expires_at` — blocked leases never expire silently.
- New `requeue-issue` subcommand clears the blocked state and releases the lease, restoring eligibility on the next backlog poll.
- 7 new tests covering the three acceptance criteria.
- `docs/CONDUCTOR.md` documents blocked-run behaviour and the operator recovery path.

## Test plan

- [ ] `python3 -m pytest -q scripts/test_conductor.py` — 59 tests, all pass
- [ ] `test_run_once_blocks_issue_so_next_poll_cannot_re_lease` exercises AC1 end-to-end
- [ ] `test_requeue_issue_makes_blocked_issue_eligible` exercises AC3 end-to-end
- [ ] `test_block_lease_not_reaped_as_expired` confirms blocked leases are durable

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blocked run state to prevent automatic re-picking of certain failed runs.
  * Added requeue command to manually re-enable blocked issues for processing.

* **Documentation**
  * Added comprehensive guide to blocked runs, including identification, management, and re-queuing workflows with examples.

* **Tests**
  * Added test coverage for blocked run behavior, state transitions, and requeue functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->