### PR TITLE
docs: record worktree lifecycle hardening resolution (#538)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,3 +12,24 @@
 - #293 commented (wait/poll hang regression signal)
 - #320 commented (json-output pollution class)
 - #388 commented (streaming regression signal)
+
+## Issue #538 — Worktree lifecycle hardening (2026-03-12)
+
+Resolved via PRs #549, #555, #557 (merged to master). Implementation:
+
+- Python-level `threading.Lock` per `(sprite, mirror)` serializes in-process concurrent ops
+- Filesystem `flock --exclusive` on `.conductor_lock` serializes cross-process access
+- `prepare_run_workspace` retries up to `WORKSPACE_PREP_RETRIES=2` on transient `CmdError` or `OSError`
+- `cleanup_builder_workspace` records `workspace_cleanup_failed` event with `surviving_path`; `worktree_path` is *not* cleared on failure so operators can recover
+- `show-runs` / `show-run` expose `worktree_path` in JSON output
+- Tests cover: flock presence, serialized overlapping calls, cross-op prepare+cleanup lock, retry on transient and OS errors, cleanup failure visibility, and worktree inspection commands
+
+### Pattern: stale conductor runs on closed issues
+
+The conductor can acquire a lease and dispatch a builder even after the underlying
+GitHub issue has been closed (e.g., if the issue was closed between lease acquisition
+and builder dispatch, or via a direct `gh issue close`). When a builder finds all
+acceptance criteria already satisfied on master, the correct move is to verify tests
+pass, write the artifact with `status=ready_for_review`, and let the governance lane
+close the loop. Do not skip the artifact write — the conductor needs it to release
+the lease cleanly.


### PR DESCRIPTION
## Summary

- Records the completed worktree lifecycle hardening in `MEMORY.md`
- All implementation for issue #538 landed in PRs #549, #555, and #557 (merged to master)
- Adds guidance on handling stale conductor runs against already-closed issues

This is a final confirmatory run: acceptance criteria verified, 30 targeted tests pass, full suite (199 tests) passes.

## Acceptance Criteria Verified

- [x] Mirror mutation serialized: `_mirror_lock` (Python) + `flock --exclusive` (filesystem)
- [x] Transient `prepare_run_workspace` failures retry with explicit error message  
- [x] Cleanup failure visibility: `workspace_cleanup_failed` event + `surviving_path` + preserved `worktree_path`
- [x] `show-runs` / `show-run` include `worktree_path` in JSON output

## Test Plan

- [x] `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` → 30 passed
- [x] `python3 -m pytest -q scripts/test_conductor.py` → 199 passed

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation covering worktree lifecycle hardening with implementation details and test coverage information.
  * Documented synchronization mechanisms, retry handling in workspace preparation, and failure reporting during cleanup.
  * Added information on worktree_path exposure in show-runs outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->