### PR TITLE
test: cover OSError retry path in prepare_run_workspace (#538)

### DIFF
--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -6077,6 +6077,36 @@ def test_prepare_run_workspace_retries_on_timeout(monkeypatch: pytest.MonkeyPatc
     assert sleeps == [conductor.WORKSPACE_PREP_RETRY_DELAY_SECONDS]
 
 
+def test_prepare_run_workspace_retries_on_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Transport-level OSError (e.g. broken pipe) is treated as transient and retried."""
+    call_count = 0
+    expected_workspace = conductor.run_workspace("misty-step/bitterblossom", "run-538-1", "builder")
+    sleeps: list[float] = []
+
+    def fake_sprite_bash(_runner: object, _sprite: str, _script: str, *, timeout: int) -> str:
+        nonlocal call_count
+        _ = timeout
+        call_count += 1
+        if call_count < 2:
+            raise OSError("Connection reset by peer")
+        return expected_workspace
+
+    monkeypatch.setattr(conductor, "sprite_bash", fake_sprite_bash)
+    monkeypatch.setattr(conductor.time, "sleep", lambda s: sleeps.append(s))
+
+    workspace = conductor.prepare_run_workspace(
+        object(),
+        "noble-blue-serpent",
+        "misty-step/bitterblossom",
+        "run-538-1",
+        "builder",
+    )
+
+    assert workspace == expected_workspace
+    assert call_count == 2
+    assert sleeps == [conductor.WORKSPACE_PREP_RETRY_DELAY_SECONDS]
+
+
 def test_prepare_run_workspace_serializes_overlapping_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     """Concurrent calls for the same sprite+repo must not interleave mirror operations."""
     import threading as _threading


### PR DESCRIPTION
Closes #538

## Summary

This PR adds a regression test for the `OSError` retry path in `prepare_run_workspace`. All four acceptance criteria from #538 are satisfied in master (implemented via #549). This branch adds coverage for the one retry path that was not explicitly tested: transport-level `OSError` (broken pipe, connection reset by peer).

## What Changed

- Added `test_prepare_run_workspace_retries_on_os_error` to `scripts/test_conductor.py`

`OSError` is already in the retry clause alongside `CmdError` and `subprocess.TimeoutExpired`, but lacked a dedicated test. Without this test, accidentally dropping `OSError` from the clause would pass the suite.

## Acceptance Criteria Verification

| Criterion | Implementation | Test(s) |
|---|---|---|
| Concurrent mirror mutation serialized | `_mirror_lock(sprite, mirror)` + `flock --exclusive` on `.conductor_lock` | `test_prepare_run_workspace_serializes_overlapping_calls`, `test_prepare_run_workspace_does_not_serialize_different_sprites`, `test_prepare_run_workspace_script_uses_flock_for_mirror_serialization`, `test_cleanup_run_workspace_script_uses_flock` |
| Transient failure retries cleanly | `WORKSPACE_PREP_RETRIES = 2` + linear backoff; explicit exhaustion message | `test_prepare_run_workspace_retries_on_transient_failure`, `test_prepare_run_workspace_exhausts_retries_with_explicit_message`, `test_prepare_run_workspace_retries_on_timeout`, **`test_prepare_run_workspace_retries_on_os_error`** (new) |
| Cleanup failure visible to operators | `cleanup_builder_workspace` emits `workspace_cleanup_failed` with `surviving_path`; does not clear `worktree_path` | `test_cleanup_builder_workspace_records_workspace_cleanup_failed_on_error`, `test_cleanup_builder_workspace_preserves_worktree_path_on_failure` |
| `show-runs`/`show-run` expose worktree_path | `serialize_run_surface` includes `worktree_path` | `test_show_runs_includes_worktree_path`, `test_show_run_includes_worktree_path` |

## Test Results

```
python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"
29 passed in 0.69s

python3 -m pytest -q scripts/test_conductor.py
198 passed in 1.73s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for transient error retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->