### PR TITLE
feat: withhold merge while trusted external review surfaces are pending

### DIFF
--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -75,6 +75,10 @@ python3 scripts/conductor.py run-once \
   --reviewer council-thorn-20260306
 ```
 
+`--trusted-external-surface` is exact, not substring-based. Use exact status
+context names such as `CodeRabbit` / `Greptile Review`, or an exact workflow
+name such as `Cerberus` when you want to wait on a whole check-run family.
+
 Run continuously against the backlog:
 
 ```bash

--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -622,8 +622,7 @@ def ensure_reviewers_ready(runner: Runner, repo: str, reviewers: list[str], prom
         ensure_sprite_ready(runner, reviewer, repo, prompt_template)
 
 
-def select_worker(runner: Runner, repo: str, workers: list[str], prompt_template: pathlib.Path) -> str:
-    _ = runner
+def select_worker(repo: str, workers: list[str], prompt_template: pathlib.Path) -> str:
     last_error = ""
     for worker in workers:
         try:
@@ -840,6 +839,12 @@ def rollup_item_name(item: dict[str, Any]) -> str:
     return ""
 
 
+def rollup_item_workflow_name(item: dict[str, Any]) -> str:
+    if str(item.get("__typename", "")) != "CheckRun":
+        return ""
+    return str(item.get("workflowName", ""))
+
+
 def rollup_item_state(item: dict[str, Any]) -> tuple[str, bool, bool]:
     typename = str(item.get("__typename", ""))
     if typename == "CheckRun":
@@ -860,6 +865,15 @@ def rollup_item_state(item: dict[str, Any]) -> tuple[str, bool, bool]:
         return state or "PENDING", False, False
 
     return "", False, False
+
+
+def trusted_surface_matches(item: dict[str, Any], trusted_surface: str) -> bool:
+    names = {rollup_item_name(item)}
+    workflow_name = rollup_item_workflow_name(item)
+    if workflow_name:
+        names.add(workflow_name)
+    names.discard("")
+    return trusted_surface in names
 
 
 def summarize_status_check_rollup(payload: dict[str, Any]) -> str:
@@ -1148,6 +1162,10 @@ def ensure_required_checks_present(runner: Runner, repo: str, pr_number: int) ->
         )
 
 
+SurfaceMatchSnapshot = tuple[str, str, str, str, str]
+TrustedSurfaceSnapshot = tuple[tuple[str, tuple[SurfaceMatchSnapshot, ...]], ...]
+
+
 def trusted_surfaces_pending(payload: dict[str, Any], trusted_surfaces: list[str]) -> list[str]:
     """Return trusted surfaces that still block merge.
 
@@ -1164,10 +1182,10 @@ def trusted_surfaces_pending(payload: dict[str, Any], trusted_surfaces: list[str
         for item in rollup:
             if not isinstance(item, dict):
                 continue
-            name = rollup_item_name(item)
-            if not name or pattern not in name:
+            if not trusted_surface_matches(item, pattern):
                 continue
             matched = True
+            name = rollup_item_name(item)
             _state, terminal, failed = rollup_item_state(item)
             if not terminal or failed:
                 blocking.append(name)
@@ -1176,29 +1194,30 @@ def trusted_surfaces_pending(payload: dict[str, Any], trusted_surfaces: list[str
     return blocking
 
 
-def trusted_surface_snapshot(payload: dict[str, Any], trusted_surfaces: list[str]) -> tuple[tuple[str, tuple[tuple[str, str, str, str], ...]], ...]:
+def trusted_surface_snapshot(payload: dict[str, Any], trusted_surfaces: list[str]) -> TrustedSurfaceSnapshot:
     """Capture the observed state of all watched trusted surfaces.
 
-    The snapshot is keyed by configured pattern so unseen surfaces are represented
+    The snapshot is keyed by configured trusted surface so unseen surfaces are represented
     explicitly instead of disappearing from the comparison set.
     """
     rollup = payload.get("statusCheckRollup", [])
     if not isinstance(rollup, list):
         return tuple((pattern, ()) for pattern in trusted_surfaces)
 
-    snapshots: list[tuple[str, tuple[tuple[str, str, str, str], ...]]] = []
+    snapshots: list[tuple[str, tuple[SurfaceMatchSnapshot, ...]]] = []
     for pattern in trusted_surfaces:
-        matches: list[tuple[str, str, str, str]] = []
+        matches: list[SurfaceMatchSnapshot] = []
         for item in rollup:
             if not isinstance(item, dict):
                 continue
-            name = rollup_item_name(item)
-            if not name or pattern not in name:
+            if not trusted_surface_matches(item, pattern):
                 continue
+            name = rollup_item_name(item)
+            workflow_name = rollup_item_workflow_name(item)
             state, _terminal, _failed = rollup_item_state(item)
             started = str(item.get("startedAt") or "")
             completed = str(item.get("completedAt") or "")
-            matches.append((name, state, started, completed))
+            matches.append((name, workflow_name, state, started, completed))
         snapshots.append((pattern, tuple(sorted(matches))))
     return tuple(snapshots)
 
@@ -1225,7 +1244,7 @@ def wait_for_external_reviews(
     deadline = time.time() + timeout_minutes * 60
     quiet_since: float | None = None
     last_payload: dict[str, Any] = {}
-    last_snapshot: tuple[tuple[str, tuple[tuple[str, str, str, str], ...]], ...] | None = None
+    last_snapshot: TrustedSurfaceSnapshot | None = None
 
     while time.time() < deadline:
         try:
@@ -1871,7 +1890,7 @@ def run_once(args: argparse.Namespace) -> int:
         )
         ensure_reviewers_ready(runner, args.repo, args.reviewer, pathlib.Path(args.reviewer_template))
         record_event(conn, event_log, run_id, "reviewers_ready", {"reviewers": args.reviewer})
-        worker = select_worker(runner, args.repo, args.worker, pathlib.Path(args.builder_template))
+        worker = select_worker(args.repo, args.worker, pathlib.Path(args.builder_template))
         update_run(conn, run_id, phase="building", builder_sprite=worker)
         touch_run(conn, args.repo, issue.number, run_id, args.builder_timeout * 60 + DEFAULT_LEASE_BUFFER_SECONDS)
         record_event(conn, event_log, run_id, "builder_selected", {"sprite": worker})
@@ -2035,10 +2054,10 @@ def run_once(args: argparse.Namespace) -> int:
                     pr_feedback_rounds += 1
                     continue
 
-                trusted_surfaces = getattr(args, "trusted_external_surfaces", [])
+                trusted_surfaces = args.trusted_external_surfaces
                 if trusted_surfaces:
-                    external_review_timeout = getattr(args, "external_review_timeout", 30)
-                    external_review_quiet_window = getattr(args, "external_review_quiet_window", 60)
+                    external_review_timeout = args.external_review_timeout
+                    external_review_quiet_window = args.external_review_quiet_window
                     touch_run(
                         conn,
                         args.repo,
@@ -2388,7 +2407,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             dest="trusted_external_surfaces",
             action="append",
             default=[],
-            help="Name substring of a trusted external review surface to wait for before merge (repeatable)",
+            help="Exact trusted surface name or exact workflow name to wait for before merge (repeatable)",
         )
         p.add_argument(
             "--external-review-quiet-window",

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -763,7 +763,6 @@ def test_select_worker_skips_failed_probes_without_auto_repair(monkeypatch: pyte
     monkeypatch.setattr(conductor, "probe_sprite_readiness", fake_probe)
 
     selected = conductor.select_worker(
-        _RunnerSpy(),
         "misty-step/bitterblossom",
         ["thorn", "sage"],
         pathlib.Path("scripts/prompts/conductor-builder-template.md"),
@@ -1117,6 +1116,10 @@ def test_run_once_releases_lease_on_failure_after_comment_error(monkeypatch: pyt
         review_quorum=2,
         max_revision_rounds=1,
         max_ci_rounds=1,
+        max_pr_feedback_rounds=1,
+        trusted_external_surfaces=[],
+        external_review_quiet_window=0,
+        external_review_timeout=30,
     )
 
     rc = conductor.run_once(args)
@@ -1178,6 +1181,10 @@ def test_run_once_keeps_merged_truth_when_issue_comment_fails(monkeypatch: pytes
         review_quorum=2,
         max_revision_rounds=1,
         max_ci_rounds=1,
+        max_pr_feedback_rounds=1,
+        trusted_external_surfaces=[],
+        external_review_quiet_window=0,
+        external_review_timeout=30,
     )
 
     rc = conductor.run_once(args)
@@ -1253,6 +1260,9 @@ def test_run_once_routes_unresolved_pr_threads_back_to_builder(monkeypatch: pyte
         max_revision_rounds=1,
         max_ci_rounds=1,
         max_pr_feedback_rounds=1,
+        trusted_external_surfaces=[],
+        external_review_quiet_window=0,
+        external_review_timeout=30,
     )
 
     rc = conductor.run_once(args)
@@ -1324,6 +1334,9 @@ def test_run_once_blocks_when_stale_pr_threads_persist_after_revision(monkeypatc
         max_revision_rounds=1,
         max_ci_rounds=1,
         max_pr_feedback_rounds=1,
+        trusted_external_surfaces=[],
+        external_review_quiet_window=0,
+        external_review_timeout=30,
     )
 
     rc = conductor.run_once(args)
@@ -1390,6 +1403,9 @@ def test_run_once_blocks_on_untrusted_pr_thread(monkeypatch: pytest.MonkeyPatch,
         max_revision_rounds=1,
         max_ci_rounds=1,
         max_pr_feedback_rounds=1,
+        trusted_external_surfaces=[],
+        external_review_quiet_window=0,
+        external_review_timeout=30,
     )
 
     rc = conductor.run_once(args)
@@ -1804,6 +1820,7 @@ def _pr483_rollup() -> list[dict[str, Any]]:
         {
             "__typename": "CheckRun",
             "name": "review / Cerberus · wave1 · Correctness",
+            "workflowName": "Cerberus",
             "status": "IN_PROGRESS",
             "startedAt": "2026-03-07T00:18:00Z",
             "completedAt": None,
@@ -1811,6 +1828,7 @@ def _pr483_rollup() -> list[dict[str, Any]]:
         {
             "__typename": "CheckRun",
             "name": "review / Cerberus · wave1 · Security",
+            "workflowName": "Cerberus",
             "status": "IN_PROGRESS",
             "startedAt": "2026-03-07T00:18:00Z",
             "completedAt": None,
@@ -1818,6 +1836,7 @@ def _pr483_rollup() -> list[dict[str, Any]]:
         {
             "__typename": "CheckRun",
             "name": "review / Cerberus · wave1 · Testing",
+            "workflowName": "Cerberus",
             "status": "IN_PROGRESS",
             "startedAt": "2026-03-07T00:18:00Z",
             "completedAt": None,
@@ -1838,7 +1857,7 @@ def test_trusted_surfaces_pending_identifies_non_terminal_states() -> None:
     payload = {"statusCheckRollup": _pr483_rollup()}
     pending = conductor.trusted_surfaces_pending(
         payload,
-        ["Greptile Review", "CodeRabbit", "review / Cerberus"],
+        ["Greptile Review", "CodeRabbit", "Cerberus"],
     )
     assert set(pending) == {
         "Greptile Review",
@@ -1855,6 +1874,23 @@ def test_trusted_surfaces_pending_ignores_unconfigured_surfaces() -> None:
     # merge-gate is SUCCESS and not in the list — should not appear
     pending = conductor.trusted_surfaces_pending(payload, ["Greptile Review"])
     assert pending == ["Greptile Review"]
+
+
+def test_trusted_surfaces_pending_requires_exact_surface_identity() -> None:
+    payload = {
+        "statusCheckRollup": [
+            {
+                "__typename": "StatusContext",
+                "context": "CodeRabbit Copycat",
+                "state": "SUCCESS",
+                "startedAt": "2026-03-07T00:20:00Z",
+            }
+        ]
+    }
+
+    pending = conductor.trusted_surfaces_pending(payload, ["CodeRabbit"])
+
+    assert pending == ["CodeRabbit"]
 
 
 def test_trusted_surfaces_pending_empty_when_all_settled() -> None:
@@ -1890,6 +1926,25 @@ def test_trusted_surfaces_pending_blocks_failed_trusted_surface() -> None:
     assert pending == ["Greptile Review"]
 
 
+def test_trusted_surface_snapshot_tracks_exact_workflow_matches() -> None:
+    snapshot = conductor.trusted_surface_snapshot(
+        {"statusCheckRollup": _pr483_rollup()},
+        ["CodeRabbit", "Cerberus"],
+    )
+
+    assert snapshot == (
+        ("CodeRabbit", (("CodeRabbit", "", "PENDING", "2026-03-07T00:18:00Z", ""),)),
+        (
+            "Cerberus",
+            (
+                ("review / Cerberus · wave1 · Correctness", "Cerberus", "IN_PROGRESS", "2026-03-07T00:18:00Z", ""),
+                ("review / Cerberus · wave1 · Security", "Cerberus", "IN_PROGRESS", "2026-03-07T00:18:00Z", ""),
+                ("review / Cerberus · wave1 · Testing", "Cerberus", "IN_PROGRESS", "2026-03-07T00:18:00Z", ""),
+            ),
+        ),
+    )
+
+
 def test_wait_for_external_reviews_passes_immediately_when_no_surfaces() -> None:
     ok, summary = conductor.wait_for_external_reviews(
         _RunnerSpy(), "misty-step/bitterblossom", 42, [], quiet_window_seconds=60, timeout_minutes=1
@@ -1915,7 +1970,7 @@ def test_wait_for_external_reviews_times_out_when_surfaces_stay_pending(monkeypa
         _RunnerSpy(),
         "misty-step/bitterblossom",
         483,
-        ["Greptile Review", "CodeRabbit", "review / Cerberus"],
+        ["Greptile Review", "CodeRabbit", "Cerberus"],
         quiet_window_seconds=10,
         timeout_minutes=1,
     )
@@ -2006,11 +2061,17 @@ def test_wait_for_external_reviews_resets_quiet_window_when_surface_changes(monk
             {"statusCheckRollup": settled_v2},
         ]
     )
-    ticks = iter([0.0, 0.0, 10.0, 70.0, 75.0, 136.0])
+    gh_calls: list[str] = []
+    ticks = iter([0.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 41.0, 100.0, 100.0, 100.0])
 
     monkeypatch.setattr(conductor.time, "time", lambda: next(ticks))
     monkeypatch.setattr(conductor.time, "sleep", lambda _s: None)
-    monkeypatch.setattr(conductor, "gh_json", lambda *_args, **_kwargs: next(gh_responses))
+
+    def fake_gh_json(*_args: object, **_kwargs: object) -> dict[str, object]:
+        gh_calls.append("poll")
+        return next(gh_responses)
+
+    monkeypatch.setattr(conductor, "gh_json", fake_gh_json)
 
     ok, summary = conductor.wait_for_external_reviews(
         _RunnerSpy(),
@@ -2023,6 +2084,7 @@ def test_wait_for_external_reviews_resets_quiet_window_when_surface_changes(monk
 
     assert ok is True
     assert "CodeRabbit" in summary
+    assert gh_calls == ["poll", "poll", "poll", "poll"]
 
 
 def test_wait_for_external_reviews_caps_sleep_at_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2103,7 +2165,7 @@ def test_run_once_withholds_merge_while_trusted_surfaces_pending(
     args = _make_run_once_args(
         tmp_path,
         issue_number=483,
-        trusted_external_surfaces=["Greptile Review", "CodeRabbit", "review / Cerberus"],
+        trusted_external_surfaces=["Greptile Review", "CodeRabbit", "Cerberus"],
         external_review_quiet_window=60,
         external_review_timeout=1,
     )


### PR DESCRIPTION
Closes #484.

## Problem

Run `run-478-1772842172` merged PR #483 while Greptile Review, CodeRabbit, and Cerberus checks were still unsettled. The conductor moved from council-pass + CI-green directly to merge without waiting for trusted external governance to actually finish.

## What Changed

```mermaid
flowchart TD
    CI[Internal council + CI green] --> Gate[PR thread gate]
    Gate --> External[Wait for trusted external surfaces]
    External --> Quiet[Quiet window on stable snapshot]
    Quiet --> Recheck[Re-check PR review threads]
    Recheck --> Merge[Squash merge]
    External --> Block[Block run rc=2]
    Recheck --> Revise[Builder revision]
```

## Solution

Adds a configurable trusted-surface guard in the conductor merge path. Before final merge, if `--trusted-external-surface` values are configured, the conductor calls `wait_for_external_reviews`, which now:

1. Matches trusted surfaces by exact status-context name or exact workflow name, not substring.
2. Blocks until every configured trusted surface is actually observed.
3. Treats pending or failed trusted surfaces as blocking.
4. Restarts the quiet window whenever any watched trusted-surface snapshot changes.
5. Re-runs the PR-thread gate after trusted surfaces settle.
6. Blocks the run (`rc=2`) instead of merging if trusted governance does not settle in time.

## New helpers / refinements

- `trusted_surface_matches(...)` — exact trusted-surface identity matching.
- `trusted_surfaces_pending(...)` — fail-closes on unseen, pending, or failed trusted surfaces.
- `trusted_surface_snapshot(...)` — canonical watched-surface snapshot for quiet-window resets.
- `wait_for_external_reviews(...)` — polling loop with quiet-window enforcement and deadline-aware sleeping.
- `handle_pr_review_threads(...)` — shared PR-thread gate used before and after external-review settlement.
- `select_worker(...)` — polished to reflect its real dependency surface after the reviewer auto-heal split.

## New CLI args (run-once / loop)

| Flag | Default | Description |
|------|---------|-------------|
| `--trusted-external-surface` | `[]` | Exact trusted surface name or exact workflow name (repeatable) |
| `--external-review-quiet-window` | `60` | Seconds of silence after trusted surfaces settle |
| `--external-review-timeout` | `30` | Minutes before blocking if trusted surfaces do not settle |

Example:
```bash
scripts/conductor.py run-once \
  --trusted-external-surface "Greptile Review" \
  --trusted-external-surface "CodeRabbit" \
  --trusted-external-surface "Cerberus" \
  ...
```

## Tests

Focused coverage now includes:

- unseen configured surfaces
- failed trusted surfaces
- exact-match protection against lookalike surface names
- trusted workflow-family snapshots (`Cerberus`)
- quiet-window reset on watched-surface changes
- timeout and fetch-failure paths
- re-checking PR review threads after external reviews settle
- the original `#483` regression and the normal merge path

## Before / After

Before: the conductor could merge after internal council + CI even if trusted external review surfaces had not appeared yet, were still pending, or changed during the quiet window. The matching contract also relied on substring heuristics, which made the trusted-surface identity too loose.

After: the conductor waits on exact trusted identities, restarts the quiet window on any trusted-surface change, re-checks PR threads before merge, and blocks the run instead of merging when trusted governance has not actually settled. The polish pass also removed dead arg fallbacks, removed the unused `select_worker` runner dependency, and added direct helper regression coverage.

## Merge Confidence

### Evidence

- `python3 -m pytest -q scripts/test_conductor.py`
- `ruff check scripts/conductor.py scripts/test_conductor.py`
- `go test ./cmd/bb/...`
- Direct regression coverage for PR #483 timeline
- Direct exact-match coverage for trusted-surface identity
- Direct snapshot coverage for workflow-family matching and quiet-window reset behavior

### Gaps

- Live end-to-end replay against a fresh conductor run is not part of this PR-scoped verification.
- Trusted status contexts without a stronger upstream identity field still rely on exact GitHub context names.

### Risk

- The main residual risk is future provider identity drift on external status contexts. This change removes substring collisions and narrows the trust boundary, but it still depends on GitHub exposing stable names/workflow names for the configured review surfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-dispatch readiness probing for builders and reviewers; unhealthy workers are now skipped.
  * Auto-repair mechanism for reviewers with re-probing; runs fail fast if reviewer pool cannot be dispatch-ready.
  * Added external trusted review surface waiting with configurable timeout and quiet window to delay merge until external checks settle.
  * New CLI options: `--trusted-external-surface`, `--external-review-quiet-window`, `--external-review-timeout`.

* **Documentation**
  * Clarified that `--trusted-external-surface` matching is exact (not substring-based); recommend using exact status context or workflow names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->