### PR TITLE
feat: harden conductor worktree lifecycle under concurrency and transient failures

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,53 +1,43 @@
-# PLAN: Issue #478 — Prevent blocked issues from immediate retry in backlog loop
+# PLAN: Issue #538 — Harden conductor worktree lifecycle under concurrency and transient failures
+
+## Status: COMPLETE (implementation already in master via #549)
 
 ## Problem
 
-When `run_once` exits with `rc=2` (blocked), the `finally` block calls
-`release_lease`, which frees the issue for immediate re-pick on the next poll.
-A blocked issue gets re-leased, re-run, and spams repeated blocker comments.
+The per-run worktree isolation from #469 fixed the shared-checkout contract but left
+the lifecycle vulnerable under concurrent or degraded sprite conditions: mirror mutation
+could race, transient failures left ambiguous state, and cleanup failures were silent.
 
-## Root Cause
+## Acceptance Criteria Mapping
 
-`release_lease` is called unconditionally in `run_once`'s `finally` block.
-Blocked runs need their lease kept active (not released) until an operator
-explicitly re-queues the issue.
+All four acceptance criteria are satisfied in the current codebase:
 
-## Solution
+| Criterion | Location | Coverage |
+|---|---|---|
+| [test] Concurrent mirror mutation serialized | `prepare_run_workspace` + `_mirror_lock` | `test_prepare_run_workspace_serializes_overlapping_calls` |
+| [test] Transient failure retries cleanly | `WORKSPACE_PREP_RETRIES` + retry loop | `test_prepare_run_workspace_retries_on_transient_failure`, `_exhausts_retries_with_explicit_message`, `_retries_on_timeout` |
+| [behavioral] Cleanup failure is visible | `cleanup_builder_workspace` preserves `worktree_path` + emits `workspace_cleanup_failed` event | `test_cleanup_builder_workspace_records_workspace_cleanup_failed_on_error`, `_preserves_worktree_path_on_failure` |
+| [command] `show-runs`/`show-run` include `worktree_path` | `serialize_run_surface`, `show_runs`, `show_run` | `test_show_runs_includes_worktree_path`, `test_show_run_includes_worktree_path` |
 
-Treat `blocked` as a scheduler state in the lease table:
+## Implementation Summary
 
-1. Add `blocked_at` column to `leases`.
-2. New `block_lease()` sets `blocked_at = now, lease_expires_at = null`.
-3. `run_once` tracks `block_on_release = True` at each `return 2` point,
-   and the `finally` calls `block_lease` instead of `release_lease`.
-4. `pick_issue` already skips issues where `released_at is null` — so blocked
-   issues (with `released_at = null`) are excluded automatically.
-5. `acquire_lease` already returns False for active leases — blocked leases
-   have `released_at = null`, `lease_expires_at = null`, so they block re-acquisition.
-6. `reap_expired_leases` skips `lease_expires_at = null` leases — no change needed.
-7. New `requeue-issue` command clears `blocked_at`, sets `released_at = now`.
+- **In-process lock**: `_mirror_lock(sprite, mirror)` — one `threading.Lock` per (sprite, mirror) pair
+- **Filesystem flock**: `flock --exclusive` on `.conductor_lock` inside the mirror dir — serializes concurrent processes
+- **Retry policy**: `WORKSPACE_PREP_RETRIES = 2`, exponential backoff (`attempt + 1 * WORKSPACE_PREP_RETRY_DELAY_SECONDS`), retries on `CmdError`, `OSError`, `subprocess.TimeoutExpired`; exhausted retries raise with explicit message
+- **Cleanup truth**: `cleanup_builder_workspace` records `workspace_cleanup_failed` event (with `surviving_path`) on failure; intentionally does not clear `worktree_path` column so operators can recover without reading the sprite filesystem
+- **Inspector surface**: `show_runs` and `show_run` include `worktree_path` in JSON output; `show-events` reveals `workspace_cleanup_failed` event detail
 
-## Affected Files
+## Docs
 
-- `scripts/conductor.py`
-- `scripts/test_conductor.py`
-- `docs/CONDUCTOR.md`
+`docs/CONDUCTOR.md` "Worktree Lifecycle and Serialization" section documents the two-level lock strategy, retry policy, cleanup failure visibility, and manual cleanup procedure.
 
-## Steps
+## Verification
 
-- [x] Plan written and verified
-- [x] Create branch `factory/478-p1-conductor-prevent-blocked-iss-1772842172`
-- [ ] `init_db`: add `ensure_column(conn, "leases", "blocked_at", "text")`
-- [ ] Add `block_lease(conn, repo, issue_number)` function
-- [ ] Modify `run_once`: track `block_on_release`, conditional finally
-- [ ] Add `requeue_issue(args)` function
-- [ ] Add `requeue-issue` subparser
-- [ ] Write tests (AC1: not re-picked, AC3: re-queue, unit tests for block_lease)
-- [ ] Update `docs/CONDUCTOR.md`
-- [ ] Run `python3 -m pytest -q scripts/test_conductor.py`
-- [ ] Push branch, open draft PR
-- [ ] Write builder artifact
-
-## Review
-
-(To be filled in after implementation)
+```bash
+python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"
+# 28 passed
+python3 -m pytest -q scripts/test_conductor.py
+# 197 passed
+python3 scripts/conductor.py show-runs --limit 20
+python3 scripts/conductor.py show-run --run-id <run-id>
+```


### PR DESCRIPTION
## Summary

This PR closes the remaining credibility gaps in the run-scoped worktree lifecycle introduced by #469. All four acceptance criteria from #538 are satisfied in the current codebase.

**Closes #538**

## What's in This Branch

The implementation was already landed in master (primarily via #549). This factory branch records the verification pass:

- All 28 worktree/workspace/cleanup regression tests pass
- All 197 conductor tests pass
- `docs/CONDUCTOR.md` documents the two-level serialization strategy, retry policy, and operator recovery surface

## Acceptance Criteria Verification

| Criterion | Implementation | Test(s) |
|---|---|---|
| Concurrent mirror mutation serialized | `_mirror_lock(sprite, mirror)` (in-process) + `flock --exclusive` on `.conductor_lock` (cross-process) | `test_prepare_run_workspace_serializes_overlapping_calls`, `test_prepare_run_workspace_does_not_serialize_different_sprites`, `test_prepare_run_workspace_releases_lock_before_retry_sleep` |
| Transient failure retries cleanly | `WORKSPACE_PREP_RETRIES = 2` + exponential backoff, raises explicit message on exhaustion | `test_prepare_run_workspace_retries_on_transient_failure`, `_exhausts_retries_with_explicit_message`, `_retries_on_timeout`, `test_prepare_run_workspace_script_uses_flock_for_mirror_serialization` |
| Cleanup failure visible to operators | `cleanup_builder_workspace` emits `workspace_cleanup_failed` event w/ `surviving_path`; does NOT clear `worktree_path` | `test_cleanup_builder_workspace_records_workspace_cleanup_failed_on_error`, `_preserves_worktree_path_on_failure` |
| `show-runs`/`show-run` expose worktree-path lifecycle | `serialize_run_surface` includes `worktree_path`; both commands query it | `test_show_runs_includes_worktree_path`, `test_show_run_includes_worktree_path` |

## Test Plan

- [x] `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` — 28 passed
- [x] `python3 -m pytest -q scripts/test_conductor.py` — 197 passed
- [ ] Operator verification: `python3 scripts/conductor.py show-runs --limit 20` includes `worktree_path` field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated planning documentation with formalized acceptance criteria and implementation details covering concurrency controls and retry policies.
  * Added verification section with test commands and expected outcomes.

* **Chores**
  * Restructured planning document to provide clearer status tracking and behavior-focused coverage mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->