### PR TITLE
refactor: centralize conductor builder turns

### DIFF
--- a/docs/walkthroughs/builder-turn-handoff.md
+++ b/docs/walkthroughs/builder-turn-handoff.md
@@ -1,0 +1,70 @@
+# Builder Turn Handoff Walkthrough
+
+## Claim
+
+This refactor makes "successful builder turn" a real conductor boundary instead of a repeated call-site ritual.
+
+## Renderer
+
+- Diagram-led walkthrough with terminal verification
+
+## Why Now
+
+The governor loop is the most change-prone part of the control plane. Before this branch, every place that reran the builder also had to remember the same handoff bookkeeping. That was cheap to copy once and expensive to keep correct forever.
+
+## Before
+
+```mermaid
+flowchart TD
+    A["review / CI / thread / polish branch"] --> B["run_builder(...)"]
+    B --> C["update_run(... phase=awaiting_governance ...)"]
+    C --> D["record_event(... builder_* ...)"]
+    D --> E["continue governor loop"]
+```
+
+The same sequence appeared in multiple branches inside `govern_pr_flow(...)` plus the initial handoff in `run_once(...)`.
+
+## After
+
+```mermaid
+flowchart TD
+    A["review / CI / thread / polish branch"] --> B["run_builder_turn(...)"]
+    B --> C["validated builder result"]
+    C --> D["continue governor loop"]
+```
+
+## State Invariant
+
+```mermaid
+stateDiagram-v2
+    [*] --> revising
+    revising --> "run_builder_turn(...)"
+    "run_builder_turn(...)" --> awaiting_governance
+    awaiting_governance --> governing
+```
+
+Successful builder work now publishes one invariant in one place:
+
+- refresh branch / PR metadata on the run row
+- restore `phase="awaiting_governance"`
+- emit the matching builder event
+
+## Evidence Mapping
+
+- Boundary implementation:
+  `scripts/conductor.py`
+- Governor call-site simplification:
+  `scripts/conductor.py`
+- Regression proof:
+  `scripts/test_conductor.py::test_run_builder_turn_records_governance_handoff`
+
+## Verification
+
+```bash
+pytest -q scripts/test_conductor.py
+pytest -q scripts/test_conductor.py -k 'run_once or govern_pr'
+```
+
+## Residual Risk
+
+This branch centralizes successful handoff behavior only. Error handling and broader conductor modularization are still separate follow-up candidates.

--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -2916,6 +2916,53 @@ def run_builder(
     return builder, payload
 
 
+def run_builder_turn(
+    runner: Runner,
+    conn: sqlite3.Connection,
+    event_log: pathlib.Path,
+    repo: str,
+    worker: str,
+    issue: Issue,
+    run_id: str,
+    branch: str,
+    prompt_template: pathlib.Path,
+    timeout_minutes: int,
+    *,
+    workspace: str,
+    event_type: str,
+    feedback: str | None = None,
+    pr_number: int | None = None,
+    pr_url: str | None = None,
+    feedback_source: str = "review",
+) -> BuilderResult:
+    """Run one builder turn and publish the validated handoff to governance."""
+    builder, payload = run_builder(
+        runner,
+        repo,
+        worker,
+        issue,
+        run_id,
+        branch,
+        prompt_template,
+        timeout_minutes,
+        workspace=workspace,
+        feedback=feedback,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        feedback_source=feedback_source,
+    )
+    update_run(
+        conn,
+        run_id,
+        phase="awaiting_governance",
+        branch=builder.branch,
+        pr_number=builder.pr_number,
+        pr_url=builder.pr_url,
+    )
+    record_event(conn, event_log, run_id, event_type, payload)
+    return builder
+
+
 def run_review_round(
     runner: Runner,
     conn: sqlite3.Connection,
@@ -3191,6 +3238,7 @@ def govern_pr_flow(
     pr_url: str,
     builder_workspace: str,
 ) -> int:
+    builder_template = pathlib.Path(args.builder_template)
     builder = BuilderResult(
         status="ready_for_review",
         branch=branch,
@@ -3314,23 +3362,24 @@ def govern_pr_flow(
             feedback = summarize_reviews(blocks + fixes)
             update_run(conn, run_id, phase="revising")
             record_event(conn, event_log, run_id, "revision_requested", {"feedback": feedback, "reason": "review"})
-            builder, builder_payload = run_builder(
+            builder = run_builder_turn(
                 runner,
+                conn,
+                event_log,
                 args.repo,
                 worker,
                 issue,
                 run_id,
                 branch,
-                pathlib.Path(args.builder_template),
+                builder_template,
                 args.builder_timeout,
                 workspace=builder_workspace,
+                event_type="builder_revised",
                 feedback=feedback,
                 feedback_source="review",
                 pr_number=builder.pr_number,
                 pr_url=builder.pr_url,
             )
-            update_run(conn, run_id, phase="awaiting_governance", branch=builder.branch, pr_number=builder.pr_number, pr_url=builder.pr_url)
-            record_event(conn, event_log, run_id, "builder_revised", builder_payload)
             review_rounds += 1
             last_pr_feedback_thread_ids = ()
             continue
@@ -3370,23 +3419,24 @@ def govern_pr_flow(
             feedback = f"CI checks failed for PR #{builder.pr_number}:\n{checks_output}"
             update_run(conn, run_id, phase="revising")
             record_event(conn, event_log, run_id, "revision_requested", {"feedback": feedback, "reason": "ci"})
-            builder, builder_payload = run_builder(
+            builder = run_builder_turn(
                 runner,
+                conn,
+                event_log,
                 args.repo,
                 worker,
                 issue,
                 run_id,
                 branch,
-                pathlib.Path(args.builder_template),
+                builder_template,
                 args.builder_timeout,
                 workspace=builder_workspace,
+                event_type="builder_revised",
                 feedback=feedback,
                 feedback_source="ci",
                 pr_number=builder.pr_number,
                 pr_url=builder.pr_url,
             )
-            update_run(conn, run_id, phase="awaiting_governance", branch=builder.branch, pr_number=builder.pr_number, pr_url=builder.pr_url)
-            record_event(conn, event_log, run_id, "builder_revised", builder_payload)
             ci_rounds += 1
             last_pr_feedback_thread_ids = ()
             continue
@@ -3410,23 +3460,24 @@ def govern_pr_flow(
             return 2
         if thread_action == "revise" and feedback is not None:
             last_pr_feedback_thread_ids = thread_ids
-            builder, builder_payload = run_builder(
+            builder = run_builder_turn(
                 runner,
+                conn,
+                event_log,
                 args.repo,
                 worker,
                 issue,
                 run_id,
                 branch,
-                pathlib.Path(args.builder_template),
+                builder_template,
                 args.builder_timeout,
                 workspace=builder_workspace,
+                event_type="builder_revised",
                 feedback=feedback,
                 feedback_source="pr_review_threads",
                 pr_number=builder.pr_number,
                 pr_url=builder.pr_url,
             )
-            update_run(conn, run_id, phase="awaiting_governance", branch=builder.branch, pr_number=builder.pr_number, pr_url=builder.pr_url)
-            record_event(conn, event_log, run_id, "builder_revised", builder_payload)
             pr_feedback_rounds += 1
             continue
 
@@ -3494,46 +3545,48 @@ def govern_pr_flow(
                 return 2
             if thread_action == "revise" and feedback is not None:
                 last_pr_feedback_thread_ids = thread_ids
-                builder, builder_payload = run_builder(
+                builder = run_builder_turn(
                     runner,
+                    conn,
+                    event_log,
                     args.repo,
                     worker,
                     issue,
                     run_id,
                     branch,
-                    pathlib.Path(args.builder_template),
+                    builder_template,
                     args.builder_timeout,
                     workspace=builder_workspace,
+                    event_type="builder_revised",
                     feedback=feedback,
                     feedback_source="pr_review_threads",
                     pr_number=builder.pr_number,
                     pr_url=builder.pr_url,
                 )
-                update_run(conn, run_id, phase="awaiting_governance", branch=builder.branch, pr_number=builder.pr_number, pr_url=builder.pr_url)
-                record_event(conn, event_log, run_id, "builder_revised", builder_payload)
                 pr_feedback_rounds += 1
                 continue
 
         if not polish_completed:
             update_run(conn, run_id, phase="polishing")
             record_event(conn, event_log, run_id, "final_polish_requested", {"pr_number": builder.pr_number})
-            builder, builder_payload = run_builder(
+            builder = run_builder_turn(
                 runner,
+                conn,
+                event_log,
                 args.repo,
                 worker,
                 issue,
                 run_id,
                 branch,
-                pathlib.Path(args.builder_template),
+                builder_template,
                 args.builder_timeout,
                 workspace=builder_workspace,
+                event_type="final_polish_complete",
                 feedback=final_polish_feedback(builder.pr_number),
                 feedback_source="polish",
                 pr_number=builder.pr_number,
                 pr_url=builder.pr_url,
             )
-            update_run(conn, run_id, phase="awaiting_governance", branch=builder.branch, pr_number=builder.pr_number, pr_url=builder.pr_url)
-            record_event(conn, event_log, run_id, "final_polish_complete", builder_payload)
             polish_completed = True
             last_pr_feedback_thread_ids = ()
             # Re-enter the full governor loop so any polish changes re-run review,
@@ -3628,30 +3681,25 @@ def run_once(args: argparse.Namespace) -> int:
         record_event(conn, event_log, run_id, "builder_selected", {"sprite": worker})
 
         branch = branch_name(issue.number, run_id_suffix(run_id))
+        builder_template = pathlib.Path(args.builder_template)
         builder_workspace = prepare_run_workspace(runner, worker, args.repo, run_id, "builder")
         builder_workspace_prepared = True
         update_run(conn, run_id, worktree_path=builder_workspace)
         record_event(conn, event_log, run_id, "builder_workspace_prepared", {"workspace": builder_workspace})
-        builder, builder_payload = run_builder(
+        builder = run_builder_turn(
             runner,
+            conn,
+            event_log,
             args.repo,
             worker,
             issue,
             run_id,
             branch,
-            pathlib.Path(args.builder_template),
+            builder_template,
             args.builder_timeout,
             workspace=builder_workspace,
+            event_type="builder_complete",
         )
-        update_run(
-            conn,
-            run_id,
-            phase="awaiting_governance",
-            branch=builder.branch,
-            pr_number=builder.pr_number,
-            pr_url=builder.pr_url,
-        )
-        record_event(conn, event_log, run_id, "builder_complete", builder_payload)
         builder_handoff_recorded = True
         if getattr(args, "stop_after_pr", False):
             record_event(

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -2343,6 +2343,69 @@ def test_run_builder_precleans_worker(monkeypatch: pytest.MonkeyPatch) -> None:
     assert builder.pr_number == 465
 
 
+def test_run_builder_turn_records_governance_handoff(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    issue = conductor.Issue(number=464, title="docs", body="body", url="https://example.com/464", labels=["autopilot"])
+    conductor.create_run(conn, "run-464-1", "misty-step/bitterblossom", issue, "default")
+    conductor.update_run(conn, "run-464-1", phase="revising")
+
+    builder = conductor.BuilderResult(
+        status="ready_for_review",
+        branch="factory/464-docs-1",
+        pr_number=465,
+        pr_url="https://github.com/misty-step/bitterblossom/pull/465",
+        summary="done",
+        tests=[],
+    )
+    payload = {
+        "status": "ready_for_review",
+        "branch": builder.branch,
+        "pr_number": builder.pr_number,
+        "pr_url": builder.pr_url,
+        "summary": builder.summary,
+        "tests": builder.tests,
+    }
+
+    monkeypatch.setattr(conductor, "run_builder", lambda *_args, **_kwargs: (builder, payload))
+
+    got = conductor.run_builder_turn(
+        _RunnerSpy(),
+        conn,
+        tmp_path / "events.jsonl",
+        "misty-step/bitterblossom",
+        "noble-blue-serpent",
+        issue,
+        "run-464-1",
+        "factory/464-docs-1",
+        pathlib.Path("scripts/prompts/conductor-builder-template.md"),
+        10,
+        workspace="/tmp/run-464-1-builder",
+        event_type="builder_revised",
+        feedback="fix it",
+        pr_number=465,
+        pr_url=builder.pr_url,
+    )
+
+    assert got == builder
+    run = conn.execute(
+        "select phase, branch, pr_number, pr_url from runs where run_id = ?",
+        ("run-464-1",),
+    ).fetchone()
+    assert run is not None
+    assert run["phase"] == "awaiting_governance"
+    assert run["branch"] == builder.branch
+    assert run["pr_number"] == builder.pr_number
+    assert run["pr_url"] == builder.pr_url
+
+    event = conn.execute(
+        "select event_type, payload_json from events where run_id = ? order by id desc limit 1",
+        ("run-464-1",),
+    ).fetchone()
+    assert event is not None
+    assert event["event_type"] == "builder_revised"
+    assert json.loads(event["payload_json"]) == payload
+
+
 def test_ensure_sprite_ready_repairs_after_failed_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
     probe_results = iter(

--- a/walkthrough/reviewer-evidence.md
+++ b/walkthrough/reviewer-evidence.md
@@ -2,52 +2,41 @@
 
 ## Claim
 
-This branch removes a dead compatibility layer that advertised `bb` commands and flags the binary does not implement, then aligns repo-local docs and shipped skills to the real transport surface.
+This branch turns a successful conductor builder pass into one explicit operation. The governor no longer has to remember, in six separate branches, to both restore `phase=awaiting_governance` and record the matching builder event.
 
 ## Before
 
-- `scripts/provision.sh`, `scripts/sync.sh`, `scripts/status.sh`, and `scripts/teardown.sh` pretended to preserve an old wrapper API.
-- `scripts/test_legacy_wrappers.sh` only asserted argument forwarding, not that the forwarded commands existed.
-- `go run ./cmd/bb provision fern` failed with `unknown command "provision" for "bb"`.
-- `go run ./cmd/bb status --format text` failed with `unknown flag: --format`.
-- Multiple docs and Bitterblossom skills still taught those stale commands and flags.
+- `scripts/conductor.py` duplicated the same `run_builder(...) -> update_run(...) -> record_event(...)` sequence in the initial builder path, review revisions, CI revisions, PR-thread revisions, external-review revisions, and final polish.
+- Any future change to builder handoff semantics needed to touch every copy in the governor loop.
+- The invariant "a successful builder turn returns control to governance with fresh PR metadata and an event log entry" lived in call-site convention instead of one module boundary.
 
 ## After
 
-- The dead wrapper scripts and their wrapper-only test are gone.
-- `cmd/bb/main_test.go` now codifies the real CLI boundary by asserting that legacy entrypoints are rejected.
-- Repo-local docs and Bitterblossom skills now point to the supported commands: `setup`, `dispatch`, `status`, `logs`, `kill`, and `version`.
+- `run_builder_turn(...)` now owns the successful handoff contract for governance-managed builder work.
+- `run_once(...)` and `govern_pr_flow(...)` call that boundary instead of re-spelling the postconditions.
+- `scripts/test_conductor.py` now includes a focused regression test proving that a builder turn updates run state and emits the expected event.
 
 ## Why This Matters
 
-The repo’s ADRs say `bb` is a thin, deterministic transport. Leaving a fake compatibility surface in place made the operator boundary shallower and more confusing: readers had to know which docs were real, which wrappers were dead, and which flags only existed in history. This branch collapses that split-brain surface back to one truth.
+The conductor is the judgment-heavy part of Bitterblossom, so its hot path should hide repeated sequencing details, not leak them into every branch. This refactor removes change amplification from the most central loop without changing behavior or broadening the transport surface.
+
+## Artifact
+
+- Walkthrough notes: `docs/walkthroughs/builder-turn-handoff.md`
+- Renderer: diagram + terminal evidence
 
 ## Evidence Bundle
 
-### Files that prove the boundary
-
-- `cmd/bb/main.go`
-- `cmd/bb/main_test.go`
-- `docs/CLI-REFERENCE.md`
-- `README.md`
-- `QA.md`
-- `base/skills/bitterblossom-dispatch/SKILL.md`
-- `base/skills/bitterblossom-monitoring/SKILL.md`
-
-### Deleted surface
-
-- `scripts/lib_bb.sh`
-- `scripts/provision.sh`
-- `scripts/sync.sh`
-- `scripts/status.sh`
-- `scripts/teardown.sh`
-- `scripts/test_legacy_wrappers.sh`
+- `scripts/conductor.py`
+- `scripts/test_conductor.py`
+- `docs/walkthroughs/builder-turn-handoff.md`
 
 ## Protecting Checks
 
-- `go test ./cmd/bb/...`
-- `python3 -m pytest -q base/hooks scripts/test_conductor.py`
+- `pytest -q scripts/test_conductor.py`
+- Targeted governance slice:
+  `pytest -q scripts/test_conductor.py -k 'run_once or govern_pr'`
 
 ## Residual Gap
 
-Older historical reports in `docs/shakedowns/` and `observations/` still mention now-removed commands as part of their historical narrative. They were left intact because they are evidence, not current operator guidance.
+`scripts/conductor.py` is still a large single module. This branch removes one high-churn seam inside it; it does not attempt the riskier multi-file conductor split.


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [walkthrough/reviewer-evidence.md](../blob/codex/simplify-builder-turns/walkthrough/reviewer-evidence.md?raw=true)
- Direct video download: n/a, this is a diagram + terminal walkthrough
- Walkthrough notes: [docs/walkthroughs/builder-turn-handoff.md](../blob/codex/simplify-builder-turns/docs/walkthroughs/builder-turn-handoff.md?raw=true)
- Fast claim: this branch makes successful builder handoff one conductor operation instead of six copy-pasted sequences.

## Why This Matters
- Problem: the governor loop repeated the same `run_builder(...) -> update_run(...) -> record_event(...)` handoff logic across review, CI, PR-thread, external-review, polish, and initial builder paths.
- Value: successful builder turns now publish one invariant in one place, which removes change amplification from the hottest conductor path.
- Why now: this is the highest-leverage simplification the current architecture can absorb in one safe PR without attempting a risky conductor split.
- Issue: none; repo-local simplification pass driven by the `$simplify` workflow and ADR-002's thin-transport / thick-control-plane intent.

## Trade-offs / Risks
- Value gained: future edits to builder handoff semantics now have one boundary to change and one focused regression test to protect it.
- Cost / risk incurred: the conductor still remains a large single file, and this adds one more helper inside that file rather than doing a broader module split.
- Why this is still the right trade: it removes real duplication in the live governance loop with low behavior risk and full existing test coverage.
- Reviewer watch-outs: pressure-test that every successful builder path still restores `phase="awaiting_governance"` and records the correct event type.

## What Changed
This PR extracts a governance-level `run_builder_turn(...)` boundary in `scripts/conductor.py` and routes the initial build, revision, thread-feedback, external-feedback, and final-polish paths through it. The result is the same behavior with less temporal coupling: successful builder work now has one place that validates the artifact, restores the run to governance, and records the event log entry.

### Base Branch
```mermaid
graph TD
  A["review / CI / thread / polish branch"] --> B["run_builder(...)"]
  B --> C["update_run(... awaiting_governance ...)"]
  C --> D["record_event(... builder_* ...)"]
  D --> E["continue governor loop"]
```

### This PR
```mermaid
graph TD
  A["review / CI / thread / polish branch"] --> B["run_builder_turn(...)"]
  B --> C["validated builder result + published handoff"]
  C --> D["continue governor loop"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> revising
  revising --> "run_builder_turn(...)"
  "run_builder_turn(...)" --> awaiting_governance
  awaiting_governance --> governing
```

Why this is better:
- The successful handoff contract is now explicit instead of being spread across callers.
- The governor loop reads more like policy and less like bookkeeping.
- One regression test now codifies the handoff invariant directly.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- ADR-002 says `bb` should stay thin while workflow judgment lives in the conductor.
- This refactor stays inside that boundary: transport behavior is unchanged, while the conductor's hottest control-flow seam gets simpler.
- There is no linked GitHub issue for this branch; the implementation target was the duplicated builder-turn bookkeeping identified during the repo simplification pass.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `run_builder_turn(...)` to `scripts/conductor.py` so successful builder work has one governance handoff boundary.
- Replaced duplicated builder handoff sequences in `govern_pr_flow(...)` and `run_once(...)` with calls to that boundary.
- Added `test_run_builder_turn_records_governance_handoff` to `scripts/test_conductor.py`.
- Added and refreshed committed walkthrough artifacts under `docs/walkthroughs/` and `walkthrough/`.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Successful builder turns still return the run to `awaiting_governance`.
- [x] Successful builder turns still record the correct event payload.
- [x] Review, CI, PR-thread, external-review, polish, and initial builder paths all share the same handoff boundary.
- [x] Existing conductor regression coverage stays green.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: no refactor risk.
- Downside: every future builder handoff change still touches six branches.
- Why rejected: the duplication is in the most central loop, so leaving it in place keeps future edits more expensive than they need to be.

### Option B — Split `scripts/conductor.py` into multiple modules
- Upside: larger architectural cleanup.
- Downside: materially bigger PR with much higher review and regression risk.
- Why rejected: good future direction, bad single-PR simplification candidate.

### Option C — Centralize the builder-turn boundary
- Upside: removes real temporal coupling with a small, reviewable diff.
- Downside: does not solve the whole conductor monolith.
- Why chosen: best complexity removed per unit of delivery risk right now.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
pytest -q scripts/test_conductor.py
pytest -q scripts/test_conductor.py -k 'run_once or govern_pr'
pytest -q scripts/test_conductor.py -k 'run_builder_turn_records_governance_handoff or run_once_routes_unresolved_pr_threads_back_to_builder or run_once_rechecks_pr_threads_after_external_reviews_settle or govern_pr_adopts_existing_pr_and_runs_final_polish or run_once_can_stop_after_builder_handoff or run_once_withholds_merge_while_trusted_surfaces_pending or run_once_merges_when_trusted_surfaces_settle'
```

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: diagram + terminal walkthrough
- Artifact: [docs/walkthroughs/builder-turn-handoff.md](../blob/codex/simplify-builder-turns/docs/walkthroughs/builder-turn-handoff.md?raw=true)
- Claim: successful builder work now has one conductor handoff boundary.
- Before / After scope: `scripts/conductor.py` governance flow and its regression coverage.
- Persistent verification: `pytest -q scripts/test_conductor.py`
- Residual gap: the conductor remains single-file; only the builder-turn seam is simplified here.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: each successful builder rerun had to manually restore governance state and emit an event from its local branch.
- After: callers request a builder turn and receive a validated handoff with the bookkeeping already applied.
- Screenshots are not needed because this PR is internal control-flow simplification rather than a user-visible change.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `scripts/test_conductor.py::test_run_builder_turn_records_governance_handoff`
- Full regression suite: `pytest -q scripts/test_conductor.py`
- Targeted governor slice: `pytest -q scripts/test_conductor.py -k 'run_once or govern_pr'`

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: the full conductor test suite passed after routing all builder paths through the new helper.
- Remaining uncertainty: only untested risk would be a behavior difference in a future builder path that bypasses the helper.
- What could still go wrong after merge: the broader conductor file can still accumulate other duplicated state transitions outside the builder-turn seam.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive walkthrough detailing the builder turn handoff process and state management patterns.
  * Updated reviewer evidence documentation to reflect improved handoff architecture.

* **Improvements**
  * Refactored builder turn handoff management to centralize governance flow coordination.
  * Enhanced test coverage for handoff verification and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->