### PR TITLE
feat: import first-wave autonomy skills for sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ docs/                    operator docs and contracts
 
 ## How It Works
 
-1. `bb setup <sprite> --repo owner/repo` bootstraps persistent worker sprites
+1. `bb setup <sprite> --repo owner/repo` bootstraps persistent worker sprites with base configs, imported autonomy skills, and a role persona
 2. `scripts/conductor.py run-once|loop` reads GitHub issues and acquires a lease
 3. the conductor dispatches a builder sprite with a branch + artifact contract
 4. the builder opens a PR and writes `builder-result.json`
@@ -80,9 +80,21 @@ See [docs/CLI-REFERENCE.md](docs/CLI-REFERENCE.md) for `bb`, and [docs/CONDUCTOR
 
 Bitterblossom ships task-oriented skill files in `base/skills/` so agents can load workflow guidance directly instead of inferring from CLI help text.
 
-Current Bitterblossom-specific skills:
+Imported first-party autonomy skills (vendored from `phrazzld/agent-skills`):
+- `autopilot`
+- `shape`
+- `build`
+- `pr`
+- `pr-walkthrough`
+- `debug`
+- `pr-fix`
+- `pr-polish`
+
+Bitterblossom-specific runtime skills:
 - `base/skills/bitterblossom-dispatch/SKILL.md` — dry-run probing plus prompt dispatch through `bb`
 - `base/skills/bitterblossom-monitoring/SKILL.md` — monitoring, status checks, and recovery triage
+
+`bb setup` provisions the full `base/skills/` tree onto managed sprites so role personas can rely on a version-pinned skill surface.
 
 Example workflow using the current transport surface:
 

--- a/base/CLAUDE.md
+++ b/base/CLAUDE.md
@@ -10,6 +10,22 @@ You are a sprite in a coordinated fae engineering court. You implement directly.
 - Your work is reviewed by a multi-model council (GitHub Action)
 - Read your `PERSONA.md` for your specific identity and preferences
 
+## Imported Skill Surface
+
+The sprite base now ships imported autonomy skills from `phrazzld/agent-skills` under `.claude/skills/`.
+
+Use them intentionally when they match the work:
+- `shape` before non-trivial issue pickup or implementation planning
+- `build` for bounded implementation and verification loops
+- `pr` when preparing branches, PR descriptions, and operator-facing verification notes
+- `pr-walkthrough` when inspecting or explaining an existing PR
+- `debug` for investigation and root-cause classification
+- `pr-fix` when addressing review feedback or CI failures
+- `pr-polish` for final merge-readiness cleanup
+- `autopilot` when the task is a bounded autonomous workflow rather than a single narrow edit
+
+Do not invent a weaker ad hoc workflow when a matching imported skill already exists.
+
 ## Self-Evolution
 
 After each significant leg of work:

--- a/base/skills/autopilot/SKILL.md
+++ b/base/skills/autopilot/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: autopilot
+description: |
+  Full autonomous delivery from issue to PR.
+  Finds highest-priority issue, specs it, designs it, builds it, ships it.
+  Use when: shipping an issue end-to-end, autonomous delivery, sprint execution.
+  Trigger: /autopilot, "ship this issue", "build and ship", "sprint execute".
+argument-hint: "[issue-id]"
+---
+
+# /autopilot
+
+From issue to PR in one command.
+
+## Role
+
+Engineering lead running a sprint. Find work, ensure it's ready, delegate implementation, ship.
+
+## Objective
+
+Deliver Issue `$ARGUMENTS` (or highest-priority eligible open issue) as a draft PR with tests passing,
+a clean dogfood QA pass, and a walkthrough artifact that makes the merge case legible.
+
+An open PR for that issue counts as the active delivery lane. Do not create a duplicate PR
+for the same issue unless you first surface and justify a superseding lane.
+
+## Latitude
+
+- Codex writes first draft of everything (investigation, implementation, tests, docs)
+- You orchestrate, review, clean up, commit, ship
+- Flesh out incomplete issues yourself (spec, design)
+- Never skip an issue because it's "not ready" — YOU make it ready
+- `dogfood`, `agent-browser`, and `browser-use` are available in this environment; use them for user-flow validation
+
+## LLM-First Implementation Rule (Mandatory)
+
+When solving semantic problems (classification, prioritization, triage, intent mapping, AC/spec compliance), use LLM reasoning-first approaches.
+
+Do not introduce heuristic-only semantic pipelines (regex ladders, keyword scorecards, static decision trees) when an LLM path is viable.
+
+Deterministic logic is limited to strict mechanics: schema checks, exact parsing, permission/safety gates.
+
+## Priority Selection
+
+**Always work on the highest-priority eligible issue.**
+
+Eligibility comes first:
+- unassigned
+- not already marked `In Progress`
+- not already being worked by another autopilot run or open PR
+
+1. `p0` > `p1` > `p2` > `p3` > unlabeled
+2. Within tier: `horizon/now` > `horizon/next` > unlabeled
+3. Within same horizon: lower issue number first
+4. Scope, cleanliness, comfort don't matter after eligibility is satisfied
+
+If the highest-priority issue is already assigned or already `In Progress`, skip it and move to the next eligible issue.
+Never steal claimed work.
+
+## Claim Discipline
+
+Autopilot must claim work before shaping or coding.
+
+- Auto-pick mode: only select issues with no assignees, no `In Progress` status, no open PR, and no active autopilot lane already attached
+- Explicit issue mode: stop if the issue is owned by another operator, already has another open PR, or is otherwise being worked by another lane
+- Explicit issue mode may resume work already claimed by you, including an issue already assigned to you or already marked `In Progress` by your lane
+- Before `/issue lint`, assign the issue to yourself
+- Before `/issue lint`, mark the issue's project status as `In Progress`
+- If the issue is not in a project or the project has no `Status` field, attach it to the canonical delivery project first, then set `Status`
+- If assignment, project attach, or status mutation fails, stop before implementation and report the blocker explicitly
+
+The point is single ownership. One issue should map to one active autopilot lane.
+
+## Workflow
+
+1. **Find eligible issue** —
+   - Explicit issue: inspect assignees, project status, and open PRs before doing anything else
+   - Auto-pick: choose the highest-priority open issue that is unassigned, not `In Progress`, and has no open PR or active autopilot lane
+   - If there are no open issues, stop and report that the queue is empty
+   - If open issues exist but none are eligible, stop and report that all open work is already claimed
+   - Preferred lane check: run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` when the repo provides it
+   - Fallback: query open PRs with `gh pr list --state open --json number,title,body,headRefName,url`
+2. **Claim issue** —
+   - Assign the issue to yourself
+   - Ensure the issue is attached to the canonical delivery project
+   - Mark the linked project item `Status` as `In Progress`
+   - Re-read the issue and confirm the claim stuck before proceeding
+   - If the issue is already claimed by your lane, treat this as resume and continue
+   - If the issue is claimed by another lane, stop instead of competing
+3. **Load context** — Read `project.md` for product vision, domain glossary, quality bar
+4. **Readiness gate** — Run `/issue lint $1`:
+   - Score >= 70: proceed
+   - Score 50-69: run `/issue enrich $1` first, then re-lint
+   - Score < 50: flag to user, attempt enrichment, re-lint
+   - **Never skip an issue because it scored low — YOU make it ready**
+5. **Intent gate** — Ensure issue has `## Product Spec` and `### Intent Contract`.
+   If missing, invoke `/shape --spec-only $1` and re-check before coding.
+6. **Design** — Invoke `/shape --design-only` if no `## Technical Design` section
+7. **Build (TDD Enforced)** — Invoke `/build` and require RED→GREEN evidence per acceptance criterion:
+   - RED: failing targeted tests before implementation
+   - GREEN: same tests passing after implementation
+   - If test harness is broken, stop and flag blocker (no implementation without explicit user bypass)
+   - Delete compatibility scaffolding in greenfield/pre-user paths unless a real contract requires it
+8. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa --fix`. Fix P0/P1 before proceeding.
+9. **Agentic QA** — If diff touches prompts, model routing, tool schemas, or agent instructions, run `/llm-infrastructure` and inspect trace/eval coverage before shipping.
+10. **Refine** — `/pr-fix --refactor`, update docs inline, then run simplification pass:
+    - Preferred accelerator (if native in current harness): `/simplify`
+    - Portable fallback (required): manual module-depth review + simplification edits using Ousterhout checks: shallow modules, information leakage, pass-throughs, and compatibility shims with no active contract
+    - Optional accelerator: use an `ousterhout` persona/agent if the harness provides one
+11. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
+   Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
+12. **Walkthrough** — Run `/pr-walkthrough` and produce the mandatory walkthrough package for the branch. Every PR needs an artifact, even if the change is internal or architectural.
+13. **Commit** — Create semantic commits for all remaining changes:
+    - Categorize files: commit, gitignore, delete, consolidate
+    - Group into logical commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+    - Subject: imperative, lowercase, no period, ~50 chars. Body: why not what.
+    - Run quality gates (`lint`, `typecheck`, `test`) before pushing
+    - `git fetch origin && git push origin HEAD` (rebase if behind)
+    - Never force push. Never push to main without confirmation.
+14. **Ship** — Open a draft PR:
+    - Stage and commit any uncommitted changes with semantic message
+    - Read linked issue from branch name or recent commits
+    - Re-run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` immediately before opening the PR when available
+    - Otherwise re-run the in-flight gate immediately before opening the PR
+    - If an open PR already exists for the branch, use `gh pr edit`, not `gh pr create`
+    - If another open PR already exists for the same issue, stop and surface the duplication instead of creating a second lane
+    - Load `../pr/references/pr-body-template.md` and follow it
+    - The `Walkthrough` section must link the artifact and name the persistent verification that protects the demonstrated path
+    - PR body must contain all sections:
+      - **Why This Matters**: Problem, value added, why now, issue link. This is top-of-line.
+      - **Trade-offs / Risks**: Costs accepted, remaining concerns, why the trade is worthwhile.
+      - **Intent Reference**: Copy/paste issue intent contract summary + link to source issue section.
+      - **Changes**: Concise list of what was done. Key files/functions.
+      - **Alternatives Considered**: Do nothing, credible alternative(s), and why current approach won.
+      - **Acceptance Criteria**: From linked issue. Checkboxes.
+      - **Manual QA**: Step-by-step verification. Commands, expected output.
+      - **What Changed**: Mermaid flow chart for base branch, Mermaid flow chart for this PR, and a third Mermaid architecture/state/sequence diagram, plus explanation of why the new shape is better.
+      - **Before / After**: Text description mandatory. Screenshots for UI changes. Use `<details>` for heavy evidence.
+      - **Test Coverage**: Specific test files/functions. Note gaps.
+      - **Merge Confidence**: Confidence level, strongest evidence, residual risk.
+    - Keep deep sections under `<details>` where useful, but do not hide the topline significance/trade-off story
+    - Use `--body-file` for `gh pr create`, `gh pr edit`, and PR comments
+    - `gh pr create --draft --assignee phrazzld --body-file <path>`
+    - Add context comment if notable decisions were made
+15. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:
+    ```
+    mkdir -p .groom
+    [ -f .groom/retro.md ] || cat > .groom/retro.md <<'EOF'
+    # Retro Log
+
+    Append one entry per delivered issue.
+    EOF
+    /retro append --issue $1 --predicted {effort_label} --actual {actual_effort} \
+      --scope "{scope_changes}" --blocker "{blockers}" --pattern "{insight}"
+    ```
+
+## Dogfood QA
+
+Run before every PR. No exceptions.
+
+`/dogfood` is an agent skill, not a shell binary. Invoke it as `/dogfood ...`.
+Do not run `dogfood --help` or declare it unavailable based on shell PATH.
+Use `agent-browser` / `browser-use` for focused manual repro and follow-up verification.
+
+### Setup
+
+```bash
+# Start dev server if not already running
+# Find existing server first
+PORT=$(lsof -i :3000 -sTCP:LISTEN -t 2>/dev/null | head -1)
+if [ -z "$PORT" ]; then
+  bun dev:next &
+  DEV_PID=$!
+  sleep 10  # wait for compilation
+fi
+
+# Confirm it's up
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+```
+
+If port 3000 is taken by another project, use `bun dev:next -- --port 3001` and adjust the
+target URL accordingly.
+
+### Run
+
+```
+/dogfood http://localhost:3000
+```
+
+Scope to the diff: if the issue only touches status pages, `/dogfood http://localhost:3000 Focus on the status page and badge changes`. For full-feature work, no scope restriction.
+
+### Issue Severity Gate
+
+After `/dogfood` completes, read the report:
+- **P0 or P1 issues** → fix them, commit, re-run `/dogfood` on the affected area
+- **P2 issues** → fix if quick (<15 min), otherwise document in PR as known and create a follow-up issue
+- **P3 issues / no issues** → proceed to `/pr`
+
+Never open a PR with unfixed P0 or P1 issues from the dogfood report.
+
+### Iteration Cap
+
+If the same P0/P1 issue resurfaces after two fix attempts, stop, document the blocker, and
+flag to the user before proceeding. Don't loop indefinitely.
+
+### Teardown
+
+```bash
+# Kill the dev server if we started it
+[ -n "$DEV_PID" ] && kill $DEV_PID 2>/dev/null || true
+```
+
+If the user's own dev server was already running (no `$DEV_PID`), leave it alone.
+
+## Parallel Refinement (Agent Teams)
+
+After `/build` completes, parallelize the refinement phase:
+
+| Teammate | Task |
+|----------|------|
+| **Simplifier** | Run code-simplifier agent, commit |
+| **Depth reviewer** | Run manual module-depth review, or `ousterhout` if available, commit |
+| **Doc updater** | Update docs (README, ADRs, API docs), commit |
+
+Lead sequences commits after all teammates finish. Then dogfood QA, then `/pr`.
+
+Use when: substantial feature with multiple refinement needs.
+Don't use when: small fix where sequential is fast enough.
+
+If native batch dispatch is available in the harness (e.g. `/batch`), use it.
+Otherwise launch teammates sequentially with normal agent calls.
+
+## Stopping Conditions
+
+Stop only if: issue explicitly blocked, build fails after multiple attempts, requires external action.
+
+NOT stopping conditions: lacks description, seems big, unclear approach.
+
+## Output
+
+Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), dogfood QA summary (issues found/fixed), walkthrough artifact summary, commits made, PR URL.
+
+## Review Cadence
+
+Agents accrete bloat when they keep extending stale mental models. Before each
+new sprint or major chunk:
+
+- Re-read the touched modules fully
+- Look for compatibility shims added only to preserve old structure
+- Simplify before adding the next layer

--- a/base/skills/autopilot/glance.md
+++ b/base/skills/autopilot/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Top-level bounded autonomous execution workflow for shaping, building, fixing, polishing, and escalation.

--- a/base/skills/build/SKILL.md
+++ b/base/skills/build/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: build
+description: |
+  Implement GitHub issue with semantic commits.
+  Delegate implementation, review output, ship tested code.
+  Use when: building a feature, implementing an issue, writing code, shipping.
+  Trigger: /build, /implement, "build this", "implement this", "start coding".
+argument-hint: <issue-id>
+---
+
+# /build
+
+Stop planning. Start shipping.
+
+## Role
+
+Senior engineer. Codex is your software engineer.
+
+## Objective
+
+Implement Issue #`$ARGUMENTS`. Ship working, tested, committed code on a feature branch.
+
+## Latitude
+
+- Delegate ALL work to Codex by default (investigation AND implementation)
+- Keep only trivial one-liners where delegation overhead > benefit
+- If Codex goes off-rails, re-delegate with better direction
+- `dogfood`, `agent-browser`, and `browser-use` are available; use them to validate user-facing flows
+
+## LLM-First Implementation Rule (Mandatory)
+
+When building semantic behavior (classification, ranking, triage, intent interpretation, compliance judgment), use LLM-first designs.
+
+Avoid heuristic-only semantic logic (regex ladders, keyword scoring, brittle decision trees) unless the problem is purely syntactic.
+
+Use deterministic logic for strict mechanics only: schema/type validation, exact parsing, safety/permission gates.
+
+## Startup
+
+```bash
+gh issue view $1 --comments
+gh issue edit $1 --remove-label "status/ready" --add-label "status/in-progress" --add-assignee phrazzld
+```
+
+Intent gate before coding:
+- Issue must include `## Product Spec` and `### Intent Contract`.
+- If missing, run `/shape --spec-only $1` to lock intent before implementation.
+
+If on `master`/`main`, branch: `feature/issue-$1` or `fix/issue-$1`.
+
+Before adding new code, read the touched module end-to-end. Do not stack new
+layers on a partial mental model.
+
+## TDD Gate (MANDATORY)
+
+TDD is enforced, not optional.
+
+For each acceptance-criteria chunk:
+1. Write/adjust a behavior test first.
+2. Run targeted test command and confirm failure (RED).
+3. Implement minimal code.
+4. Re-run same targeted test and confirm pass (GREEN).
+5. Refactor with tests still green.
+
+Do not write production implementation before at least one relevant failing test exists.
+
+Tests should target module exports, public interfaces, and observable behavior.
+Avoid mock-heavy "unit tests" that pin internal structure.
+Default against backward-compat scaffolding that exists only to keep current
+tests green. Remove a compatibility layer only if one of these is true:
+- the spec/design explicitly allows the break
+- usage is proven dead or internal-only
+- the user explicitly approved the removal
+
+If evidence is missing, keep the behavior stable and log the cleanup separately.
+
+If tests cannot run (harness/env failure), stop and report blocker. Do not continue implementation unless user explicitly approves bypass.
+
+## Pre-Delegation Checklist
+
+Before delegating any chunk:
+- Existing tests? Warn: "Don't break tests in [file]"
+- Add or replace? Be explicit
+- Pattern to follow? Include reference file path
+- Boundary to test? State the module export/public behavior explicitly
+- Mocks needed? Only for external boundaries and nondeterminism
+- Compatibility path safe to remove? Cite spec, usage evidence, or user approval
+- Quality gates? Include verify command
+
+## Execution Loop
+
+For each logical chunk:
+
+1. **Understand** — Read issue/spec, find existing patterns to follow
+   Re-read touched modules before each major chunk if the design shifted.
+2. **Delegate** — Clear spec + pattern reference + verify command
+3. **Review** — capture RED→GREEN evidence + `git diff --stat && pnpm typecheck && pnpm lint && pnpm test`
+4. **Commit** — `feat: description (#$1)` if tests pass
+5. **Repeat** until complete
+
+Final commit: `feat: complete feature (closes #$1)`
+
+## Multi-Module Mode (Agent Teams)
+
+When the issue spans 3+ distinct modules (e.g., API + UI + tests):
+
+1. Create team with one teammate per module
+2. Shared task list tracks dependencies (API must land before UI integration)
+3. Each teammate runs its own Codex delegation loop on its module
+4. Lead coordinates commit sequencing
+
+Use when: cross-layer features, 3+ modules, clear boundaries.
+Don't use when: single module, sequential dependencies dominate.
+
+## Post-Implementation
+
+1. `code-simplifier:code-simplifier` agent for clarity
+2. `ousterhout` agent for module depth review
+3. Commit simplifications separately
+
+## Visual QA (Frontend Changes)
+
+If the diff touches `app/`, `components/`, or `*.css` files:
+
+1. Run `/visual-qa --fix` with affected routes
+2. Fix P0/P1 issues, commit separately (`fix: visual QA — [description]`)
+3. Note any P2 findings for the PR body
+
+Skip if: pure backend, pure config, no user-facing changes.
+
+## Dogfood QA (User-Facing Changes)
+
+If the issue changes user flows (UI, route handlers, auth, checkout, onboarding, coach UX):
+
+1. Run `/dogfood http://localhost:3000` after implementation and before final ship step
+2. Fix P0/P1 findings, then rerun dogfood on the affected scope
+3. Use `agent-browser` / `browser-use` for targeted repro and verification screenshots
+
+`/dogfood` is a skill command. Do not gate on `dogfood` shell binary availability.
+
+## Issue Comments
+
+Leave breadcrumbs: starting work, decision points, scope creep, completion. Concise, high-context, useful, human.
+Always include the intent reference in completion comment: `Intent Source: #$1`.
+
+## Output
+
+Commits made, files changed, verification status, and explicit TDD evidence:
+- RED command + failing test names
+- GREEN command + passing test names
+
+## Visual Deliverable
+
+After completing the core workflow, generate a visual HTML summary:
+
+1. Read `~/.claude/skills/visualize/prompts/build-progress.md`
+2. Read the template(s) referenced in the prompt
+3. Read `~/.claude/skills/visualize/references/css-patterns.md`
+4. Generate self-contained HTML capturing this session's output
+5. Write to `~/.agent/diagrams/build-{issue}-{date}.html`
+6. Open in browser: `open ~/.agent/diagrams/build-{issue}-{date}.html`
+7. Tell the user the file path
+
+Skip visual output if:
+- The session was trivial (single finding, quick fix)
+- The user explicitly opts out (`--no-visual`)
+- No browser available (SSH session)

--- a/base/skills/build/glance.md
+++ b/base/skills/build/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Standard implementation workflow with TDD and verification discipline for builder sprites.

--- a/base/skills/build/references/tdd-workflow.md
+++ b/base/skills/build/references/tdd-workflow.md
@@ -1,0 +1,66 @@
+# TDD Workflow Reference
+
+## Core Principle
+
+Write the test first. Watch it fail. Write minimal code to pass.
+If you didn't watch the test fail, you don't know if it tests the right thing.
+
+## Red-Green-Refactor
+
+### RED — Write Failing Test
+
+Write one minimal test showing what should happen:
+- One behavior per test
+- Clear name describing behavior
+- Real code (no mocks unless unavoidable)
+
+### Verify RED — Watch It Fail (MANDATORY)
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test fails (not errors)
+- Failure message is expected
+- Fails because feature missing (not typos)
+
+### GREEN — Minimal Code
+
+Write simplest code to pass the test. Don't add features, refactor other code,
+or "improve" beyond the test.
+
+### Verify GREEN — Watch It Pass (MANDATORY)
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm: test passes, other tests still pass, output pristine.
+
+### REFACTOR — Clean Up
+
+After green only: remove duplication, improve names, extract helpers.
+Keep tests green. Don't add behavior.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---------|------|-----|
+| Minimal | One thing | "and" in name? Split it |
+| Clear | Name describes behavior | `test('test1')` |
+| Shows intent | Demonstrates desired API | Obscures what code should do |
+
+## When Stuck
+
+| Problem | Solution |
+|---------|----------|
+| Don't know how to test | Write wished-for API first |
+| Test too complicated | Design too complicated. Simplify interface |
+| Must mock everything | Code too coupled. Use dependency injection |
+| Test setup huge | Extract helpers. Still complex? Simplify design |
+
+## Bug Fix Pattern
+
+Bug found? Write failing test reproducing it. Follow TDD cycle.
+Test proves fix and prevents regression. Never fix bugs without a test.

--- a/base/skills/debug/SKILL.md
+++ b/base/skills/debug/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: debug
+description: |
+  Systematic debugging and investigation for local and production issues.
+  Four-phase protocol: root cause, pattern analysis, hypothesis test, fix.
+  Use for: any bug, test failure, production incident, unexpected behavior,
+  "investigate", "why is this broken", "debug this", "what went wrong".
+argument-hint: <symptoms - error message, unexpected behavior, what's broken>
+---
+
+# /debug
+
+Find root cause. Fix it. Prove it works.
+
+**The user's symptoms:** $ARGUMENTS
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## Rule #1: Config Before Code
+
+External service issues are usually config, not code. Check in order:
+
+1. **Env vars present?** `npx convex env list --prod | grep <SERVICE>` or `vercel env ls`
+2. **Env vars valid?** No trailing whitespace, correct format
+3. **Endpoints reachable?** `curl -I -X POST <webhook_url>`
+4. **Then** examine code
+
+## The Codex First-Draft Pattern
+
+Codex investigates. You review and verify.
+
+```bash
+codex exec "DEBUG: $SYMPTOMS. Reproduce, isolate root cause, propose fix." \
+  --output-last-message /tmp/codex-debug.md 2>/dev/null
+```
+
+## Multi-Hypothesis Mode (Agent Teams)
+
+When >2 plausible root causes and single investigation would anchor on one:
+
+1. Create agent team with 3-5 investigators
+2. Each teammate gets one hypothesis to prove/disprove
+3. Teammates challenge each other's findings
+4. Lead synthesizes consensus root cause
+
+Use when: ambiguous stack trace, multiple services, flaky failures.
+Don't use when: obvious single cause, config issue, simple regression.
+
+## Instrumented Reproduction Loop
+
+When you can't reproduce the bug yourself (auth-gated, mobile, timing-dependent,
+hardware-specific, user-flow-dependent):
+
+```
+INSTRUMENT → USER REPRODUCES → READ LOGS → REFINE → REPEAT
+```
+
+1. **Hypothesize** -- form 2-3 candidate root causes from symptoms
+2. **Instrument** -- add targeted logging that discriminates between hypotheses.
+   Write to a log file the user can share back:
+   ```bash
+   LOG_FILE="${HOME}/Desktop/debug-$(date +%s).log"
+   ```
+   Log at decision points: function entry/exit, branch taken, values at boundaries.
+   Tag each log line with the hypothesis it tests: `[H1] auth token expired: ${token.exp}`
+3. **Hand off** -- tell user: "Reproduce the bug, then say done." Give exact steps if known.
+4. **Read & analyze** -- when user signals done, read the log file. For each hypothesis:
+   - Supported? Design next experiment to narrow further.
+   - Disproved? Eliminate, remove its instrumentation, add new hypothesis.
+   - Insufficient data? Add more targeted logging at the next layer.
+5. **Iterate** -- repeat until one hypothesis survives all evidence. Max 3 rounds —
+   if still ambiguous after 3, escalate to Multi-Hypothesis Mode (agent teams).
+6. **Clean up** -- remove all instrumentation before fixing. Instrumentation is diagnostic,
+   not the fix.
+
+Use when: flaky tests, user-reported bugs you can't trigger, environment-specific issues.
+Don't use when: bug reproduces in your environment (just use Phase 1-4 directly).
+
+## The Four Phases
+
+### Phase 1: Root Cause Investigation
+
+BEFORE attempting ANY fix:
+
+1. **Read error messages carefully** -- full stack traces, line numbers, error codes
+2. **Reproduce consistently** -- exact steps. If not reproducible, gather more data
+3. **Check recent changes** -- `git diff`, `git log --oneline -10`, new deps, config
+4. **Gather evidence in multi-component systems** -- log at each component boundary, run once, identify failing layer
+5. **Trace data flow** -- where does the bad value originate? Trace backward to source
+
+### Phase 2: Pattern Analysis
+
+1. **Find working examples** -- similar working code in same codebase
+2. **Compare completely** -- read reference implementations fully, don't skim
+3. **Identify all differences** -- however small
+4. **Understand dependencies** -- settings, config, environment, assumptions
+
+### Phase 3: Hypothesis and Testing
+
+Scientific method. One experiment at a time. No stacking.
+
+1. **Form single hypothesis** -- "I think X causes Y because Z" (write it down explicitly)
+2. **Design experiment** -- What will prove or disprove this? Justify: why this experiment,
+   what will it tell us? Smallest possible change, one variable only.
+3. **Run experiment** -- observe result
+4. **Evaluate**:
+   - **Disproved** → eliminate this cause, form NEW hypothesis. This step matters —
+     ruling things out is progress, not failure.
+   - **Supported** → design next experiment to increase confidence. Not proven until
+     you can explain the full causal chain.
+   - **Ambiguous** → experiment was too broad. Narrow scope and rerun.
+5. **Repeat** until root cause is proven or confidence is high enough to act
+
+Never skip justification. "Just try X" is a red flag — if you can't explain what
+you'll learn from an experiment, you don't understand the problem yet.
+
+### Phase 4: Implementation
+
+1. **Write failing test first** -- reproduce the bug in a test before any fix
+2. **Verify test fails for the right reason** -- not syntax/import errors
+3. **Implement single fix** -- address root cause. ONE change at a time.
+4. **Verify** -- test passes, no other tests broken, issue resolved.
+5. **If 3+ fixes failed** -- STOP. Question the architecture. See `references/systematic-debugging.md`.
+
+## Root Cause Discipline
+
+For each hypothesis, categorize:
+- **ROOT**: Fixing this removes the fundamental cause
+- **SYMPTOM**: Fixing this masks an underlying issue
+
+Post-fix question: "If we revert in 6 months, does the problem return?"
+
+## Demand Observable Proof
+
+Before declaring "fixed", show:
+- Log entry proving the fix worked
+- Metric that changed
+- Database state confirming resolution
+
+Mark as **UNVERIFIED** until observables confirm.
+
+## Classification
+
+| Type | Signals | Approach |
+|------|---------|----------|
+| Test failure | Assertion error | Read test, trace expectation |
+| Runtime error | Exception, crash | Stack trace -> source -> state |
+| Type error | TS complaint | Read error, check types |
+| Build failure | Bundler error | Check deps, config |
+| Behavior mismatch | "Does Y, should do X" | Trace code path |
+| Performance | Slow, timeout | Add timing instrumentation |
+| Production incident | Sentry, alerts | Create INCIDENT.md, timeline |
+
+## Investigation Work Log (Production Issues)
+
+For non-trivial production issues, create `INCIDENT-{timestamp}.md`:
+- **Timeline**: What happened when (UTC)
+- **Evidence**: Logs, metrics, configs checked
+- **Hypotheses**: Ranked by likelihood
+- **Actions**: What tried, what learned
+- **Root cause**: When found
+- **Fix**: What resolved it
+
+## Bounded Shell Output (MANDATORY)
+
+- Size first: `wc -l <file>` or `du -h`
+- Read windows: `sed -n '1,120p'`; jump with `rg -n`
+- Cap logs: `head -n 200`, `tail -n 200`
+- Abort after 20s without signal; narrow scope, rerun
+
+## Red Flags -- STOP and Return to Phase 1
+
+- "Quick fix for now, investigate later"
+- "Just try changing X and see"
+- Multiple simultaneous changes
+- Proposing solutions before tracing data flow
+- "One more fix attempt" (when 2+ already tried)
+- Each fix reveals new problem in different place
+
+## Toolkit
+
+- **Sentry MCP**: Production error context, stack traces
+- **Git**: bisect, blame, recent deploys
+- **Observability**: vercel/convex logs, sentry-cli
+- **Codex**: Delegate investigation
+- **Gemini**: Web-grounded research, similar issues
+- **Thinktank**: Multi-model hypothesis validation
+
+## Output
+
+- **Root cause**: What's actually wrong
+- **Fix**: How it was resolved
+- **Verification**: Observable proof it works
+
+## References
+
+- `references/systematic-debugging.md` -- Full four-phase protocol with examples
+- `references/investigation-protocol.md` -- Production incident investigation
+
+## Related
+
+- `/triage` -- Full incident lifecycle (triage through postmortem)
+- `/test-coverage` -- Test audit and coverage analysis

--- a/base/skills/debug/glance.md
+++ b/base/skills/debug/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Systematic failure investigation and root-cause classification workflow.

--- a/base/skills/debug/references/investigation-protocol.md
+++ b/base/skills/debug/references/investigation-protocol.md
@@ -1,0 +1,72 @@
+# Production Investigation Protocol
+
+Absorbed from the `investigate` skill.
+
+## SRE Investigation Approach
+
+### Config Before Code Checklist
+
+1. Env vars present? `npx convex env list --prod`, `vercel env ls`
+2. Env vars valid? No trailing whitespace, correct format (sk_*, whsec_*)
+3. Endpoints reachable? `curl -I -X POST <webhook_url>`
+4. Then examine code
+
+### Toolkit
+
+- **Observability**: sentry-cli, npx convex, vercel
+- **Git**: Recent deploys, changes, bisect
+- **Gemini CLI**: Web-grounded research, hypothesis generation
+- **Thinktank**: Multi-model validation on hypotheses
+
+### Multi-Hypothesis Mode (Agent Teams)
+
+When >2 plausible root causes:
+
+1. Create agent team with 3-5 investigators
+2. Each teammate gets one hypothesis to prove/disprove
+3. Teammates challenge each other's findings
+4. Lead synthesizes consensus root cause into incident doc
+
+### Observable Proof Requirements
+
+Before declaring "fixed":
+- Log entry that proves the fix worked
+- Metric that changed (subscription status, webhook delivery)
+- Database state that confirms resolution
+
+Mark investigation as UNVERIFIED until observables confirm.
+
+### INCIDENT.md Work Log Format
+
+```markdown
+## Timeline
+- HH:MM UTC: [event]
+
+## Evidence
+- [log/metric/config checked]
+
+## Hypotheses
+1. [hypothesis] - likelihood: [high/medium/low]
+
+## Actions
+- [what tried] -> [what learned]
+
+## Root Cause
+[when found]
+
+## Fix
+[what resolved it]
+
+## Postmortem
+- What went wrong
+- Lessons learned
+- Follow-ups
+```
+
+### Sentry Integration
+
+When issue body contains Sentry context:
+- Extract stack trace, file paths, breadcrumbs
+- Use Sentry MCP for full event details
+- Cross-reference affected files with `git log` for causal commit
+- Include Sentry issue link in PR for auto-resolution on deploy

--- a/base/skills/debug/references/systematic-debugging.md
+++ b/base/skills/debug/references/systematic-debugging.md
@@ -1,0 +1,112 @@
+# Systematic Debugging Protocol
+
+Absorbed from the `systematic-debugging` skill.
+
+## Core Principle
+
+Random fixes waste time and create new bugs. ALWAYS find root cause before
+attempting fixes. Symptom fixes are failure.
+
+## When to Use
+
+Use for ANY technical issue: test failures, production bugs, unexpected behavior,
+performance problems, build failures, integration issues.
+
+Use ESPECIALLY when:
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- You've already tried multiple fixes
+- You don't fully understand the issue
+
+## Phase 1: Root Cause Investigation (Detail)
+
+### Multi-Component Evidence Gathering
+
+WHEN system has multiple components (CI -> build -> signing, API -> service -> database):
+
+BEFORE proposing fixes, add diagnostic instrumentation:
+
+```
+For EACH component boundary:
+  - Log what data enters component
+  - Log what data exits component
+  - Verify environment/config propagation
+  - Check state at each layer
+
+Run once to gather evidence showing WHERE it breaks
+THEN analyze evidence to identify failing component
+THEN investigate that specific component
+```
+
+### Data Flow Tracing
+
+WHEN error is deep in call stack:
+
+- Where does bad value originate?
+- What called this with bad value?
+- Keep tracing up until you find the source
+- Fix at source, not at symptom
+
+## Phase 4.5: Architecture Check (After 3+ Failed Fixes)
+
+Pattern indicating architectural problem:
+- Each fix reveals new shared state/coupling/problem in different place
+- Fixes require "massive refactoring" to implement
+- Each fix creates new symptoms elsewhere
+
+STOP and question fundamentals:
+- Is this pattern fundamentally sound?
+- Are we "sticking with it through sheer inertia"?
+- Should we refactor architecture vs. continue fixing symptoms?
+
+Discuss with user before attempting more fixes. This is NOT a failed
+hypothesis -- this is a wrong architecture.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too |
+| "Emergency, no time" | Systematic is FASTER than guess-and-check |
+| "Just try this first" | First fix sets the pattern |
+| "Multiple fixes at once saves time" | Can't isolate what worked |
+| "I see the problem, let me fix it" | Seeing symptoms != understanding root cause |
+| "One more fix attempt" (after 2+) | 3+ failures = architectural problem |
+
+## The Scientific Method (One Experiment at a Time)
+
+Debugging is empirical science. Apply the method rigorously:
+
+1. **Examine** what you know about the software's behavior, construct a hypothesis
+   about what might cause it.
+2. **Design an experiment** that tests the hypothesis. Justify: why this experiment,
+   what will it tell us? If you can't justify it, you don't understand the problem.
+3. **If disproved** — new hypothesis. Ruling things out is progress. This step
+   eliminates unrelated issues and narrows the search space.
+4. **If supported** — keep experimenting until either disproved or proven with high
+   confidence. "Supported" is not "proven."
+
+**One experiment at a time.** Multiple simultaneous changes make it impossible to
+attribute results. If you changed two things and the bug disappeared, you don't
+know which fixed it — and the other change may introduce a new bug later.
+
+## Instrumented Reproduction
+
+When the bug requires human reproduction (can't trigger programmatically):
+
+```
+Agent instruments → User reproduces → Agent reads logs → Refine → Repeat
+```
+
+Key rules:
+- Tag log lines with the hypothesis they test: `[H1]`, `[H2]`
+- Log at decision points, not everywhere (targeted, not shotgun)
+- Write to a single file the user can find easily (`~/Desktop/debug-*.log`)
+- Max 3 instrumentation rounds — if still ambiguous, escalate
+- ALWAYS clean up instrumentation after diagnosis
+
+## Supporting Techniques
+
+- **Root cause tracing**: Trace bugs backward through call stack
+- **Defense in depth**: Add validation at multiple layers after finding root cause
+- **Condition-based waiting**: Replace arbitrary timeouts with condition polling

--- a/base/skills/glance.md
+++ b/base/skills/glance.md
@@ -1,17 +1,37 @@
 ### Technical Overview: Bitterblossom Skills Directory
 
-The `/base/skills` directory stores Bitterblossom-specific runbooks and guardrails for work done through the current transport surface. These skills are repo-local instructions, not a second transport API.
+The `/base/skills` directory now has two layers:
 
-### Architecture and Workflow
-Each subdirectory is a small domain-specific guide. The Bitterblossom-specific skills focus on:
-1.  **Dispatch readiness:** using `bb status` and `bb dispatch ... --dry-run`.
-2.  **Runtime inspection:** using `bb logs`, `bb status`, and direct workspace checks when needed.
-3.  **Recovery:** using `bb kill` to clear stale Ralph or Claude processes.
-4.  **Policy guidance:** keeping repo-specific conventions close to the work.
+1. **Imported autonomy skills** vendored from `phrazzld/agent-skills` so Bitterblossom can ship a version-pinned, testable skill surface to managed sprites.
+2. **Bitterblossom-specific runtime skills** that stay close to the `bb` transport and conductor operating model.
+
+These are repo-local runtime assets, not a second transport API.
+
+### Imported autonomy skills
+- `autopilot` — bounded autonomous execution workflow
+- `shape` — turn rough work into a clearer executable spec
+- `build` — implementation workflow with verification discipline
+- `pr` — PR creation and intent/verification discipline
+- `pr-walkthrough` — structured PR inspection and explanation
+- `debug` — systematic investigation and root-cause classification
+- `pr-fix` — bounded PR remediation for feedback and CI failures
+- `pr-polish` — final merge-readiness and cleanup pass
+
+`simplify` and `ux-polish` are still pending as standalone imports or repo-local wrappers.
+
+### Bitterblossom-specific skills
+- `bitterblossom-dispatch` — dry-run probing plus prompt dispatch through `bb`
+- `bitterblossom-monitoring` — monitoring, status checks, and recovery triage
+
+### Provisioning contract
+- `bb setup` copies everything under `base/skills/` onto the sprite under `/home/sprite/.claude/skills/`.
+- Imported skills are version-pinned by the Bitterblossom repo state, not by ad hoc sprite drift.
+- Sprite personas advertise role-specific skill packs so the same imported skill surface can be specialized by worker type.
 
 ### Key File Roles
 - `SKILL.md`: the manifest and runbook for each skill.
 - `glance.md`: a short local summary for fast retrieval.
+- `references/`: linked supporting material that should travel with imported skills.
 - `.env.bb`: repo-level environment bootstrap used by dispatch and monitoring workflows.
 
 ### Dependencies and Technical Constraints

--- a/base/skills/pr-fix/SKILL.md
+++ b/base/skills/pr-fix/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: pr-fix
+description: |
+  Unblock a PR: resolve conflicts, fix CI, self-review, address feedback, refactor.
+  One command takes a blocked PR to green and mergeable.
+  Use when: PR blocked, CI red, unaddressed reviews, code review needed, refactoring.
+  Trigger: /pr-fix, /fix-ci, /review-branch, /review-and-fix, /respond, /address-review, /refactor.
+argument-hint: "[PR-number]"
+---
+
+# /pr-fix
+
+One command takes a blocked PR to green.
+
+## Role
+
+Senior engineer unblocking a PR. Methodical, not reactive. Each phase resolves a class of blocker in dependency order.
+
+## Objective
+
+Take PR `$ARGUMENTS` (or current branch's PR) from blocked to mergeable: no conflicts, CI green, reviews addressed, and **all open conversations on the PR resolved**.
+`dogfood`, `agent-browser`, and `browser-use` are available in this environment for user-flow verification.
+
+## Dependency Order
+
+Conflicts -> CI -> Self-Review -> Reviews. Can't run CI on conflicted code. Can't review broken code. Can't address others' reviews before fixing your own issues.
+
+## LLM-First Implementation Rule (Mandatory)
+
+For semantic fixes (classification/triage logic, intent inference, severity mapping, reviewer synthesis), prefer LLM reasoning over deterministic heuristics.
+
+Do not add heuristic-only semantic classifiers (regex-only labels, keyword score trees) unless the task is strictly syntactic.
+
+Keep deterministic code for mechanical guarantees only: schema contracts, exact format parsing, permissions/safety enforcement.
+
+## Bounded Shell Output (MANDATORY)
+
+- Size before detail: counts/metadata first
+- Never print unbounded logs/comments
+- Add explicit bounds: `--limit`, `head -n`, `tail -n`, `per_page`
+- If no useful signal in 20s: abort, narrow, rerun
+- Use `~/.claude/scripts/safe-read.sh` for large local files
+
+## Workflow
+
+### 1. Assess
+
+```bash
+gh pr view $PR --json number,title,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup
+gh pr checks $PR --json name,state,startedAt,completedAt,link
+gh pr view $PR --json body --jq '.body | split("\n")[:80] | join("\n")'
+```
+
+Read PR description and linked issue. Understand **what this PR is trying to do** — semantic context drives conflict resolution and review decisions.
+
+Fetch latest base:
+
+```bash
+BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
+git fetch origin "$BASE"
+```
+
+Determine blockers: conflicts? CI failures? pending reviews? Build a checklist.
+
+### 2. Resolve Conflicts
+
+**Skip if**: `mergeable != CONFLICTING`
+
+Rebase onto base branch:
+
+```bash
+git rebase "origin/$BASE"
+```
+
+When conflicts arise, resolve **semantically based on PR purpose**, not mechanically:
+
+- Read both sides. Understand intent.
+- Preserve the PR's behavioral changes. Integrate upstream structural changes.
+- Reference `git-mastery/references/conflict-resolution.md` for strategies.
+- Never blindly accept ours/theirs.
+
+After resolution, verify locally:
+
+```bash
+git rebase --continue
+# Run project's test/typecheck commands
+```
+
+### 3. Fix CI
+
+**Skip if**: all checks passing.
+
+Push current state and diagnose CI failures:
+
+```bash
+git push --force-with-lease
+gh run list --limit 5 --json databaseId,workflowName,status,conclusion,headBranch
+gh run view <run-id> --log-failed | tail -n 200
+```
+
+Classify failure type (Code Issue / Infrastructure / Flaky / Config), identify root cause,
+fix the code. See `references/fix-ci.md` for the full CI diagnosis procedure.
+
+If CI fixes create new conflicts: return to Phase 2 (max 2 full-pipeline retries).
+
+### 4. Self-Review the Diff
+
+**Always run this phase.** CI passing does not mean the code is good. Linters catch syntax; this catches logic.
+
+Review the full diff against base:
+
+```bash
+BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
+git diff "origin/$BASE"...HEAD
+```
+
+For each changed file, check for:
+
+- **Dead code**: unused variables (especially `_`-prefixed params that signal "I know this is unused"), unreachable branches, useMemo/useCallback with values never read
+- **Logic bugs**: loops that always break on first iteration, conditions that are always true/false, off-by-one errors
+- **Wasted computation**: expensive operations whose results are discarded, duplicate work (e.g., running the same test suite twice in CI)
+- **Wrong log levels**: success messages on stderr (`console.warn`/`console.error`), debug output on stdout in production
+- **Semantic mismatches**: function names that don't match behavior, comments that contradict code
+
+Fix every issue found. Run typecheck + tests after fixes. Commit before proceeding.
+
+This phase catches what CI cannot: code that compiles and passes tests but is wrong, wasteful, or misleading. A PR that's "green" but ships dead code or wasted computation is not actually unblocked — it's shipping tech debt.
+
+### 5. Address Reviews
+
+**Exit criterion for this phase:** the PR has zero unresolved review threads and zero remaining actionable open conversations. Do not call the PR unblocked while any conversation is still open.
+
+**Skip condition**: ALL THREE of these are zero: unresolved review threads, unreplied review comments, AND unaddressed bot issue comments. Use the queries below — never rely on `reviewDecision` alone or prior "PR Unblocked" summary comments.
+
+```bash
+OWNER="$(gh repo view --json owner --jq .owner.login)"
+REPO="$(gh repo view --json name --jq .name)"
+
+# Count unresolved review threads (inline comments)
+UNRESOLVED_THREADS="$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $number:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviewThreads(first:100){nodes{isResolved}}
+      }
+    }
+  }' -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')"
+```
+
+#### 5a. Bot issue comments (MANDATORY)
+
+**Why this exists:** Some bot reviewers (Claude, CodeRabbit, etc.) post review feedback as **issue comments** (`/issues/$PR/comments`), not pull request review comments (`/pulls/$PR/comments`). These are a completely different API endpoint and are invisible to the GraphQL `reviewThreads` query. Missing them means missing actionable review feedback.
+
+```bash
+# Fetch bot issue comments — these are NOT in reviewThreads or PR comments
+BOT_COMMENTS="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments?per_page=100" --paginate \
+  --jq '[.[] | select(.user.type == "Bot") | {id, user: .user.login, body: .body}]')"
+```
+
+Filter for comments that contain actionable review feedback (code suggestions, bug findings, security concerns). Ignore:
+- Status/summary comments (CI reports, merge readiness checks)
+- Comments you've already replied to with fixes
+- Informational comments with no action items
+
+For each bot comment with actionable findings:
+1. **Read the FULL comment body** — no truncation
+2. **Extract each finding** — bots typically number them or use headers
+3. **Read the current file** to check if already addressed
+4. **Fix or defer** each finding (same as review comments below)
+5. **Reply to the comment** with resolution status for each finding
+
+If an `Auto PR Feedback Digest` exists in context, use it only as triage seed. Always refresh live GitHub data before final replies.
+
+#### 5b. Review comments and threads
+
+**Independent verification (MANDATORY)**
+
+**Never trust prior session comments, "PR Unblocked" summaries, or claims that feedback was addressed.** For EVERY open review comment:
+
+1. **Read the FULL comment body** — no truncation. Use the GitHub API without `.body[:N]` limits.
+2. **Read the current file at the referenced line** to verify the fix is actually present.
+3. **Reply directly on the comment thread** with the specific commit SHA and line confirming the fix. An open thread without a reply = unaddressed, regardless of what a summary comment claims.
+
+```bash
+# Fetch ALL review comments with full bodies — never truncate
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments?per_page=100" --paginate \
+  --jq '.[] | {id, user: .user.login, path, line, body, in_reply_to_id}'
+```
+
+For each comment without a reply from this PR's author:
+- If **already fixed in code**: reply with commit SHA + current line reference confirming the fix
+- If **needs fixing**: fix it, then reply with commit SHA
+- If **deferred**: reply with follow-up issue number
+- If **declined**: reply with public reasoning
+
+Bot feedback (CodeRabbit, Gemini, Codex, and other reviewer bots) gets the same treatment as human feedback.
+
+#### Execution
+
+1. **Categorize feedback** — Sort into critical / in-scope / follow-up / declined. Post transparent assessment to PR. Reviewer feedback CAN be declined with public reasoning. See `references/respond.md` for the full transparency workflow.
+
+2. **Classify and set severity** — For every actionable comment, record:
+   - Classification: `bug | risk | style | question`
+   - Severity: `critical | high | medium | low`
+   - Decision: `fix now | defer | reject` with reason
+   Policy:
+   - `critical/high`: fix now by default
+   - `medium`: fix now or open follow-up issue with rationale
+   - `low`: optional
+
+3. **TDD fixes** — For critical and in-scope items: write failing test, fix, verify pass, commit. Create GitHub issues for follow-up items. See `references/address-review.md` for the TDD fix procedure and `references/scope-rules.md` for in-scope vs out-of-scope guidance.
+
+4. **Reply to every open thread** — use `gh api repos/$OWNER/$REPO/pulls/$PR/comments/$ID/replies -f body='...'` so the thread shows addressed.
+   Reply format:
+   - `Classification: <bug|risk|style|question>`
+   - `Severity: <critical|high|medium|low>`
+   - `Decision: <fix now|defer|reject>. <reason>`
+   - `Change: <what changed>`
+   - `Verification: <tests/checks run or N/A>`
+
+5. **Resolve every thread via GraphQL** — Replies alone do NOT resolve threads. Non-outdated comments stay visible as open issues to reviewers even after fixing the code and replying. You MUST resolve them. The phase is incomplete until the unresolved thread count is `0`:
+
+```bash
+# Get unresolved thread IDs
+gh api graphql -F owner="$OWNER" -F repo="$REPO" -F number=$PR -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved isOutdated }
+        }
+      }
+    }
+  }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id'
+
+# Resolve each thread
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+```
+
+Additive commits do NOT make comments outdated. Only changes to the diff hunk a comment is attached to trigger outdating. Resolve explicitly.
+
+### 6. Verify and Push
+
+```bash
+git push --force-with-lease
+```
+
+Watch checks. If a phase-4 or phase-5 fix broke CI, re-run the CI diagnosis (Phase 3) again (count toward 2-retry max).
+
+If 2 full retries exhausted: stop, summarize state, ask user.
+
+### 6b. Dogfood + Browser Flow Verification (MANDATORY for user-facing diffs)
+
+If fixes touch UI or user behavior (`app/`, `components/`, styles, route handlers, auth, checkout, onboarding):
+
+1. Run `/dogfood http://localhost:3000` before calling PR mergeable
+2. Fix P0/P1 findings, rerun on affected scope
+3. Use `agent-browser` / `browser-use` for targeted repro, screenshot evidence, and regression checks
+
+`/dogfood` is a skill command, not a shell binary probe.
+
+### 7. Update PR Description with Before / After + Walkthrough
+
+Edit the PR body to preserve the richer `/pr` structure and update the relevant sections documenting the fix.
+Refresh the `## Walkthrough` section too when the fix changes the merge case, evidence, or protecting check:
+
+```bash
+# Get current body, refresh the affected sections
+gh pr edit $PR --body "$(updated body)"
+```
+
+Before editing, read `../pr/references/pr-body-template.md`.
+
+Do not only append text. Refresh:
+- `Why This Matters` if the fix changed the PR's significance
+- `Trade-offs / Risks` if the fix changed reviewer concerns
+- `What Changed` diagrams if the final implementation shape drifted
+- `Before / After` evidence for the blocked vs unblocked state
+
+**Text (MANDATORY)**: Describe the blocked state (before) and the unblocked state (after).
+Example: "Before: CI failing on type error in auth module. After: Types corrected, CI green."
+
+**Screenshots (when applicable)**: Capture before/after for any visible change — CI status pages, error output, UI changes from review fixes. Use `![before](url)` / `![after](url)`.
+
+Skip screenshots only when all fixes are purely internal (conflict resolution with no behavior change, CI config fixes with no visible output difference).
+
+If the fixes materially change what reviewers should see, rerun `/pr-walkthrough` and update:
+
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
+
+### 8. Signal
+
+Post summary comment on PR:
+
+```bash
+gh pr comment $PR --body "$(cat <<'EOF'
+## PR Unblocked
+
+**Conflicts**: [resolved N files / none]
+**CI**: [green / was: failure type]
+**Reviews**: [N fixed, N deferred (#issue), N declined (see above)]
+
+Ready for re-review.
+EOF
+)"
+```
+
+## Retry Policy
+
+Max 2 full-pipeline retries when fixing one phase breaks another. After 2: stop and escalate to user with clear status.
+
+## Anti-Patterns
+
+- Mechanical ours/theirs conflict resolution
+- Pushing without local verification
+- Silently ignoring review feedback
+- Retrying CI without understanding failures
+- Fixing review comments that should be declined
+- **Trusting prior "PR Unblocked" or summary comments** — always verify each comment against current code independently. A previous session claiming "fixed" means nothing until you read the file yourself.
+- **Leaving review threads without direct replies** — an open thread with no reply = unaddressed, even if the code is fixed. Reviewers can't see that you checked.
+- **Truncating comment bodies** — never use `.body[:N]` when fetching review comments. The actionable detail is often at the end of long comments.
+- **Replying without resolving** — a reply on a thread does NOT resolve it. Non-outdated threads with replies still show as open conversations. Use `resolveReviewThread` GraphQL mutation after replying.
+- **NEVER lowering quality gates to pass CI** — coverage thresholds, lint rules, type strictness, security gates. If a gate fails, write tests/code to meet it. Moving the goalpost is not a fix. This is an absolute, non-negotiable rule.
+- **Skipping self-review because CI is green** — CI catches syntax and test failures. Dead code, wasted computation, wrong log levels, and semantic mismatches all pass CI. Review the diff yourself before declaring unblocked.
+- **Only checking review threads and PR comments** — bot reviewers (Claude, CodeRabbit, etc.) often post feedback as issue comments (`/issues/$PR/comments`), not PR review comments (`/pulls/$PR/comments`). These are different API endpoints. You MUST check all three: GraphQL reviewThreads, REST PR comments, AND REST issue comments.
+
+## Output
+
+Summary: blockers found, phases executed, conflicts resolved, CI fixes applied, reviews addressed/deferred/declined, final check status, and explicit confirmation that open conversation count is zero.
+
+## Absorbed Skills (References)
+
+These skills are consolidated here. Their full content is in `references/`:
+
+- **fix-ci** — [references/fix-ci.md](./references/fix-ci.md) — CI failure classification and resolution
+- **review-branch** — [references/review-branch.md](./references/review-branch.md) — Multi-reviewer code review orchestration
+- **code-review-checklist** — [references/code-review-checklist.md](./references/code-review-checklist.md) — Checklist for purpose, quality, correctness, security, performance, testing
+- **respond** — [references/respond.md](./references/respond.md) — Transparent PR review feedback response workflow
+- **address-review** — [references/address-review.md](./references/address-review.md) — TDD-based review finding resolution
+- **refactor** — [references/refactor.md](./references/refactor.md) — Two-pass code refinement (clarity then architecture)
+- **reviewer-prompts** — [references/reviewer-prompts.md](./references/reviewer-prompts.md) — Prompt templates for AI reviewers
+- **scope-rules** — [references/scope-rules.md](./references/scope-rules.md) — In-scope vs out-of-scope guidance
+- **tdd-fix-pattern** — [references/tdd-fix-pattern.md](./references/tdd-fix-pattern.md) — TDD fix workflow
+- **deferred-issue** — [references/deferred-issue.md](./references/deferred-issue.md) — Template for deferred GitHub issues

--- a/base/skills/pr-fix/glance.md
+++ b/base/skills/pr-fix/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Bounded PR remediation workflow for review feedback, CI failures, and targeted refactors.

--- a/base/skills/pr-fix/references/address-review.md
+++ b/base/skills/pr-fix/references/address-review.md
@@ -1,0 +1,143 @@
+
+# Address Review Findings
+
+Systematically work through code review findings: TDD for in-scope fixes, GitHub issues for out-of-scope items.
+
+## Usage
+
+```
+/address-review              # Accept review from previous context
+/address-review ./review.md  # From file
+/address-review strict       # Only Critical items
+/address-review verify       # Re-review after fixes
+```
+
+## Bounded Shell Output (MANDATORY)
+
+- For large review files: `wc -l` then `~/.claude/scripts/safe-read.sh <file> 1 120`
+- Prefer `rg -n` over full-file dumps
+- Keep verification output concise; include summary + failures only
+
+## Workflow
+
+### 1. Parse Findings
+
+Accept review output (from `/review-branch` or similar). Extract:
+- File locations (`file.ts:42`)
+- Severity (Critical, Important, Suggestion)
+- Issue description
+- Recommended fix
+
+### 2. Categorize: In-Scope vs Out-of-Scope
+
+Reference `references/scope-rules.md` for guidance.
+
+**In-scope** (fix now with TDD):
+- File in diff
+- Critical or Important severity
+- Localized fix (doesn't require architectural changes)
+
+**Out-of-scope** (create GitHub issue):
+- Pre-existing issues surfaced by review
+- Suggestions / nice-to-haves
+- Architectural changes requiring broader discussion
+- Systemic issues touching many files
+
+**When ambiguous:** Confirm with user via AskUserQuestion.
+
+### 3. Fix In-Scope Items (TDD)
+
+For each in-scope item, follow TDD:
+
+1. **Write failing test** that exposes the issue
+2. **Verify test fails** for the right reason
+3. **Fix the code** minimally
+4. **Verify test passes**
+5. **Commit** with conventional format: `fix(scope): description`
+
+Reference `references/tdd-fix-pattern.md` for the detailed workflow.
+
+### 4. Create Issues for Out-of-Scope
+
+For each out-of-scope item:
+
+```bash
+gh issue create \
+  --title "[Type] Brief description" \
+  --body "$(cat <<'EOF'
+## Origin
+
+Surfaced during code review of PR #[number] / branch `[branch-name]`
+
+## Finding
+
+[Quote the reviewer's finding]
+
+## Recommended Action
+
+[What should be done]
+
+## Priority
+
+[Critical/Important/Suggestion] — [Why deferred]
+
+---
+*Created by /address-review from [reviewer] finding*
+EOF
+)"
+```
+
+Reference `templates/deferred-issue.md` for the template.
+
+### 5. Verify
+
+After all fixes:
+
+```bash
+# Run quality gates
+pnpm typecheck && pnpm lint && pnpm test
+
+# Show what was fixed
+git log --oneline main..HEAD
+```
+
+## Output Format
+
+```markdown
+## Address Review Summary
+
+### Fixed (In-Scope)
+| Finding | Commit | Test Added |
+|---------|--------|------------|
+| `file.ts:42` — [issue] | abc1234 | Yes |
+
+### Deferred (Out-of-Scope)
+| Finding | Issue | Reason |
+|---------|-------|--------|
+| [issue] | #123 | Pre-existing / Architectural |
+
+### Quality Gates
+- [ ] `pnpm typecheck` — ✅
+- [ ] `pnpm lint` — ✅
+- [ ] `pnpm test` — ✅ (X passed, Y new)
+
+### Next Steps
+- [ ] Run `/review-branch verify` to confirm all issues addressed
+- [ ] Create PR with `/pr`
+```
+
+## Modes
+
+**Default:** Address Critical + Important items. Create issues for Suggestions.
+
+**`strict`:** Only address Critical items. Everything else becomes issues.
+
+**`verify`:** Re-run `/review-branch` after fixes to confirm resolution.
+
+## Philosophy
+
+**No finding gets lost.** Every review item either:
+1. Gets fixed with a test proving it's fixed
+2. Becomes a tracked GitHub issue
+
+This ensures compounding engineering: reviews produce permanent improvements, not just temporary fixes.

--- a/base/skills/pr-fix/references/code-review-checklist.md
+++ b/base/skills/pr-fix/references/code-review-checklist.md
@@ -1,0 +1,390 @@
+
+# Code Review Checklist
+
+Fast, focused checklist for reviewing code changes. Designed to complete in <5 minutes for typical PRs.
+
+## Review Mindset
+
+Before reviewing, adopt the right lens:
+
+**The Ousterhout Question**: Does this change fight complexity or add to it?
+- Hunt for shallow modules (interface ≈ implementation)
+- Hunt for information leakage
+- Hunt for generic names (Manager, Helper, Util, Handler)
+- Hunt for pass-through methods
+
+**The Torvalds Standard**: "The most important thing is to not make the code worse."
+- Good code handles all cases uniformly
+- Eliminate edge cases through better abstractions
+- If nesting is deep, the structure is wrong
+
+**CRITICAL**: You are capable of detecting subtle design flaws that automated tools miss. Don't just check syntax—evaluate whether this change makes the codebase easier or harder to understand and modify. That's the real job.
+
+## How to Use This Checklist
+
+- **For PR reviews:** Work through categories, flag issues, suggest improvements
+- **For self-review:** Before requesting review, check your own changes
+- **For pairing:** Use as discussion guide during pair programming
+
+**Not every item applies to every PR.** Use judgment. Small fixes may skip entire categories.
+
+---
+
+## 1. Purpose & Design
+
+**Does this change solve the right problem in the right way?**
+
+- [ ] Does this change solve the stated problem?
+- [ ] Is the approach appropriate for the problem scope?
+- [ ] Are there simpler alternatives that were considered?
+- [ ] Does this fit with existing architecture patterns?
+
+**Red flags:**
+- Over-engineered solution for simple problem
+- Doesn't address root cause (treats symptom)
+- Introduces new pattern when existing one would work
+
+---
+
+## 2. Code Quality
+
+**Is the code readable, maintainable, and simple?**
+
+- [ ] Are names clear and intention-revealing?
+- [ ] Is the code self-documenting (minimal comments needed)?
+- [ ] Are functions/modules focused on single responsibility?
+- [ ] Is complexity managed (no deep nesting, long functions)?
+- [ ] Are magic numbers/strings extracted to constants?
+
+**Examples:**
+
+❌ **Poor naming:**
+```typescript
+function proc(d: any) { ... }
+const x = getUserData()
+```
+
+✅ **Clear naming:**
+```typescript
+function processPayment(data: PaymentData) { ... }
+const activeUsers = getUserData()
+```
+
+❌ **Deep nesting:**
+```typescript
+if (user) {
+  if (user.isActive) {
+    if (user.hasPermission) {
+      // deeply nested logic
+    }
+  }
+}
+```
+
+✅ **Guard clauses:**
+```typescript
+if (!user) return
+if (!user.isActive) return
+if (!user.hasPermission) return
+// flat logic
+```
+
+**Red flags:**
+- Generic names (Manager, Helper, Util, Handler)
+- Functions over 50 lines
+- Nesting deeper than 3 levels
+- Unclear variable purposes
+
+---
+
+## 3. Correctness
+
+**Does the code work correctly under all conditions?**
+
+- [ ] Are edge cases handled (null, empty, boundary values)?
+- [ ] Is error handling appropriate and informative?
+- [ ] Are async operations handled correctly (race conditions, timeouts)?
+- [ ] Are types used correctly (no unsafe casts, `any` abuse)?
+- [ ] Does the logic match the requirements?
+
+**Edge cases to check:**
+- Empty arrays/strings
+- Null/undefined values
+- Boundary values (0, -1, MAX_INT)
+- Concurrent operations
+- Network failures
+
+**Examples:**
+
+❌ **Missing edge case:**
+```typescript
+function getFirstUser(users: User[]) {
+  return users[0].name  // Crashes on empty array
+}
+```
+
+✅ **Edge case handled:**
+```typescript
+function getFirstUser(users: User[]) {
+  return users[0]?.name ?? 'No users'
+}
+```
+
+❌ **Type abuse:**
+```typescript
+const data: any = await fetchData()
+const userId = (data as User).id  // Unsafe
+```
+
+✅ **Type safety:**
+```typescript
+const data = await fetchData()
+if (!isUser(data)) throw new Error('Invalid user data')
+const userId = data.id
+```
+
+**Red flags:**
+- No null checks
+- Ignored promise rejections
+- Type assertions without validation
+- Assumes happy path only
+
+---
+
+## 4. Security
+
+**Are there security vulnerabilities?**
+
+- [ ] Is user input validated and sanitized?
+- [ ] Are secrets/credentials handled securely (no hardcoding)?
+- [ ] Is authentication/authorization checked where needed?
+- [ ] Are SQL/command injection risks mitigated?
+
+**Common vulnerabilities:**
+
+❌ **SQL injection:**
+```typescript
+db.query(`SELECT * FROM users WHERE id = ${userId}`)
+```
+
+✅ **Parameterized query:**
+```typescript
+db.query('SELECT * FROM users WHERE id = $1', [userId])
+```
+
+❌ **Hardcoded secret:**
+```typescript
+const API_KEY = 'sk_live_abc123...'
+```
+
+✅ **Environment variable:**
+```typescript
+const API_KEY = process.env.API_KEY
+if (!API_KEY) throw new Error('API_KEY not configured')
+```
+
+❌ **Missing auth check:**
+```typescript
+async function deleteUser(userId: string) {
+  await db.users.delete(userId)
+}
+```
+
+✅ **Auth check:**
+```typescript
+async function deleteUser(userId: string, requestingUserId: string) {
+  if (!canDeleteUser(requestingUserId, userId)) {
+    throw new UnauthorizedError()
+  }
+  await db.users.delete(userId)
+}
+```
+
+**Red flags:**
+- Direct SQL string concatenation
+- Secrets in code
+- Missing auth checks on sensitive operations
+- Unvalidated redirects or file paths
+
+---
+
+## 5. Performance
+
+**Are there obvious performance issues?**
+
+- [ ] Are there obvious performance issues (N+1 queries, unnecessary loops)?
+- [ ] Is data fetching efficient (pagination, caching considered)?
+- [ ] Are re-renders/re-computations minimized (React: memo, useMemo)?
+
+**Common issues:**
+
+❌ **N+1 query:**
+```typescript
+for (const user of users) {
+  user.posts = await db.posts.find({ userId: user.id })
+}
+```
+
+✅ **Batch query:**
+```typescript
+const userIds = users.map(u => u.id)
+const posts = await db.posts.find({ userId: { $in: userIds } })
+const postsByUser = groupBy(posts, 'userId')
+users.forEach(u => u.posts = postsByUser[u.id] || [])
+```
+
+❌ **Unnecessary re-renders:**
+```typescript
+function UserList({ users }: Props) {
+  const sorted = users.sort((a, b) => a.name.localeCompare(b.name))
+  // Re-sorts on every render
+}
+```
+
+✅ **Memoized computation:**
+```typescript
+function UserList({ users }: Props) {
+  const sorted = useMemo(
+    () => users.sort((a, b) => a.name.localeCompare(b.name)),
+    [users]
+  )
+}
+```
+
+**Red flags:**
+- Queries in loops
+- Missing indexes on filtered/sorted columns
+- Large payloads without pagination
+- Expensive computations without memoization
+
+---
+
+## 6. Testing
+
+**Are changes adequately tested?**
+
+- [ ] Are critical paths tested (happy path + key errors)?
+- [ ] Do tests verify behavior, not implementation details?
+- [ ] Are test names clear about what they verify?
+
+**Good test characteristics:**
+
+✅ **Clear test name:**
+```typescript
+it('should return 404 when user not found', async () => {
+  const response = await request(app).get('/users/999')
+  expect(response.status).toBe(404)
+})
+```
+
+✅ **Tests behavior:**
+```typescript
+it('should disable submit button while submitting', async () => {
+  render(<Form />)
+  const button = screen.getByRole('button', { name: 'Submit' })
+  await userEvent.click(button)
+  expect(button).toBeDisabled()
+})
+```
+
+❌ **Tests implementation:**
+```typescript
+it('should call setState when button clicked', () => {
+  const mockSetState = jest.fn()
+  // Testing implementation detail, not behavior
+})
+```
+
+**Red flags:**
+- No tests for new feature
+- Tests only test happy path
+- Tests coupled to implementation
+- Unclear what test verifies
+
+---
+
+## 7. Documentation
+
+**Is the change adequately documented?**
+
+- [ ] Are non-obvious decisions explained in comments?
+- [ ] Is user-facing documentation updated (README, API docs)?
+- [ ] Are breaking changes clearly documented?
+
+**When to comment:**
+
+✅ **Explain "why":**
+```typescript
+// Use exponential backoff to avoid overwhelming API during outages
+const retryDelay = Math.pow(2, attempt) * 1000
+```
+
+✅ **Document non-obvious behavior:**
+```typescript
+// Returns null instead of throwing to allow graceful degradation
+// when feature flag service is unavailable
+function getFeatureFlag(name: string): boolean | null { ... }
+```
+
+❌ **Don't explain "what":**
+```typescript
+// Increment counter by 1
+counter += 1
+```
+
+**Documentation updates needed:**
+- New public API → Update API docs
+- Changed behavior → Update README
+- Breaking change → Update CHANGELOG, migration guide
+- New environment variable → Update deployment docs
+
+**Red flags:**
+- Breaking change without migration guide
+- New feature without usage examples
+- Complex algorithm without explanation
+- Changed behavior without updating docs
+
+---
+
+## Quick Decision Guide
+
+### Stop and Fix Now (Block PR)
+- Security vulnerabilities
+- Data loss scenarios
+- Breaking changes without migration path
+- Incorrect logic on critical path
+
+### Request Changes (Strong Suggestion)
+- Poor naming (hard to understand)
+- Missing error handling
+- No tests for new behavior
+- Performance issues (N+1, obvious bottlenecks)
+
+### Suggest Improvements (Nice to Have)
+- Could be simpler
+- Could have better names
+- Could use helper function
+- Could add more tests
+
+### Approve (Minor or Nitpick)
+- Style preferences
+- Alternative approaches (both work)
+- Optional refactoring opportunities
+
+---
+
+## Philosophy
+
+**Good code review is:**
+- **Fast:** <5 minutes for typical PR
+- **Focused:** Critical issues first, nitpicks last
+- **Constructive:** Suggest improvements, don't just criticize
+- **Collaborative:** Discussion, not dictation
+
+**Good code review is NOT:**
+- Gatekeeping or showing off knowledge
+- Rewriting in your preferred style
+- Blocking on personal preferences
+- Testing (that's CI's job)
+
+**Remember:** You're reviewing to help ship better code, not perfect code.

--- a/base/skills/pr-fix/references/deferred-issue.md
+++ b/base/skills/pr-fix/references/deferred-issue.md
@@ -1,0 +1,197 @@
+# Deferred Issue Template
+
+Use this template when creating GitHub issues for out-of-scope review findings.
+
+## Template
+
+```markdown
+## Origin
+
+Surfaced during code review of PR #[PR_NUMBER] / branch `[BRANCH_NAME]`
+
+**Reviewer:** [REVIEWER_NAME] (e.g., security-sentinel, Grug, Fowler)
+
+## Finding
+
+> [QUOTE THE EXACT FINDING FROM THE REVIEW]
+
+**File(s):** `[FILE:LINE]` (if applicable)
+
+## Context
+
+[Brief description of why this was flagged and why it's being deferred]
+
+## Recommended Action
+
+[What should be done to address this finding]
+
+## Priority
+
+**Severity:** [Critical / Important / Suggestion]
+**Why deferred:** [Pre-existing / Architectural / Out of scope / Needs profiling / etc.]
+
+## Acceptance Criteria
+
+- [ ] [Specific measurable outcome 1]
+- [ ] [Specific measurable outcome 2]
+- [ ] Tests added proving the fix
+
+---
+*Created by `/address-review` from [REVIEWER] finding*
+*Original PR: #[PR_NUMBER]*
+```
+
+## Example Issues
+
+### Security Finding (Pre-existing)
+
+```markdown
+## Origin
+
+Surfaced during code review of PR #42 / branch `feature/user-auth`
+
+**Reviewer:** security-sentinel
+
+## Finding
+
+> `utils/crypto.ts:23` — Using MD5 for password hashing. MD5 is cryptographically broken.
+
+**File(s):** `utils/crypto.ts:23`
+
+## Context
+
+This issue predates PR #42. The auth feature touched adjacent code, which triggered the review finding. Fixing requires migration strategy for existing hashed passwords.
+
+## Recommended Action
+
+1. Switch to bcrypt or argon2 for new passwords
+2. Create migration plan for existing users (rehash on next login)
+3. Add password hashing tests
+
+## Priority
+
+**Severity:** Critical
+**Why deferred:** Pre-existing issue requiring migration strategy
+
+## Acceptance Criteria
+
+- [ ] New passwords use bcrypt with cost factor 12+
+- [ ] Existing passwords rehashed on successful login
+- [ ] Legacy MD5 code removed after migration period
+- [ ] Tests verify secure hashing
+
+---
+*Created by `/address-review` from security-sentinel finding*
+*Original PR: #42*
+```
+
+### Architectural Suggestion
+
+```markdown
+## Origin
+
+Surfaced during code review of PR #87 / branch `feature/order-processing`
+
+**Reviewer:** Grug
+
+## Finding
+
+> Order processing has 8 layers of indirection. Grug head hurt. Could be 3 layers: Controller → Service → Repository.
+
+**File(s):** `src/orders/` (multiple files)
+
+## Context
+
+Current architecture evolved organically. Simplifying requires coordinated refactor across multiple features. Not safe to do mid-feature.
+
+## Recommended Action
+
+1. Map current call graph
+2. Identify which layers add value vs pass-through
+3. Design simplified architecture
+4. Refactor in dedicated PR with full test coverage
+
+## Priority
+
+**Severity:** Suggestion
+**Why deferred:** Architectural change requiring design discussion
+
+## Acceptance Criteria
+
+- [ ] Architecture diagram showing before/after
+- [ ] Call depth reduced from 8 to ≤4 layers
+- [ ] No behavior changes (all existing tests pass)
+- [ ] Performance maintained or improved
+
+---
+*Created by `/address-review` from Grug finding*
+*Original PR: #87*
+```
+
+### Performance Finding (Needs Profiling)
+
+```markdown
+## Origin
+
+Surfaced during code review of PR #103 / branch `feature/report-export`
+
+**Reviewer:** performance-pathfinder
+
+## Finding
+
+> `reports/export.ts:45` — Potential N+1 query pattern when fetching report items. Each item triggers separate DB call.
+
+**File(s):** `reports/export.ts:45`
+
+## Context
+
+This may or may not be a real performance issue. Need to profile with production-like data volumes before optimizing.
+
+## Recommended Action
+
+1. Add performance test with realistic data (1000+ items)
+2. Profile query execution
+3. If confirmed: batch queries or use JOIN
+4. If not confirmed: document why current approach is acceptable
+
+## Priority
+
+**Severity:** Important
+**Why deferred:** Needs profiling before optimization
+
+## Acceptance Criteria
+
+- [ ] Performance test added
+- [ ] Profile data captured
+- [ ] Decision documented (optimize or accept)
+- [ ] If optimized: query count reduced to O(1) or O(log n)
+
+---
+*Created by `/address-review` from performance-pathfinder finding*
+*Original PR: #103*
+```
+
+## Labels to Apply
+
+Based on finding type:
+
+| Finding Type | Labels |
+|--------------|--------|
+| Security | `security`, `priority:high` |
+| Performance | `performance`, `needs-profiling` |
+| Architecture | `architecture`, `tech-debt` |
+| Code smell | `refactor`, `code-quality` |
+| Pre-existing | `pre-existing`, `improvement` |
+| Suggestion | `enhancement`, `priority:low` |
+
+## CLI Command
+
+```bash
+gh issue create \
+  --title "[Type] Brief description" \
+  --label "from-review,tech-debt" \
+  --body "$(cat <<'EOF'
+[paste template content]
+EOF
+)"
+```

--- a/base/skills/pr-fix/references/fix-ci.md
+++ b/base/skills/pr-fix/references/fix-ci.md
@@ -1,0 +1,250 @@
+# Fix CI
+
+> **THE CI/CD MASTERS**
+>
+> **Jez Humble**: "If it hurts, do it more frequently, and bring the pain forward."
+>
+> **Martin Fowler**: "Continuous Integration is a software development practice where members of a team integrate their work frequently."
+>
+> **Nicole Forsgren**: "Lead time for changes is a key metric for software delivery performance."
+
+You're the CI Specialist who's debugged 500+ pipeline failures. CI failures are not random—they're signals. Your job: classify the failure type, identify root cause, and provide a specific resolution.
+
+## Your Mission
+
+Analyze CI failure logs, classify the failure type, identify root cause, and generate a resolution plan.
+
+**The CI Question**: Is this a code issue, infrastructure issue, or flaky test?
+
+## Bounded Shell Output (MANDATORY)
+
+- Never run raw unbounded CI logs
+- List first, then inspect one failed job
+- Cap output with `--limit` and `tail -n`
+- Narrow to failed steps before reruns
+
+## The CI Philosophy
+
+### Humble's Wisdom: Bring Pain Forward
+If CI hurts, the pain is teaching you something. Don't ignore it—lean into it. Frequent small fixes beat infrequent major failures.
+
+### Fowler's Practice: Integrate Frequently
+CI exists to catch integration issues early. A failing CI is doing its job. The question is: what did it catch?
+
+### Forsgren's Metric: Lead Time Matters
+Every minute CI is red is a minute the team is blocked. Fast diagnosis = fast flow.
+
+## Phase 1: Check CI Status
+
+Use `gh` to check CI status for the current PR:
+- If successful, celebrate and stop
+- If in progress, wait and check again
+- If failed, proceed to analyze
+
+```bash
+# Recent workflow runs
+gh run list --limit 5 --json databaseId,workflowName,status,conclusion,displayTitle,headBranch
+
+# Specific run details
+gh run view <run-id> --log-failed | tail -n 200
+
+# PR checks
+gh pr checks --json name,state,startedAt,completedAt,link
+```
+
+## Phase 2: Classify Failure Type
+
+### Type 1: Code Issue
+**Symptoms**: Test assertion failed, type error, lint error, missing import
+**Cause**: Your code has a bug or doesn't meet standards
+**Fix**: Fix the code
+**Evidence**: Error points to specific file/line in your branch
+
+### Type 2: Infrastructure Issue
+**Symptoms**: Timeout, network error, dependency download failed, OOM
+**Cause**: CI environment or external service problem
+**Fix**: Retry, fix config, add caching, increase resources
+**Evidence**: Error mentions network, timeout, resource limits
+
+### Type 3: Flaky Test
+**Symptoms**: Fails intermittently, passes on retry, works locally
+**Cause**: Non-deterministic test (timing, order, external dependency)
+**Fix**: Fix or quarantine the test
+**Evidence**: Historical runs show same test passing/failing randomly
+
+### Type 4: Configuration Issue
+**Symptoms**: Command not found, wrong version, missing env var
+**Cause**: CI config doesn't match local environment
+**Fix**: Update workflow YAML, sync versions
+**Evidence**: Works locally, fails in CI consistently
+
+## Pre-Fix Checklist
+
+Before implementing any fix:
+
+- [ ] Do we have a failing test that reproduces this? If not, write one.
+- [ ] Is this the ROOT cause or a symptom of deeper issue?
+- [ ] What's the idiomatic way to solve this in [language/framework]?
+- [ ] What breaks if we revert in 6 months?
+
+## Phase 3: Analyze Failure
+
+**Make the invisible visible**—don't guess at CI failures. Add logging, capture state, trace the failure path.
+
+Create `CI-FAILURE-SUMMARY.md` with:
+- **Workflow**: Name, job, step
+- **Command**: Exact command that failed
+- **Exit code**: What the system reported
+- **Error messages**: Full text (no paraphrasing)
+- **Stack trace**: If available
+- **Environment**: OS, Node/Python version, relevant env vars
+
+### Root Cause Analysis
+
+**For Code Issues**:
+- Which test/check failed?
+- What's the exact error?
+- Which commit introduced it?
+- What changed recently?
+
+**For Infrastructure Issues**:
+- Which step timed out/failed?
+- What external service is involved?
+- Is caching working?
+- Are resources sufficient?
+
+**For Flaky Tests**:
+- Is there timing/sleep involved?
+- Database state assumptions?
+- External API calls without mocking?
+- Test order dependency?
+
+## Phase 4: Generate Resolution Plan
+
+Create `CI-RESOLUTION-PLAN.md` with your analysis and approach.
+
+### TODO Entry Format
+
+```markdown
+- [ ] [CODE FIX] Fix failing assertion in auth.test.ts
+  ```
+  Files: src/auth/__tests__/auth.test.ts:45
+  Issue: Expected token to be valid, got undefined
+  Cause: Missing await on async call
+  Fix: Add await to line 45
+  Verify: Run test locally, push, confirm CI passes
+  Estimate: 15m
+  ```
+
+- [ ] [CI FIX] Increase timeout for integration tests
+  ```
+  Files: .github/workflows/ci.yml
+  Issue: Integration tests timing out at 5m
+  Cause: Added new tests, total time exceeds limit
+  Fix: Increase timeout-minutes to 10
+  Verify: Rerun workflow, confirm completion
+  Estimate: 10m
+  ```
+```
+
+### Labels
+- **[CODE FIX]**: Changes to application code or tests
+- **[CI FIX]**: Changes to pipeline or environment
+- **[FLAKY]**: Test needs quarantine or fix
+- **[RETRY]**: Safe to retry without changes
+
+## Phase 5: Communicate
+
+Update PR or create summary with:
+- Classification of failure
+- Root cause analysis
+- Resolution plan
+- Verification steps
+- Prevention measures
+
+## Common CI Issues
+
+### Tests Pass Locally, Fail in CI
+- Node/npm version mismatch
+- Missing environment variables
+- Different timezone
+- Database state assumptions
+
+### Timeout Failures
+- Test too slow → optimize or increase timeout
+- Network issue → add retry logic
+- Deadlock → fix async code
+- Resource contention → run tests serially
+
+### Dependency Failures
+- npm registry down → retry
+- Private package auth → fix NPM_TOKEN
+- Version conflict → update lockfile
+- Cache corruption → clear cache
+
+## Output Format
+
+```markdown
+## CI Failure Analysis
+
+**Workflow**: [Name]
+**Run**: [ID/URL]
+**Classification**: [Code Issue / Infrastructure / Flaky / Config]
+
+---
+
+### Error Summary
+
+```
+[Key error lines - exact text]
+```
+
+### Root Cause
+
+**Type**: [Classification]
+**Location**: [File/step]
+**Cause**: [Specific explanation]
+
+---
+
+### Resolution Plan
+
+**Action**: [Fix / Retry / Quarantine / Config Change]
+
+[Specific fix with code/config]
+
+### Verification
+
+- [ ] [Step to verify fix]
+
+---
+
+### Prevention
+
+[How to prevent this class of failure]
+```
+
+## Red Flags
+
+- [ ] Same test fails randomly (flaky—fix or quarantine)
+- [ ] CI takes >15 minutes (optimize pipeline)
+- [ ] No local reproduction (environment drift)
+- [ ] Retrying without understanding (hiding the problem)
+- [ ] Multiple unrelated failures (systemic issue)
+- [ ] **Lowering a quality gate to make CI pass** — NEVER do this. Coverage thresholds, lint strictness, type-check config, security gates — if a gate fails, write code to meet it. More tests, better code, actual fixes. Never move the goalpost. This is absolute and non-negotiable.
+
+## Philosophy
+
+> **"CI failures are features, not bugs. They caught an issue before users did."**
+
+**Humble's wisdom**: Bring pain forward. The earlier you find issues, the cheaper they are to fix.
+
+**Fowler's practice**: Integrate frequently. CI failures from small changes are easy to fix; CI failures from big changes are nightmares.
+
+**Forsgren's metric**: Lead time matters. Fast CI resolution = fast delivery.
+
+**Your goal**: Classify, fix, and prevent. Don't just make CI green—understand why it was red.
+
+---
+
+*Run this command when CI fails. Insert specific tasks into TODO.md, then remove temporary files.*

--- a/base/skills/pr-fix/references/refactor.md
+++ b/base/skills/pr-fix/references/refactor.md
@@ -1,0 +1,64 @@
+# Refactor
+
+> "Simplicity is the ultimate sophistication." — da Vinci
+
+## Philosophy
+
+Fight entropy. Leave the codebase better than you found it.
+
+Every shortcut becomes someone else's burden. Every hack compounds into technical debt. You are not just refactoring code—you are shaping the future of this project.
+
+## Role
+
+You are the senior engineer. Codex does the refactoring; you review and ship.
+
+**Codex writes first draft. You review and ship.**
+
+## Objective
+
+Post-implementation refinement: simplify code, improve module depth.
+
+## Process
+
+### Codex Does the Refactoring
+
+Delegate the actual refactoring to Codex:
+
+```bash
+codex exec "REFACTOR: Simplify [file/module]. Focus on clarity, naming, reduced nesting. Follow CLAUDE.md standards. Run pnpm typecheck after." \
+  --output-last-message /tmp/codex-refactor.md 2>/dev/null
+```
+
+Review what Codex produces. Fix issues if needed, then commit.
+
+## Mission
+
+Two-pass refinement:
+1. **Clarity** — Simplify code without changing behavior
+2. **Architecture** — Improve module depth and information hiding
+
+## Phase 1: Simplification
+
+Launch `code-simplifier:code-simplifier` agent.
+
+Goals: clarity, naming, reduced nesting, consolidated logic, project standards from CLAUDE.md.
+
+Commit: `refactor: simplify implementation`
+
+## Phase 2: Deep Module Review
+
+Launch `ousterhout` agent to review for Ousterhout's design principles.
+
+Looking for:
+- Shallow modules or pass-through methods
+- Leaky abstractions exposing implementation details
+- Change amplification risk (small change → many edits)
+- Cognitive load issues (too much to hold in head)
+
+If high-impact issues found:
+1. Implement suggested refactorings
+2. Commit: `refactor: improve module depth`
+
+## Completion
+
+Report what was simplified and any architectural improvements made.

--- a/base/skills/pr-fix/references/respond.md
+++ b/base/skills/pr-fix/references/respond.md
@@ -1,0 +1,215 @@
+
+# Respond to PR Review Feedback
+
+You're a senior engineer responding to code review feedback on a PR. Your job is to analyze, decide, act, and **document everything publicly in the PR**.
+
+## Core Philosophy: Radical Transparency
+
+**Never work silently.** Every judgment, decision, categorization, and action must be documented in PR comments. The PR comment history should tell the complete story of how feedback was handled and why.
+
+Why this matters:
+- Reviewers see their feedback was heard and considered
+- Future readers understand the reasoning behind decisions
+- Rubber-ducking improves decision quality
+- Creates institutional memory
+
+## Workflow
+
+## Bounded Shell Output (MANDATORY)
+
+- Count first; fetch details second
+- Use bounded pages (`per_page`, `page`) instead of raw dumps
+- Truncate body previews during triage
+- Process newest 50 first, then continue page-by-page
+
+### 1. Gather All Feedback
+
+Collect from all three GitHub comment sources:
+- Review comments (inline on code)
+- Issue comments (general discussion)
+- Review summaries (top-level review state)
+
+Use pagination. Don't miss anything.
+
+Bounded collection pattern:
+
+```bash
+OWNER="$(gh repo view --json owner --jq .owner.login)"
+REPO="$(gh repo view --json name --jq .name)"
+
+REVIEW_COUNT="$(gh api "repos/$OWNER/$REPO/pulls/$PR/comments?per_page=100" --paginate --jq '.[] | 1' | wc -l | tr -d ' ')"
+ISSUE_COUNT="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments?per_page=100" --paginate --jq '.[] | 1' | wc -l | tr -d ' ')"
+SUMMARY_COUNT="$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" --paginate --jq '.[] | 1' | wc -l | tr -d ' ')"
+
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments?per_page=50&page=1" \
+  --jq '.[] | {id,user:.user.login,path,line,body:(.body|gsub("\n";" ")|.[0:200])}'
+```
+
+### 2. Post Initial Acknowledgment
+
+**MANDATORY**: Before any analysis, post a comment acknowledging receipt:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+## 📋 Review Feedback Received
+
+I'm analyzing feedback from this PR. Will post my assessment shortly.
+
+**Found:**
+- X review comments
+- Y issue comments
+- Z review summaries
+
+Working through categorization and will respond to each item.
+EOF
+)"
+```
+
+### 3. Analyze and Categorize (with Second Opinions)
+
+For each piece of feedback:
+1. Assess technical merit and scope
+2. **For non-trivial decisions**, get a second opinion via Task tool:
+   ```
+   # Get a second perspective
+   Task({ subagent_type: "general-purpose", prompt: "Review this feedback: [quote]. Is this valid? Should it block merge?" })
+
+   # Get Gemini perspective for architectural questions
+   gemini "Analyze this architectural suggestion: [quote]. What are the tradeoffs?"
+   ```
+3. Document your reasoning
+
+Categories:
+- **Critical/Merge-blocking**: Must fix before merge
+- **In-scope improvements**: Valid, fits this PR's purpose
+- **Follow-up work**: Valid, but separate concern
+- **Declined**: Not addressing, with explicit reasoning
+
+### 4. Post Categorization Summary
+
+**MANDATORY**: Post your categorized assessment as a PR comment:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+## 📊 Feedback Analysis
+
+### Critical/Merge-blocking (X items)
+| Feedback | Source | My Assessment |
+|----------|--------|---------------|
+| [quote] | @reviewer | Valid - will fix. [reasoning] |
+
+### In-scope Improvements (X items)
+| Feedback | Source | My Assessment |
+|----------|--------|---------------|
+| [quote] | @reviewer | Agreed - implementing. [reasoning] |
+
+### Follow-up Work (X items)
+| Feedback | Issue Created | Rationale for Deferring |
+|----------|---------------|-------------------------|
+| [quote] | #123 | [why not in this PR] |
+
+### Declined (X items)
+| Feedback | Source | Why Not Addressing |
+|----------|--------|-------------------|
+| [quote] | @reviewer | [explicit reasoning] |
+
+---
+*Consulted: Codex (for X), Gemini (for Y)*
+EOF
+)"
+```
+
+### 5. Implement Fixes (Narrating as You Go)
+
+For each fix, post a comment explaining what you're doing:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+### Addressing: [feedback summary]
+
+**What I'm changing:**
+- [specific change 1]
+- [specific change 2]
+
+**Why this approach:**
+[reasoning]
+
+Will commit shortly.
+EOF
+)"
+```
+
+Then implement using pr-comment-resolver agents or directly.
+
+### 6. Post Resolution Summary
+
+After all fixes are committed:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+## ✅ Feedback Resolution Complete
+
+### Changes Made
+- [commit hash]: [what it fixed]
+- [commit hash]: [what it fixed]
+
+### Issues Created
+- #123: [deferred item]
+
+### Still Open
+- [anything that needs reviewer re-review]
+
+Ready for another look when you have time, @reviewer.
+EOF
+)"
+```
+
+### 7. Codify Learnings
+
+Every piece of feedback represents a gap in our preventive systems. After resolving:
+
+1. Brainstorm prevention mechanisms (hooks, agents, skills, CLAUDE.md)
+2. Implement codification
+3. Post what was codified:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+## 📚 Codified from This Review
+
+To prevent similar feedback in future PRs:
+
+- **[feedback pattern]** → Added to `[target]`: [what]
+
+This class of issue should now be caught earlier.
+EOF
+)"
+```
+
+## Decision Framework
+
+**When to get a second opinion (Task tool / Codex CLI):**
+- Architectural suggestions
+- Disagreements with reviewer
+- Ambiguous requirements
+- Tradeoff decisions
+- Anything you're uncertain about
+
+**When to decline feedback:**
+- Out of scope for this PR (create issue instead)
+- Technically incorrect (explain why)
+- Already addressed elsewhere (link to it)
+- Would introduce regression (explain risk)
+
+Always explain declined feedback publicly. Never silently ignore.
+
+## Anti-Patterns
+
+❌ Silent fixes with no explanation
+❌ Categorizing without posting rationale
+❌ Making decisions without documenting reasoning
+❌ Ignoring feedback without explicit comment
+❌ Working through feedback without acknowledging receipt
+
+## Remember
+
+The PR comment thread is the permanent record. Future you, future maintainers, and future AI agents will read it. Make it tell the complete story.

--- a/base/skills/pr-fix/references/review-branch.md
+++ b/base/skills/pr-fix/references/review-branch.md
@@ -1,0 +1,79 @@
+
+# /review-branch
+
+You're a tech lead orchestrating a rigorous code review.
+
+## Role
+
+Review orchestrator. You don't review the code — you delegate to ~12 specialized reviewers, then synthesize.
+
+## Objective
+
+Produce a prioritized action plan from comprehensive multi-reviewer analysis of the current branch diff.
+
+## Latitude
+
+- Run ALL reviewers concurrently for speed
+- Security-sentinel is **MANDATORY** on every PR regardless of size
+- Skip data-integrity-guardian enhanced mode if no migrations in diff
+- For small PRs (<100 lines): all Moonbridge personas + security-sentinel + 1-2 relevant specialists
+- For large PRs (>500 lines): consider recommending split
+
+## Review Team
+
+### Tier 1: Personas (via Moonbridge, parallel)
+| Reviewer | Focus |
+|----------|-------|
+| **Grug** | Complexity demons, premature abstraction |
+| **Carmack** | Simplest solution, shippability, YAGNI |
+| **Ousterhout** | Module depth, information hiding, wide interfaces |
+| **Beck** | TDD discipline, behavior-focused tests |
+| **Fowler** | Code smells, duplication, shotgun surgery |
+
+### Tier 2: Domain Specialists (via Task, parallel)
+| Agent | Focus | Priority |
+|-------|-------|----------|
+| **security-sentinel** | Auth, injection, secrets, OWASP | **MANDATORY** |
+| **performance-pathfinder** | Bottlenecks, N+1, scaling | Standard |
+| **data-integrity-guardian** | Transactions, migrations, referential integrity | Standard |
+| **architecture-guardian** | Module boundaries, coupling | Standard |
+
+### Tier 3: Meta (sequential after Tier 1+2)
+- **hindsight-reviewer** — "Would you build it from scratch this way?"
+- **Synthesizer (You)** — Dedupe, resolve conflicts, prioritize
+
+## Process
+
+1. **Scope** — `git diff --name-only $(git merge-base HEAD main)...HEAD` + full diff
+2. **Parallel reviews** — Launch all Tier 1 + Tier 2 concurrently
+3. **Hindsight** — After Phase 2, feed summary to hindsight-reviewer
+4. **Synthesize** — Dedupe, resolve conflicts, calibrate severity
+
+See `references/reviewer-prompts.md` for prompt templates.
+
+## Severity Calibration
+
+- **Critical**: Security holes, data loss, broken functionality
+- **Important**: Convention violations, missing error handling, performance issues
+- **Suggestion**: Style improvements, refactoring opportunities
+
+## Output
+
+Action plan with: Critical (block merge), Important (fix in PR), Suggestions (optional). Synthesis notes, consensus findings, conflict resolutions, positive observations. Raw outputs in collapsible details.
+
+## Visual Deliverable
+
+After completing the core workflow, generate a visual HTML summary:
+
+1. Read `~/.claude/skills/visualize/prompts/review-findings.md`
+2. Read the template(s) referenced in the prompt
+3. Read `~/.claude/skills/visualize/references/css-patterns.md`
+4. Generate self-contained HTML capturing this session's output
+5. Write to `~/.agent/diagrams/review-{branch}-{date}.html`
+6. Open in browser: `open ~/.agent/diagrams/review-{branch}-{date}.html`
+7. Tell the user the file path
+
+Skip visual output if:
+- The session was trivial (single finding, quick fix)
+- The user explicitly opts out (`--no-visual`)
+- No browser available (SSH session)

--- a/base/skills/pr-fix/references/reviewer-prompts.md
+++ b/base/skills/pr-fix/references/reviewer-prompts.md
@@ -1,0 +1,169 @@
+# Reviewer Prompt Templates
+
+Templates for each reviewer in the /review-branch system.
+
+## Moonbridge Persona Prompts
+
+### Grug
+```
+[GRUG REVIEW]
+
+You are Grug. complexity very, very bad.
+
+Review this diff for:
+- Complexity demons (too many layers? too clever?)
+- Abstraction too early (only one use but already interface/factory?)
+- Can grug debug this? (can put log and understand?)
+- Chesterton Fence violations (removing code without understanding why?)
+
+Report format:
+- [ ] file:line — [Issue] — Severity: critical/important/suggestion
+
+[DIFF]
+```
+
+### Carmack
+```
+[CARMACK REVIEW]
+
+You are John Carmack. Direct implementation. Always shippable.
+
+Review this diff for:
+- Is this the simplest solution? (fewer abstractions possible?)
+- Is this shippable now? (can deploy immediately?)
+- Premature optimization? (measuring before optimizing?)
+- Speculative features? ("might need later")
+
+Report format:
+- [ ] file:line — [Issue] — Severity: critical/important/suggestion
+
+[DIFF]
+```
+
+### Ousterhout
+```
+[OUSTERHOUT REVIEW]
+
+You are John Ousterhout, author of "A Philosophy of Software Design".
+
+Review this diff for:
+- Shallow modules (lots of boilerplate, little functionality)
+- Wide interfaces (too many methods/parameters)
+- Information leakage (implementation details exposed)
+- Pass-through methods (just delegate to another layer)
+- Configuration explosion (too many options)
+
+Report format:
+- [ ] file:line — [Issue] — Severity: critical/important/suggestion
+
+[DIFF]
+```
+
+### Beck
+```
+[BECK REVIEW]
+
+You are Kent Beck, father of TDD and XP.
+
+Review this diff for:
+- Tests testing implementation not behavior?
+- Missing tests for changed behavior?
+- Tests that would break on refactor?
+- Overmocking (>3 mocks = smell)?
+- Test isolation (shared state between tests)?
+
+Report format:
+- [ ] file:line — [Issue] — Severity: critical/important/suggestion
+
+[DIFF]
+```
+
+### Fowler
+```
+[FOWLER REVIEW]
+
+You are Martin Fowler, author of "Refactoring".
+
+Review this diff for:
+- Code smells: Long Method, Feature Envy, Data Clumps
+- Duplication (Rule of Three violations)
+- Shotgun Surgery (change requires touching many files)
+- Primitive Obsession (should be value object?)
+- Message Chains (a.b.c.d.e)
+
+Report format:
+- [ ] file:line — [Issue] — Severity: critical/important/suggestion
+
+[DIFF]
+```
+
+## Data Integrity Guardian: Migration-Enhanced Prompt
+
+When diff contains `*.sql`, migration files, or DDL (`CREATE`/`ALTER`/`DROP`):
+
+```
+Review this diff for data integrity issues.
+
+CRITICAL: This PR contains database migrations. Include a Migration Visibility Report:
+
+1. For each new column, identify if it's used in WHERE/JOIN predicates
+2. State what value existing rows will have (NULL, default, backfilled)
+3. Prove visibility preservation: 'Existing [entity] will [still be queryable / become invisible] because [reason]'
+4. If visibility is NOT preserved, flag as CRITICAL with required backfill SQL
+
+Output MUST include:
+| Table.Column | Used in Predicate | Legacy Value | Query Result | Action Required |
+|--------------|-------------------|--------------|--------------|-----------------|
+
+[DIFF]
+```
+
+## Output Format Template
+
+```markdown
+## Code Review: [branch-name]
+
+**Scope:** [X files, Y lines changed]
+**Reviewers:** [list]
+
+---
+
+### Action Plan
+
+#### Critical (Block Merge)
+- [ ] `file.ts:42` — [Issue] — Fix: [action] (Source: [reviewer])
+
+#### Important (Fix in PR)
+- [ ] `service.go:89` — [Issue] — Fix: [action] (Source: [reviewer])
+
+#### Suggestions (Optional)
+- [ ] Consider [improvement] (Source: [reviewer])
+
+---
+
+### Synthesis Notes
+
+**Consensus (2+ reviewers):** [shared findings]
+**Conflicts resolved:** [reasoning]
+**Hindsight insights:** [strategic observations]
+
+---
+
+### Positive Observations
+- [What was done well]
+
+---
+
+<details>
+<summary>Raw Reviewer Outputs</summary>
+
+### Grug
+[output]
+
+### Carmack
+[output]
+
+(etc.)
+
+</details>
+```

--- a/base/skills/pr-fix/references/scope-rules.md
+++ b/base/skills/pr-fix/references/scope-rules.md
@@ -1,0 +1,106 @@
+# Scope Rules for Review Findings
+
+## Decision Tree
+
+```
+Is the file in the current diff?
+├── No → OUT-OF-SCOPE (pre-existing issue)
+└── Yes → Continue...
+    │
+    Is severity Critical or Important?
+    ├── No (Suggestion) → OUT-OF-SCOPE (nice-to-have)
+    └── Yes → Continue...
+        │
+        Is the fix localized (1-3 files)?
+        ├── No → OUT-OF-SCOPE (architectural change)
+        └── Yes → IN-SCOPE (fix with TDD)
+```
+
+## In-Scope Indicators
+
+Fix now if:
+- **File is in diff** — You touched it, you own it
+- **Critical severity** — Security, data loss, broken functionality
+- **Important severity** — Convention violation, missing error handling
+- **Localized fix** — Changes 1-3 files, doesn't alter APIs
+- **Clear remediation** — Reviewer provided specific fix
+
+## Out-of-Scope Indicators
+
+Create issue if:
+- **Pre-existing** — Issue existed before this branch
+- **Suggestion** — Nice-to-have, not blocking
+- **Systemic** — Pattern repeated across codebase (needs coordinated fix)
+- **Architectural** — Requires design discussion, broad refactor
+- **API change** — Would break existing callers
+- **Performance** — Needs profiling before fixing (don't optimize blind)
+
+## Gray Areas (Confirm with User)
+
+**Pre-existing but easy fix:**
+- Issue existed before, but trivial to fix while here
+- Ask: "This is pre-existing but easy. Fix now or defer?"
+
+**Suggestion that's quick:**
+- Low priority but 5 minutes to implement
+- Ask: "Suggestion item, but quick. Include or defer?"
+
+**Cascading fix:**
+- Fixing one thing reveals another
+- Ask: "Found additional issue while fixing. Scope in or create issue?"
+
+**Hindsight items:**
+- Strategic observations, not bugs
+- Usually out-of-scope unless actionable immediately
+
+## Examples
+
+### In-Scope
+
+```
+Finding: auth/login.ts:42 — Missing input validation
+Severity: Important
+File in diff? Yes
+Localized? Yes (single function)
+→ IN-SCOPE: Fix with TDD
+```
+
+```
+Finding: api/orders.ts:17 — SQL injection vulnerability
+Severity: Critical
+File in diff? Yes
+Localized? Yes
+→ IN-SCOPE: Fix immediately with TDD
+```
+
+### Out-of-Scope
+
+```
+Finding: Similar pattern in utils/helpers.ts (not in diff)
+Severity: Important
+File in diff? No
+→ OUT-OF-SCOPE: Pre-existing, create issue
+```
+
+```
+Finding: Consider using dependency injection throughout
+Severity: Suggestion
+Architectural? Yes
+→ OUT-OF-SCOPE: Requires design discussion, create issue
+```
+
+```
+Finding: N+1 query pattern should be optimized
+Severity: Important
+Needs profiling? Yes
+→ OUT-OF-SCOPE: Profile first, then fix. Create issue.
+```
+
+## Priority for Issues
+
+When creating issues for out-of-scope items:
+
+- **Critical deferred** → Label: `priority: high`, `type: bug`
+- **Important deferred** → Label: `priority: medium`, `type: improvement`
+- **Suggestion deferred** → Label: `priority: low`, `type: enhancement`
+- **Hindsight items** → Label: `type: tech-debt` or `type: discussion`

--- a/base/skills/pr-fix/references/tdd-fix-pattern.md
+++ b/base/skills/pr-fix/references/tdd-fix-pattern.md
@@ -1,0 +1,215 @@
+# TDD Fix Pattern
+
+For each in-scope review finding, follow this test-driven workflow.
+
+## The Pattern
+
+### 1. Write Failing Test
+
+Create a test that exposes the issue. The test should:
+- Target the specific behavior being fixed
+- Fail before the fix
+- Pass after the fix
+- Not break on unrelated refactors
+
+```typescript
+// Example: Review finding about missing input validation
+describe('createUser', () => {
+  it('should reject invalid email format', () => {
+    // Arrange
+    const invalidInput = { email: 'not-an-email', name: 'Test' }
+
+    // Act & Assert
+    expect(() => createUser(invalidInput)).toThrow('Invalid email format')
+  })
+})
+```
+
+### 2. Verify Test Fails Correctly
+
+Run the test and confirm it fails for the right reason:
+
+```bash
+pnpm test -- --watch auth.test.ts
+```
+
+**Check:**
+- ❌ Test fails (expected)
+- ❌ Fails because the validation doesn't exist (correct reason)
+- ❌ NOT because of syntax error, wrong import, or unrelated issue
+
+### 3. Fix the Code Minimally
+
+Implement the smallest fix that makes the test pass:
+
+```typescript
+// Before
+function createUser(input: UserInput): User {
+  return { id: generateId(), ...input }
+}
+
+// After (minimal fix)
+function createUser(input: UserInput): User {
+  if (!input.email.includes('@')) {
+    throw new Error('Invalid email format')
+  }
+  return { id: generateId(), ...input }
+}
+```
+
+**Rules:**
+- Fix only what the test requires
+- Don't refactor beyond the fix
+- Don't add "nice to have" improvements
+
+### 4. Verify Test Passes
+
+```bash
+pnpm test -- auth.test.ts
+```
+
+**Check:**
+- ✅ New test passes
+- ✅ All existing tests still pass
+- ✅ No regressions introduced
+
+### 5. Commit the Fix
+
+Use conventional commit format:
+
+```bash
+git add -A
+git commit -m "fix(auth): validate email format in createUser
+
+Review finding: Missing input validation allows invalid emails
+Test: should reject invalid email format
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+**Commit message pattern:**
+```
+fix(scope): brief description
+
+Review finding: [quote the original finding]
+Test: [name of the test that proves the fix]
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+## Test Types by Finding Category
+
+### Security Findings
+
+Test the attack vector directly:
+
+```typescript
+it('should prevent SQL injection in username', () => {
+  const maliciousInput = "admin'; DROP TABLE users;--"
+  // Should not throw SQL error or execute injection
+  expect(() => findUser(maliciousInput)).not.toThrow()
+  // Should return no results (user doesn't exist)
+  expect(findUser(maliciousInput)).toBeNull()
+})
+```
+
+### Validation Findings
+
+Test boundary conditions:
+
+```typescript
+describe('password validation', () => {
+  it('should reject password under 8 characters', () => {
+    expect(() => validatePassword('short')).toThrow()
+  })
+
+  it('should accept password with 8+ characters', () => {
+    expect(() => validatePassword('longenough')).not.toThrow()
+  })
+})
+```
+
+### Error Handling Findings
+
+Test failure modes:
+
+```typescript
+it('should handle network timeout gracefully', async () => {
+  // Arrange: Mock timeout
+  jest.spyOn(fetch, 'fetch').mockRejectedValue(new Error('timeout'))
+
+  // Act
+  const result = await fetchUserData('user123')
+
+  // Assert: Returns fallback, doesn't crash
+  expect(result).toEqual({ error: 'Failed to fetch user data' })
+})
+```
+
+### Performance Findings
+
+Test with measurable assertions (where possible):
+
+```typescript
+it('should fetch users in single query (no N+1)', async () => {
+  const queryCounter = jest.fn()
+  db.on('query', queryCounter)
+
+  await fetchUsersWithOrders(10)
+
+  // Should be 2 queries max: users + orders (joined or batched)
+  expect(queryCounter).toHaveBeenCalledTimes(2)
+})
+```
+
+## When Test Is Hard to Write
+
+Sometimes a finding is hard to test directly. Options:
+
+### Option 1: Test at a Higher Level
+
+Can't unit test? Integration test instead:
+
+```typescript
+it('should complete checkout flow end-to-end', async () => {
+  const response = await request(app)
+    .post('/api/checkout')
+    .send(validCheckoutData)
+
+  expect(response.status).toBe(200)
+  expect(response.body.orderId).toBeDefined()
+})
+```
+
+### Option 2: Manual Verification + Commit Note
+
+If truly untestable (rare), document in commit:
+
+```bash
+git commit -m "fix(config): set secure cookie flags
+
+Review finding: Session cookies missing secure flag
+Verification: Manual - inspected Set-Cookie header in browser devtools
+Note: Cookie flag verification requires browser; mocking deemed too brittle
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+### Option 3: Reconsider the Fix
+
+If you can't test it, maybe the fix approach is wrong. Consider:
+- Is there a more testable implementation?
+- Should this be refactored first?
+- Create issue for architectural fix instead
+
+## Anti-Patterns
+
+❌ **Test after fix** — Write test first. Always.
+
+❌ **Test implementation** — Test behavior. If test breaks on refactor, it's testing implementation.
+
+❌ **Over-mocking** — >3 mocks = design smell. Refactor instead.
+
+❌ **Skipping test** — No test = no proof the fix works. No exceptions.
+
+❌ **Multiple fixes per commit** — One fix = one test = one commit.

--- a/base/skills/pr-polish/SKILL.md
+++ b/base/skills/pr-polish/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: pr-polish
+description: |
+  Elevate a working PR: hindsight review, code refinement, test audit, docs, quality gates.
+  Use when: PR works but could be better, pre-merge quality pass, retrospective review.
+  Trigger: /pr-polish, "polish this PR", "elevate quality", "hindsight review".
+argument-hint: "[PR-number]"
+---
+
+# /pr-polish
+
+Holistic quality elevation for a PR that already works.
+
+## Role
+
+Staff engineer doing a retrospective pass. Not finding bugs — asking "would we build it the same way starting over?"
+
+## Objective
+
+Elevate PR `$ARGUMENTS` (or current branch's PR) from "works" to "exemplary": clean architecture, solid tests, current docs.
+Secondary question: **"How confident are we that merging this will not break existing behavior?"**
+Treat confidence as an explicit deliverable, not a vibe.
+
+## Precondition Gate
+
+Before starting, verify:
+
+```bash
+gh pr view $PR --json mergeable,statusCheckRollup,reviewDecision
+```
+
+Requirements:
+- No merge conflicts
+- CI green for any relevant existing checks
+- No unaddressed critical review feedback
+
+If mergeability is broken, relevant CI is red, or critical review feedback is still open:
+- run `/pr-fix` first
+- do not proceed with polish
+
+If the repo simply lacks the relevant CI checks, continue. Missing CI is a polish target and must be called out in the merge-confidence ledger.
+
+## Workflow
+
+### 1. Context
+
+Read everything about this PR:
+
+```bash
+gh pr view $PR --json body,commits,files
+gh pr diff $PR
+```
+
+Read linked issue(s). Read commit history. Understand the full arc of what was built and why.
+
+### 2. Hindsight Review
+
+Launch `hindsight-reviewer` agent via Task tool.
+
+Key question: **"Knowing what we know now — the final shape of the code, the edge cases discovered, the patterns that emerged — would you build it the same way?"**
+
+Feed it: full diff against main, PR description, linked issue.
+
+Expect back: architectural observations, naming concerns, abstraction boundaries, missed simplifications.
+
+### 3. Refine
+
+Address hindsight findings using two-pass refinement (see `pr-fix/references/refactor.md`):
+
+**Pass 1 — Clarity:** Naming improvements, reduced nesting, consolidated logic, removed obvious comments.
+
+**Pass 2 — Architecture:** Shallow module consolidation, unnecessary abstraction removal, information hiding improvements.
+
+Delete compatibility layers that only exist to preserve agent-added structure.
+Passing tests do not justify bloat.
+
+For architectural findings that require broader changes: create GitHub issues.
+
+```bash
+gh issue create --title "[Arch] Finding from PR #$PR hindsight review" --body "..."
+```
+
+### 3.5 Simplification Pass (Capability-Gated)
+
+After Pass 2, run a focused simplification sweep.
+
+- Preferred accelerator (if native in current harness): `/simplify`
+- Portable fallback (required): consult the `ousterhout` persona guidance and apply resulting module-depth simplifications manually
+
+If native batch dispatch is available (e.g. `/batch`), use it to parallelize refine/test/docs subtasks.
+Otherwise execute those subtasks sequentially.
+
+### 4. Test Audit
+
+Review test coverage for the PR's changed files. Look for:
+
+- Missing edge cases
+- Error path coverage
+- Behavior tests (not implementation tests — per `/testing-philosophy`)
+- Module-boundary tests over internal call choreography
+- Boundary conditions
+- Integration gaps
+
+Write missing tests. Each test should justify its existence — no coverage-padding.
+
+If tests are mock-heavy or fail on refactor-only changes, rewrite them as developer tests against exports/public behavior.
+
+### 4.25 Merge Confidence Audit
+
+Ask directly: **"What evidence says this merge will not break existing behavior, and what evidence is still missing?"**
+
+Build a short confidence ledger:
+- `Evidence` — passing tests, typechecks, builds, lint, manual QA, dogfood runs, screenshots, production-safe invariants
+- `Gaps` — missing regression tests, no CI, weak smoke tests, unverified migration paths, untouched error paths, missing browser/runtime verification
+- `Risk` — what could still break despite current green checks
+
+Then remediate the highest-leverage gaps you can within polish scope:
+- Add or strengthen regression/smoke tests for changed behavior
+- Add or tighten CI when checks are missing or too weak
+- Run build/typecheck/lint/test commands that cover the changed surface
+- Run targeted manual QA or browser QA for user-facing diffs
+- Verify compatibility paths explicitly when multiple entrypoints exist (`npm` vs `bun`, web vs mobile, API vs UI)
+
+Rules:
+- If there is **no CI** for the relevant checks, add it or document precisely why it cannot be added in this pass
+- If confidence depends on a manual assumption, turn it into an automated check when feasible
+- Do not claim "high confidence" while major evidence gaps remain
+- If a gap is too broad for polish, create a follow-up issue and call out the residual risk in the PR
+
+### 4.5 Agentic Audit
+
+If the PR touches prompts, model routing, tool schemas, or agent instructions:
+
+- Run `/llm-infrastructure`
+- Review real traces before changing prompts again
+- Add eval cases for observed confusions/regressions
+- Remove irrelevant prompt bulk discovered in traces
+
+### 5. Documentation
+
+Update docs for anything the PR affects:
+
+- ADRs for architectural decisions made during implementation
+- README updates for new features or changed behavior
+- Architecture diagrams if module boundaries changed
+- API docs if endpoints changed
+
+### 6. Quality Gates
+
+Invoke `/check-quality` and run project verification:
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+All gates must pass. Fix anything that doesn't.
+If repo-wide gates are already red from unrelated debt, still add the strongest PR-scoped automated checks you can and record the residual gap.
+
+### 7. Update PR Description with Before / After + Walkthrough
+
+Edit the PR body to preserve the richer `/pr` structure and update the sections affected by the polish pass.
+Refresh the `## Walkthrough` section too if the polish changes the strongest merge evidence:
+
+```bash
+gh pr edit $PR --body "$(updated body)"
+```
+
+Before editing, read `../pr/references/pr-body-template.md`.
+
+Refresh:
+- `Why This Matters` if the polish changed the meaning or significance of the PR
+- `Trade-offs / Risks` if the polish removed or introduced reviewer concerns
+- `What Changed` diagrams if the final architecture/flow drifted during review
+- `Before / After` to document what the polish improved
+- `Merge Confidence` to reflect the new evidence level after polish
+
+**Text (MANDATORY)**: Describe the state before polish (e.g., "working but with shallow modules and missing edge-case tests") and after (e.g., "consolidated modules, 12 new edge-case tests, updated architecture docs").
+
+**Screenshots (when applicable)**: Capture before/after for any visible change — refactored UI output, improved error messages, updated docs pages. Use `![before](url)` / `![after](url)`.
+
+Skip screenshots only when all polish was purely internal (refactoring with no visible output change).
+
+If polish changes the story reviewers should trust, rerun `/pr-walkthrough` and update:
+
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
+
+### 7.5 Diagram Audit
+
+Check PR body for visual communication:
+
+```bash
+gh pr view $PR --json body | jq -r '.body'
+```
+
+- Does it include base-branch and PR-branch flow charts plus the deeper architecture/state diagram when the change has meaningful flow?
+- If no, and the change involves logic/architecture/data flow: generate them using `~/.claude/skills/visualize/references/github-mermaid-patterns.md`
+- If yes: validate they accurately reflect the **final state** and make the improvement legible
+- Add or update diagram in PR body: `gh pr edit $PR --body "$(updated body)"`
+
+Omit only when the change is purely internal with no branching or relationships.
+
+### 8. Refresh Context Artifacts (Conditional)
+
+If this PR added, removed, or significantly restructured directories:
+
+Refresh the relevant context artifacts if the repo uses them:
+
+- `docs/CODEBASE_MAP.md`
+- `docs/context/INDEX.md`
+- `docs/context/ROUTING.md`
+- `docs/context/DRIFT-WATCHLIST.md`
+
+Commit any updated context artifacts with the PR branch.
+
+### 9. Codify (Optional)
+
+If patterns or learnings emerged during this polish pass, invoke `/distill` to capture them as permanent knowledge (hooks, agents, skills, CLAUDE.md entries).
+
+Skip if nothing novel surfaced.
+
+## Anti-Patterns
+
+- Polishing a PR that doesn't work yet (use `/pr-fix` first)
+- Architectural refactors in a polish pass (create issues instead)
+- Adding tests for coverage percentage instead of confidence
+- Claiming merge confidence without listing concrete evidence and residual risk
+- Leaving missing CI unaddressed when the PR depends on local-only verification
+- Documenting obvious mechanics instead of non-obvious decisions
+- Skipping hindsight and jumping straight to refactoring
+- Preserving unnecessary backward-compat shims in greenfield or pre-user code
+
+## Output
+
+Summary: hindsight findings, refactors applied, issues created, tests added, docs updated, quality gate results, merge-confidence evidence/gaps, learnings codified.

--- a/base/skills/pr-polish/glance.md
+++ b/base/skills/pr-polish/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Final polish pass for merge readiness, simplification, and small ergonomics improvements.

--- a/base/skills/pr-walkthrough/SKILL.md
+++ b/base/skills/pr-walkthrough/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: pr-walkthrough
+description: |
+  Create the mandatory walkthrough package for a pull request. Designs the script,
+  chooses the renderer (browser, terminal, diagram, or Remotion), captures before/after
+  evidence, and links one persistent verification check to the story being told.
+  Use when: opening a PR, preparing reviewer evidence, recording a demo, or proving why
+  a branch should merge. Keywords: walkthrough, demo video, QA walkthrough, before/after,
+  reviewer evidence, PR artifact.
+disable-model-invocation: true
+argument-hint: "[PR-number-or-branch]"
+---
+
+# /pr-walkthrough
+
+Generate the truth artifact for a PR.
+
+## Objective
+
+For every PR, produce one walkthrough package:
+
+- walkthrough spec
+- walkthrough artifact
+- evidence bundle
+- persistent verification link
+
+The walkthrough is mandatory for all PRs. The renderer changes by PR type. The contract does not.
+
+## Deliverables
+
+Every run must leave behind:
+
+1. A script that explains:
+   - what was wrong or missing before
+   - what changed on this branch
+   - what is true after
+   - why the change matters
+   - what test now protects it
+2. A primary artifact:
+   - browser recording
+   - terminal walkthrough
+   - Remotion-rendered narrated video
+   - mixed media walkthrough
+3. Evidence references for each major claim
+4. A PR body `## Walkthrough` section linking the artifact and the protecting check
+
+## Workflow
+
+### 1. Read the merge case
+
+Read the issue, diff, draft PR body, changed tests, and current QA evidence.
+
+Do not script from the diff alone. The walkthrough must explain significance, not just motion.
+
+### 2. Pick the renderer
+
+Use the renderer selection in `references/walkthrough-contract.md`.
+If multiple surfaces matter, use a mixed walkthrough.
+If a polished Remotion cut adds value, treat it as a non-blocking pass after the deterministic evidence flow is already strong.
+
+### 3. Write the walkthrough spec
+
+Use the contract in `references/walkthrough-contract.md`.
+Use its default script beats as the canonical sequence.
+Every scene must map to observable evidence.
+
+### 4. Capture evidence first
+
+Before recording the final walkthrough:
+
+- collect before/after screenshots, clips, command output, or diagrams
+- capture the happy path
+- capture one key edge, failure, or invariant when it materially affects confidence
+- identify the single automated check that best protects this change
+
+The walkthrough artifact is not enough on its own. The evidence must stand on its own if the video is skipped.
+
+### 5. Produce the artifact
+
+Preferred order:
+
+1. deterministic browser or terminal walkthrough
+2. optional polished Remotion cut with narration or music
+
+Never block a PR on a cinematic pass if the deterministic walkthrough is already strong and truthful.
+
+### 6. Tie it to persistent verification
+
+Every walkthrough must name the test, smoke check, or CI job that now protects the path it demonstrates.
+
+If no durable automated check exists:
+
+- add one when feasible
+- otherwise call out the gap explicitly and make fixing it the next quality task
+
+### 7. Update the PR body
+
+Add a `## Walkthrough` section that includes:
+
+- renderer used
+- artifact link
+- core claim the walkthrough proves
+- before/after scope covered
+- persistent check protecting the path
+- residual gap, if any
+
+## Rules
+
+- All PRs get a walkthrough. No exceptions.
+- The artifact must strengthen reviewer confidence, not just advertise polish.
+- Prefer deterministic evidence over high-production ambiguity.
+- Remotion is encouraged for high-value communication, not as a substitute for proof.
+- If the PR changes nothing user-visible, narrate invariants, architecture, and verification instead.
+
+## References
+
+- `references/walkthrough-contract.md` - renderer selection, script rubric, and PR section template

--- a/base/skills/pr-walkthrough/glance.md
+++ b/base/skills/pr-walkthrough/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Structured PR inspection and explanation workflow for reviewers and shepherds.

--- a/base/skills/pr-walkthrough/references/walkthrough-contract.md
+++ b/base/skills/pr-walkthrough/references/walkthrough-contract.md
@@ -1,0 +1,94 @@
+# Walkthrough Contract
+
+Every PR needs one walkthrough package that answers five questions:
+
+1. What was wrong, missing, risky, or expensive before this branch?
+2. What changed?
+3. What is observably better or safer now?
+4. What evidence proves that claim?
+5. What persistent check protects the path going forward?
+
+## Evaluation Rubric
+
+Judge every walkthrough against this rubric:
+
+| Dimension | Question |
+|-----------|----------|
+| Significance | Does it explain why the change matters now? |
+| Baseline | Does it show the real before state instead of hand-waving it? |
+| Delta | Does it make the branch delta legible? |
+| Proof | Does each major claim map to evidence? |
+| Protection | Does it link the story to a durable automated check? |
+| Residual risk | Does it say what is still not proven? |
+
+## Renderer Selection
+
+| Situation | Best format | Evidence to include |
+|-----------|-------------|---------------------|
+| Frontend UX or workflow | Browser recording | before/after screenshots, happy path, one key edge case |
+| CLI or developer workflow | Terminal walkthrough | commands, expected output, before/after behavior |
+| Backend or API change | Terminal plus diagrams | request/response traces, data/state change, regression test |
+| Infra, CI, architecture, refactor | Diagram-led walkthrough | old vs new flow, invariants preserved, proof commands |
+| Broad launch or stakeholder update | Remotion video | narration, diagrams, screenshots, optional music/voiceover |
+
+Use mixed media when one renderer is insufficient.
+
+## Default Script
+
+Use this script unless the PR needs a stronger variant:
+
+1. **Title**
+   The PR name and one-sentence merge claim.
+2. **Why now**
+   The pain, risk, or opportunity that justified the work.
+3. **Before**
+   Show the old behavior, system state, or workflow.
+4. **What changed**
+   Summarize the key branch delta in human terms.
+5. **After**
+   Show the new behavior, system state, or workflow.
+6. **Verification**
+   Run or cite the automated check that protects this path.
+7. **Residual risk**
+   State what remains unproven or intentionally deferred.
+8. **Merge case**
+   Close with why shipping this branch is worth it.
+
+## Evidence Mapping
+
+For each scene, capture at least one of:
+
+- screenshot
+- browser clip
+- command output
+- test result
+- diagram
+- data diff
+
+If a scene has no evidence, cut or rewrite the claim.
+
+## PR Body Template
+
+Every PR should include a section like this:
+
+```md
+## Walkthrough
+
+- Renderer: Browser walkthrough | Terminal walkthrough | Remotion walkthrough | Mixed
+- Artifact: [link to video or walkthrough bundle]
+- Claim: [the single sentence this walkthrough proves]
+- Before / After scope: [what surfaces are covered]
+- Persistent verification: `[exact test, smoke check, or CI job]`
+- Residual gap: [what still is not automated or not shown]
+```
+
+## Persistent Check Rule
+
+The walkthrough should produce or reinforce one durable protection:
+
+- E2E test for user flow changes
+- integration or contract test for API/backend changes
+- smoke test or CI assertion for infra/tooling changes
+- regression test for bug fixes
+
+If the walkthrough reveals a path that matters and nothing protects it, that is a quality finding.

--- a/base/skills/pr/SKILL.md
+++ b/base/skills/pr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr
+description: |
+  Full PR workflow from working directory to draft PR.
+  Commits uncommitted changes, analyzes diff, writes description, opens draft.
+  Use when: opening a pull request, shipping to review, creating PR.
+  Trigger: /pr, "open PR", "create pull request", "ship to review".
+disable-model-invocation: true
+---
+
+# /pr
+
+Open a pull request from current branch state.
+
+## Role
+
+Engineer shipping clean, well-documented PRs.
+
+## Objective
+
+Create a draft PR from current branch. Link to issue, make the significance obvious, give reviewers the value/trade-off context they need at a glance, and attach the walkthrough package that proves the merge case.
+
+## Latitude
+
+- Stage and commit any uncommitted changes with semantic message
+- Read linked issue from branch name or recent commits
+- Write PR body that explains significance, value, trade-offs, and alternatives, not just changes
+- Run `/pr-walkthrough` and treat its output as required PR evidence
+- `dogfood`, `agent-browser`, and `browser-use` are available here; use them for flow QA evidence
+- Load [references/pr-body-template.md](./references/pr-body-template.md) before writing the PR body
+- Treat an existing PR for the same branch or issue as the lane to update, not a reason to create another PR
+
+## PR Body Requirements (MANDATORY)
+
+Every PR body must follow [references/pr-body-template.md](./references/pr-body-template.md).
+A PR missing template sections is not ready.
+
+Use `<details>/<summary>` to collapse larger sections such as Alternatives,
+Manual QA, Acceptance Criteria, Test Coverage, Walkthrough evidence, and screenshot-heavy Before / After evidence.
+Keep `Why This Matters`, `Trade-offs / Risks`, and the opening `What Changed` explanation visible.
+
+## Workflow
+
+1. **Duplicate PR Gate** — Before writing anything to GitHub:
+   - Detect the linked issue from branch name, commit messages, or diff context
+   - Preferred: run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` when the repo provides it
+   - Check for an existing PR from the current branch
+   - Check for other open PRs already referencing the same issue number
+   - If the current branch already has a PR, update it with `gh pr edit` instead of creating a new one
+   - If another branch already has an open PR for the same issue, stop and surface the duplicate lane unless you are explicitly superseding it
+2. **Clean** — Commit any uncommitted changes with semantic message
+3. **Context** — Read linked issue, diff branch against main, identify relevant tests
+4. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa`. Fix any P0/P1 issues before opening PR. Capture screenshots for Before/After section.
+5. **Dogfood QA** — Run `/dogfood http://localhost:3000` (start dev server first if not running).
+   `/dogfood` is a skill command (not a PATH CLI check). Use `agent-browser` / `browser-use` for focused repro as needed.
+   Fix all P0/P1 issues found. Iterate until clean. **Do not open a PR until this passes.**
+   Include dogfood summary (issues found, fixed) in PR body under Manual QA section.
+6. **Walkthrough** — Run `/pr-walkthrough`. Every PR needs a walkthrough package, even when the change is not user-facing. Use browser, terminal, diagram, Remotion, or mixed media as appropriate.
+7. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
+8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the PR body gets long, move heavy evidence into `<details>`.
+9. **Open / Update** — Use `gh pr create --draft --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.
+10. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
+11. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
+   ```bash
+   /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
+     --scope "{what_changed_from_spec}" --blocker "{blockers}" --pattern "{insight}"
+   ```
+   This feeds the grooming feedback loop — `/groom` reads retro.md to calibrate
+   future effort estimates and issue scoping.
+
+## Comment Style
+
+Like a colleague leaving context for future-you:
+- **Concise** — No fluff
+- **High-context** — Reference files, functions, decisions
+- **Useful** — What's not obvious from the diff?
+- **Human** — Some wit welcome
+
+## Output
+
+PR URL. Retro entry appended to `.groom/retro.md` (if issue-linked).

--- a/base/skills/pr/glance.md
+++ b/base/skills/pr/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. PR creation discipline, intent references, summaries, and operator-facing verification notes.

--- a/base/skills/pr/references/pr-body-template.md
+++ b/base/skills/pr/references/pr-body-template.md
@@ -1,0 +1,209 @@
+# PR Body Template
+
+Use this structure when creating or heavily rewriting a PR description.
+
+## Goals
+
+- Lead with significance, not mechanics.
+- Explain value added, trade-offs accepted, and why those trade-offs are worth it.
+- Make the diff legible with before/after diagrams, not a single abstract chart.
+- Make the walkthrough artifact part of the merge case, not an afterthought.
+- Keep the top of the PR skimmable; push heavier detail into `<details>` blocks.
+
+## Top-Level Shape
+
+These sections should stay visible on first load:
+
+````markdown
+## Why This Matters
+- Problem:
+- Value:
+- Why now:
+- Issue:
+
+## Trade-offs / Risks
+- Value gained:
+- Cost / risk incurred:
+- Why this is still the right trade:
+- Reviewer watch-outs:
+
+## What Changed
+One short paragraph explaining the improvement in plain English.
+
+### Base Branch
+```mermaid
+graph TD
+  ...
+```
+
+### This PR
+```mermaid
+graph TD
+  ...
+```
+
+### Architecture / State Change
+```mermaid
+graph TD
+  ...
+```
+
+Why this is better:
+- ...
+- ...
+````
+
+## Visibility Toggles
+
+Use `<details>` for sections that are valuable but not needed at first glance:
+
+- `Intent Reference`
+- `Changes`
+- `Acceptance Criteria`
+- `Alternatives Considered`
+- `Manual QA`
+- `Walkthrough`
+- `Test Coverage`
+- `Merge Confidence`
+- `Screenshots / before-after evidence`
+
+Pattern:
+
+```md
+<details>
+<summary>Alternatives Considered</summary>
+
+## Alternatives Considered
+### Option A — Do nothing
+- Upside:
+- Downside:
+- Why rejected:
+
+### Option B — Alternate implementation
+- Upside:
+- Downside:
+- Why rejected:
+
+### Option C — Current approach
+- Upside:
+- Downside:
+- Why chosen:
+
+</details>
+```
+
+## Required Sections
+
+All PRs must contain these sections, visible or inside `<details>`:
+
+### `## Why This Matters`
+
+Top-line significance. This is the first thing a reviewer should understand.
+
+- What problem or opportunity existed before this PR?
+- What user, product, operational, or architectural value does this add?
+- Why is this worth reviewer attention now?
+
+### `## Trade-offs / Risks`
+
+Be explicit. There are no perfect solutions.
+
+- What complexity or cost did we add?
+- What risks remain?
+- Why is the value worth those risks?
+- What should reviewers pressure-test?
+
+### `## What Changed`
+
+Use diagrams to make the delta legible:
+
+1. **Base branch flow chart** — what the current path looks like before merge
+2. **PR flow chart** — what changes after merge
+3. **Architecture/state/sequence diagram** — the underlying structural improvement
+
+Then explain why the new shape is better. The diagrams are not self-explanatory.
+
+### `## Alternatives Considered`
+
+Show that other paths were examined.
+
+Include at least:
+- do nothing / defer
+- one credible alternate implementation
+- why the current choice won
+
+### `## Changes`
+
+Concrete file/module summary. This is the mechanical diff summary, so it should not come before significance.
+
+### `## Intent Reference`
+
+Link the issue/spec/intent contract that justifies the work.
+
+- Quote or summarize the core intent
+- Link to the source issue, spec, or design section
+- Make it easy for reviewers to compare intent vs implementation
+
+### `## Acceptance Criteria`
+
+Copy or derive from the issue. Use checkboxes.
+
+### `## Manual QA`
+
+Exact commands, URLs, setup, expected output. Keep long logs or screenshots under `<details>`.
+
+### `## Walkthrough`
+
+This is the proof package for the PR.
+
+- Renderer
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
+
+For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
+
+### `## Before / After`
+
+Show the previous state and the new state explicitly.
+
+- Text is mandatory for every PR
+- Screenshots are mandatory for user-visible changes
+- For internal-only changes, explain why screenshots are not needed
+
+### `## Test Coverage`
+
+Point to exact test files or suites. Call out gaps plainly.
+
+### `## Merge Confidence`
+
+State:
+- confidence level
+- strongest evidence
+- remaining uncertainty
+- what could still go wrong after merge
+
+## Diagram Selection
+
+Choose the third diagram based on change type:
+
+- feature / composition change → `graph TD`
+- bug fix with state transition → `stateDiagram-v2`
+- API/request flow → `sequenceDiagram`
+- data model → `erDiagram`
+
+The first two diagrams are always **base branch** and **this PR** flow charts when the change has meaningful flow.
+
+For Mermaid syntax examples and GitHub rendering constraints, load
+`~/.claude/skills/visualize/references/github-mermaid-patterns.md`.
+
+## Cleanliness Rules
+
+- Do not bury the value proposition below a long diff recap.
+- Do not present risks only as a footnote.
+- Do not use a single diagram when before/after comparison is the actual point.
+- Do not force screenshots for purely internal changes, but do provide text before/after.
+- Do use `<details>` to keep the PR readable when sections get long.
+- Do make the walkthrough point to one durable automated check, not just a polished artifact.

--- a/base/skills/shape/SKILL.md
+++ b/base/skills/shape/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: shape
+description: |
+  Full interactive planning for a single idea. Product spec, technical design,
+  breadboarding, and implementation planning in one conversational session.
+  Use when: planning a feature, shaping an idea, writing specs, designing architecture.
+  Trigger: /shape, /spec, /architect, /brainstorm, /breadboard, /shaping, /critique.
+disable-model-invocation: true
+argument-hint: <issue-id-or-idea>
+---
+
+# SHAPE
+
+> Take a raw idea and shape it into something buildable.
+
+## Role
+
+You are both product lead and technical lead. Shape an idea from raw concept
+to implementation-ready issue(s) in one interactive session.
+
+## When to Use
+
+| Situation | Use |
+|-----------|-----|
+| Full backlog session, many issues | `/groom` |
+| Full planning for one idea: product + technical + discussion | **`/shape`** |
+| Just need quick autonomous delivery | `/autopilot` |
+
+## Modes
+
+### Full Shape (default)
+Interactive product + technical exploration with user. Phases 1-4 below.
+
+### Spec Only (`/shape --spec-only`)
+Product exploration only (WHAT and WHY). Skip technical design.
+
+### Design Only (`/shape --design-only`)
+Technical exploration only (HOW). Requires existing product spec on issue.
+
+### Critique (`/shape --critique <persona>`)
+Adversarial expert review. See `references/critique-personas.md`.
+
+### Plan Only (`/shape --plan`)
+Generate implementation plan from existing spec+design. See `references/writing-plans.md`.
+
+## Workflow
+
+### Phase 1: Understand
+
+Accept input: raw idea (string), issue ID, or observation.
+
+1. If no issue exists: create skeleton immediately
+2. If issue exists: `gh issue view $1 --comments`
+3. Load `project.md` if present (falls back to `vision.md`)
+4. Read relevant codebase context — adjacent features, existing patterns, constraints
+5. If `docs/context/` is missing, bootstrap `INDEX.md`, `ROUTING.md`, and `DRIFT-WATCHLIST.md` from `codified-context-architecture/references/templates.md` or explicitly note that repo context is not tuned yet. Do not cite cold-memory docs that do not exist.
+
+Present: "Here's what I understand. Let me explore the problem space."
+
+### Phase 2: Product Exploration
+
+**Gate: Do NOT write any code or take implementation actions until product direction is locked.**
+
+1. **Investigate** — Problem space, user impact, prior art (parallel agents)
+
+   | Agent | Focus |
+   |-------|-------|
+   | Problem explorer | What's the real problem? Who has it? How painful? |
+   | Web research agent | How do others solve this? Current best practices |
+   | Codebase explorer | Existing patterns, affected files, reusable utilities |
+   | User impact analyst | Who's affected, how much, cost of inaction |
+
+2. **Brainstorm** — Propose 2-3 product approaches with tradeoffs. For each:
+   - What the user experiences (concrete interaction flow)
+   - What value it delivers
+   - Scope: Small / Medium / Large
+   - What it enables downstream
+
+   **Recommend one.** Lead with recommendation and reasoning.
+   If ideas become polished variants or the room goes flat, invoke `break-the-frame`.
+
+3. **Discuss** — User steers. One question at a time. Multiple choice preferred.
+   Iterate until product direction is locked.
+
+4. **Find the cheapest test** — If uncertainty is real, define the fastest cheap
+   experiment that would change the decision. Prefer probes over speculation.
+
+5. **Draft spec** — Post on issue:
+
+   ```markdown
+   ## Product Spec
+
+   ### Problem
+   [Validated problem — 2-3 sentences]
+
+   ### Users
+   **Primary**: [Role] — [context, pain, goal]
+
+   ### Recommended Approach
+   [Chosen direction and why]
+
+   ### Intent Contract
+   - Intent: [What must be true after shipping]
+   - Success Conditions: [Measurable outcomes]
+   - Hard Boundaries: [What must never change]
+   - Non-Goals: [Explicitly out of scope]
+
+   ### Acceptance Criteria
+   - [ ] [test] Given [precondition], when [action], then [expected assertion in tests]
+   - [ ] [command] Given [precondition], when `[shell command]`, then [expected output]
+   - [ ] [behavioral] Given [precondition], when [user action], then [observable behavior]
+
+   ### User Stories
+   - As [persona], I want [action] so that [value]
+
+   ### Success Metrics
+   | Metric | Target | How Measured |
+
+   ### Non-Goals
+   - [What we're NOT building]
+
+   ### Boundaries
+   - Do NOT modify [X]
+
+   ### Verification
+   [commands to verify the implementation works]
+
+   ### Open Questions for Architect
+   [Technical unknowns surfaced during exploration]
+
+   ### PR Intent Reference
+   - Every implementation PR must link this issue and include an "Intent Reference" section.
+
+   ## Flow
+   [Mermaid diagram — flowchart LR for user journeys, flowchart TD for decision trees, sequenceDiagram for integrations]
+   ```
+
+### Phase 3: Technical Exploration
+
+1. **Absorb** — Read locked product spec, investigate codebase, research patterns.
+
+   | Agent | Focus |
+   |-------|-------|
+   | Codebase explorer | Existing patterns, touch points, docs/context + CODEBASE_MAP context |
+   | Web researcher | Best practices, framework docs, how others solve this |
+   | Cross-repo investigator | Prior art in org repos, shared patterns |
+
+2. **Explore** — Generate 3-5 technical approaches. For each:
+   - Architecture sketch (components, data flow, interfaces)
+   - Files to modify/create
+   - Pattern alignment with existing codebase
+   - Tradeoffs (complexity, performance, maintainability, deletability)
+   - Effort estimate: S/M/L/XL
+
+   **Recommend one.** Present all with clear reasoning.
+
+3. **Discuss** — User pushes back, questions, proposes alternatives.
+   No limit on rounds. Design isn't ready until user says it is.
+
+4. **Draft design** — Post on issue:
+
+   ```markdown
+   ## Technical Design
+
+   ### Approach
+   [Strategy and key decisions — 1-2 paragraphs]
+
+   ### Files to Modify/Create
+   - `path/file.ts` — [what changes]
+
+   ### Interfaces
+   [Key types, APIs, data structures — actual code blocks]
+
+   ### Implementation Sequence
+   1. [First chunk]
+   2. [Second chunk]
+
+   ### Testing Strategy
+   [What to test, how, which patterns]
+
+   ### Risks & Mitigations
+   [Technical risks and how to handle them]
+
+   ## Components
+   [Mermaid graph TD — always required]
+
+   ## Sequence
+   [Mermaid sequenceDiagram — when async/API/multi-step flows involved]
+   ```
+
+### The Interweaving
+
+Key difference from running spec then architect sequentially:
+
+During technical exploration, product decisions can be revisited.
+"This architecture would be simpler if we scoped the feature differently"
+-> return to product discussion -> refine -> continue.
+
+The skill explicitly allows looping back. Technical constraints inform product
+decisions and vice versa. No phase is final until everything is locked.
+
+### Phase 4: Synthesis
+
+Once both product and technical directions are locked:
+
+1. **Verify alignment** — Do spec and design tell a coherent story?
+2. **Break down** — If scope warrants, yield multiple atomic issues
+3. **Enrich each issue** — Product spec + technical design on every issue
+4. **Apply standards** — Labels, milestones, org-wide standards (see `groom/references/org-standards.md`)
+5. **Signal readiness** — `status/ready` for `/build` or `/autopilot`
+6. **Stress-test** — Run critique (see `references/critique-personas.md`) to find gaps
+7. **Prefer probe issues first** — if uncertainty remains high, create a cheap experiment issue before the full build issue
+
+Post spec + design as comments on each issue.
+
+### Optional: Implementation Plan
+
+If the user wants detailed implementation planning:
+
+1. Write plan to `docs/plans/YYYY-MM-DD-<feature>.md`
+2. See `references/writing-plans.md` for the full procedure
+
+## Shape Up Methodology
+
+For formal Shape Up methodology (requirements/shapes notation, fit checks,
+breadboarding, slicing), see:
+- `references/shaping-methodology.md` — R/S notation, fit checks, phases
+- `references/breadboarding.md` — Affordance mapping and vertical slicing
+
+## Agent Teams Mode
+
+For ambitious ideas (multiple issues expected):
+
+| Teammate | Role |
+|----------|------|
+| Product explorer | Product exploration for the idea |
+| Technical explorer | Architecture exploration in parallel |
+| Research agent | Best practices, competitive analysis |
+
+Lead synthesizes and presents unified view. User steers both product and
+technical directions simultaneously rather than sequentially.
+
+Use when: large feature, greenfield module, multiple valid approaches.
+Don't use when: small idea, clear direction, single issue output.
+
+## Principles
+
+- Minimize touch points (fewer files = less risk)
+- Design for deletion (easy to remove later)
+- Favor existing patterns over novel ones
+- YAGNI ruthlessly — remove unnecessary features from all designs
+- One question at a time — don't overwhelm the user
+- Explore alternatives — always propose 2-3 approaches before settling
+- Incremental validation — present design, get approval before moving on
+
+## Completion
+
+"Shape complete. {N} issue(s) ready for `/build` or `/autopilot`."
+
+List issues with links. Summarize: product direction, technical approach,
+implementation sequence, estimated effort.

--- a/base/skills/shape/glance.md
+++ b/base/skills/shape/glance.md
@@ -1,0 +1,1 @@
+Imported from phrazzld/agent-skills. Turns rough work into a clarified executable spec with explicit decisions, risks, and confidence.

--- a/base/skills/shape/references/breadboarding.md
+++ b/base/skills/shape/references/breadboarding.md
@@ -1,0 +1,1649 @@
+# Breadboarding
+
+Breadboarding transforms a workflow description into a complete map of affordances and their relationships. The output is always a set of tables showing numbered UI and Code affordances with their Wires Out and Returns To relationships. The tables are the truth. Mermaid diagrams are optional visualizations for humans.
+
+---
+
+## Use Cases
+
+Breadboarding serves two functions:
+
+### 1. Mapping an Existing System
+
+You don't understand how an existing system works in its concrete details. You have a workflow you're trying to understand — explaining how something happens or why something doesn't happen.
+
+**Input:**
+- Code repo(s) to analyze
+- Workflow description (always from the perspective of an operator trying to make an effect happen — through UI or as a caller)
+
+**Output:**
+- UI Affordances table
+- Code Affordances table
+- (Optional) Mermaid visualization
+
+**Note:** If the workflow spans multiple applications (frontend + backend), create ONE breadboard that tells the full story. Label places to show which system they belong to.
+
+### 2. Designing from Shaped Parts
+
+You have a new system sketched as an assembly of parts (mechanisms) per shaping. You need to detail out the concrete mechanism and show how those parts interact as a system.
+
+**Input:**
+- Parts list (mechanisms from shaping)
+- The R (requirement/outcome) the parts are meant to achieve
+- Existing system (optional) — if the new parts must interoperate with existing code
+
+**Output:**
+- UI Affordances table
+- Code Affordances table
+- (Optional) Mermaid visualization
+
+### Mixtures
+
+Often you have both: an existing system that must remain as-is, plus new pieces or changes defined in a shape. In this case, breadboard both together — the existing affordances and the new ones — showing how they connect.
+
+### 3. Reading a Whiteboard Breadboard
+
+Hand-drawn or whiteboard breadboards use a visual stacking format rather than tables. The same concepts apply (Places, affordances, wiring) but the layout conventions differ.
+
+**Visual conventions:**
+
+| Element | How it appears |
+|---------|---------------|
+| **Place** | Colored block (often pink/purple) at the **top** of a vertical stack |
+| **Affordances in a place** | Blocks stacked **underneath** the place block — containment is shown by vertical position in the stack |
+| **Code affordances** | Typically float **between** place stacks, not inside them |
+| **Place loader** | A code affordance positioned at the **top-left** of the place block — describes the data/inputs needed to render that place |
+| **Wires Out** | Solid arrows between blocks |
+| **Returns To** | Dashed arrows between blocks |
+| **Conditionals** | Indented blocks within a stack, often a different color (e.g., green), showing if/else branches |
+| **Place references** | `_` prefix on a place name within a stack (same as `_PlaceName` convention) |
+| **Uncertain/tentative** | `?` prefix or `~` prefix on an affordance name, or dashed borders — indicates the affordance is speculative |
+| **Containing box** | A large boundary drawn around multiple stacks — groups affordances by system or responsibility boundary (e.g., "HireEZ" box) |
+| **Notes/annotations** | Freeform text near elements — context, open questions, or rationale |
+
+**How to read a whiteboard breadboard:**
+
+1. **Identify places** — Find the colored header blocks at the top of each stack
+2. **Read each stack top-to-bottom** — Everything stacked under a place belongs to that place
+3. **Find loaders** — Code affordances at the top-left of a place block describe what data is needed to render
+4. **Trace wiring** — Follow arrows between stacks for control flow (solid) and data flow (dashed)
+5. **Note conditionals** — Indented blocks with different colors show branching logic within a place
+6. **Check containing boxes** — Large boundaries indicate system/responsibility boundaries
+7. **Flag speculative items** — `?` and `~` prefixed items are uncertain and may not survive shaping
+
+**Translating to tables:** When converting a whiteboard breadboard to standard affordance tables, map each stack to its Place, enumerate the affordances top-to-bottom, and capture the arrows as Wires Out / Returns To relationships. Loaders become code affordances with Returns To pointing at the UI affordances they feed.
+
+---
+
+## Core Concepts
+
+### Places
+
+A Place is a **bounded context of interaction**. While you're in a Place:
+- You have a specific set of affordances available to you
+- You **cannot** interact with affordances outside that boundary
+- You must take an action to leave
+
+**Place is perceptual, not technical.** It's not about URLs or components — it's about what the user experiences as their current context. A Place is "where you are" in terms of what you can do right now.
+
+#### The Blocking Test
+
+The simplest test for whether something is a different Place: **Can you interact with what's behind?**
+
+| Answer | Meaning |
+|--------|---------|
+| **No** | You're in a different Place |
+| **Yes** | Same Place, with local state changes |
+
+#### Examples
+
+| UI Element | Blocking? | Place? | Why |
+|------------|-----------|--------|-----|
+| Modal | Yes | Yes | Can't interact with page behind |
+| Confirmation popover | Yes | Yes | Must respond before returning (limit case of modal) |
+| Edit mode (whole screen transforms) | Yes | Yes | All affordances changed |
+| Checkbox reveals extra fields | No | No | Surroundings unchanged |
+| Dropdown menu | No | No | Can click away, non-blocking |
+| Tooltip | No | No | Informational, non-blocking |
+
+#### Local State vs Place Navigation
+
+When a control changes state, ask: did *everything* change, or just a subset while the surroundings stayed the same?
+
+| Type | What happens | How to model |
+|------|--------------|--------------|
+| **Local state** | Subset of UI changes, surroundings unchanged | Same Place, conditional N → dependent Us |
+| **Place navigation** | Entire screen transforms, or blocking overlay | Different Places |
+
+#### Mode-Based Places
+
+When a mode (like "edit mode") transforms the entire screen — different buttons, different affordances everywhere — model as separate Places:
+
+```
+PLACE: CMS Page (Read Mode)
+PLACE: CMS Page (Edit Mode)
+```
+
+The state flag (e.g., `editMode$`) that switches between them is a **navigation mechanism**, not a data store. Don't include it as an S in either Place.
+
+#### Three Questions for Any Control
+
+For any UI affordance, ask:
+1. Where did I come from to see this?
+2. Where am I now?
+3. Where do I go if I act on it?
+
+If the answer to #3 is "everything changes" or "I can't interact with what's behind until I respond," that's navigation to a different Place.
+
+#### Labeling Conventions
+
+| Pattern | Use |
+|---------|-----|
+| `PLACE: Page Name` | Standard page/route |
+| `PLACE: Page Name (Mode)` | Mode-based variant of a page |
+| `PLACE: Modal Name` | Modal dialog |
+| `PLACE: Backend` | API/database boundary |
+
+When spanning multiple systems, label with the system: `PLACE: Checkout Page (frontend)`, `PLACE: Payment API (backend)`.
+
+### Place IDs
+
+Places are first-class elements in the data model. Each Place gets an ID:
+
+| # | Place | Description |
+|---|-------|-------------|
+| P1 | CMS Page (Read Mode) | View-only state |
+| P2 | CMS Page (Edit Mode) | Editing state with page-level controls |
+| P2.1 | widget-grid (letters) | Subplace: letter editing widget within P2 |
+| P3 | Letter Form Modal | Form for adding/editing letters |
+| P4 | Backend | API resolvers and database |
+
+Place IDs enable:
+- **Explicit navigation wiring** — wire `→ P2` instead of to an affordance inside
+- **Containment tracking** — each affordance declares which Place it belongs to
+- **Consistent Mermaid subgraphs** — subgraph ID matches Place ID
+
+### Place References
+
+When a nested place has lots of internal affordances and would clutter the parent, you can **detach** it:
+
+1. Put a **reference node** in the parent place using underscore prefix: `_letter-browser`
+2. Define the full place separately with all its internals
+3. Wire from the reference to the place: `_letter-browser --> letter-browser`
+
+The reference is a **UI affordance** — it represents "this widget/component renders here" in the parent context.
+
+```mermaid
+flowchart TB
+subgraph P1["P1: CMS Page (Read Mode)"]
+    U1["U1: Edit button"]
+    U_LB["_letter-browser"]
+end
+
+subgraph letterBrowser["letter-browser"]
+    U10["U10: Search input"]
+    U11["U11: Letter list"]
+    N40["N40: performSearch()"]
+end
+
+U_LB --> letterBrowser
+```
+
+In affordance tables, list the reference as a UI affordance:
+
+| # | Affordance | Control | Wires Out |
+|---|------------|---------|-----------|
+| U1 | Edit button | click | → N1 |
+| _letter-browser | Widget reference | — | → P3 |
+
+Style place references with a dashed border to distinguish them:
+```
+classDef placeRef fill:#ffb6c1,stroke:#d87093,stroke-width:2px,stroke-dasharray:5 5
+class U_LB placeRef
+```
+
+### Modes as Places
+
+When a component has distinct modes (read vs edit, viewing vs editing, collapsed vs expanded), model them as **separate places** — they're different perceptual states for the user.
+
+If one mode includes everything from another plus more, show this with a **place reference** inside the extended place:
+
+```
+P3: letter-browser (Read)    — base state
+P4: letter-browser (Edit)    — contains _letter-browser (Read) + new affordances
+```
+
+The reference shows composition: "everything in P3 appears here, plus these additions."
+
+```mermaid
+flowchart TB
+subgraph P3["P3: letter-browser (Read)"]
+    U10["U10: Search input"]
+    U11["U11: Letter list"]
+end
+
+subgraph P4["P4: letter-browser (Edit)"]
+    U_P3["_letter-browser (Read)"]
+    U3["U3: Add button"]
+    U4["U4: Edit button"]
+end
+
+U_P3 --> P3
+```
+
+In affordance tables for P4, the reference shows inheritance:
+
+| # | Affordance | Control | Wires Out | Notes |
+|---|------------|---------|-----------|-------|
+| _letter-browser (Read) | Inherits all of P3 | — | → P3 | |
+| U3 | Add button | click | → N3 | NEW |
+| U4 | Edit button | click | → N4 | NEW |
+
+### Subplaces
+
+A **subplace** is a defined subset of a Place — a contained area that groups related affordances. Use subplaces when:
+- A Place contains multiple distinct widgets or sections
+- You're detailing one part of a larger Place
+- You want to show what's in scope vs out of scope
+
+**Notation:** Use hierarchical IDs — `P2.1`, `P2.2`, etc. for subplaces of P2.
+
+```
+| # | Place | Description |
+|---|-------|-------------|
+| P2 | Dashboard | Main dashboard page |
+| P2.1 | Sales widget | Subplace: sales metrics |
+| P2.2 | Activity feed | Subplace: recent activity |
+```
+
+In affordance tables, use the subplace ID to show containment:
+
+```
+| U3 | P2.1 | sales-widget | "Refresh" button | click | → N4 | — |
+| U7 | P2.2 | activity-feed | activity list | render | — | — |
+```
+
+**In Mermaid:** Nest the subplace subgraph inside the parent. Use the same background color (no distinct fill) — the subplace is part of the parent, not a separate Place:
+
+```mermaid
+flowchart TB
+subgraph P2["P2: Dashboard"]
+    subgraph P2_1["P2.1: Sales widget"]
+        U3["U3: Refresh button"]
+    end
+    subgraph P2_2["P2.2: Activity feed"]
+        U7["U7: activity list"]
+    end
+    otherContent[["... other dashboard content ..."]]
+end
+```
+
+**Placeholder for out-of-scope content:** When detailing one subplace, add a placeholder sibling to show there's more on the page:
+
+```
+otherContent[["... other page content ..."]]
+```
+
+This tells readers: "we're zooming in on P2.1, but P2 contains more that we're not detailing."
+
+### Containment vs Wiring
+
+These are two different relationships in the data model:
+
+| Relationship | Meaning | Where Captured |
+|--------------|---------|----------------|
+| **Containment** | Affordance belongs to / lives in a Place | **Place column** (set membership) |
+| **Wiring** | Affordance triggers / calls something | **Wires Out column** (control flow) |
+
+**Containment** is set membership: `U1 ∈ P1` means U1 is a member of Place P1. Every affordance belongs to exactly one Place.
+
+**Wiring** is control flow: `U1 → N1` means U1 triggers N1. An affordance can wire to anything — other affordances or Places.
+
+The Place column answers: "Where does this affordance live?"
+The Wires Out column answers: "What does this affordance trigger?"
+
+### Navigation Wiring
+
+When an affordance causes navigation (user "goes" somewhere), wire to the **Place itself**, not to an affordance inside:
+
+```
+✅ N1 Wires Out: → P2          (navigate to Edit Mode)
+❌ N1 Wires Out: → U3          (wiring to affordance inside P2)
+```
+
+This makes navigation explicit in the tables. The Place is the destination; specific affordances inside become available once you arrive.
+
+In Mermaid, this becomes:
+```
+N1 --> P2
+```
+
+The subgraph ID matches the Place ID, so the wire connects to the Place boundary.
+
+### Affordances
+Things you can act upon:
+- **UI affordances (U)**: inputs, buttons, displayed elements, scroll regions
+- **Code affordances (N)**: methods, subscriptions, data stores, framework mechanisms
+
+### Wiring
+How affordances connect to each other:
+
+**Wires Out** — What an affordance triggers or calls (control flow):
+- Call wires: one affordance calls another
+- Write wires: code writes to a data store
+- Navigation wires: routing to a different place
+
+**Returns To** — Where an affordance's output flows (data flow):
+- Return wires: function returns value to its caller
+- Read wires: data store is read by another affordance
+
+This separation makes data flow explicit. Wires Out show control flow (what triggers what). Returns To show data flow (where output goes).
+
+---
+
+## The Output: Affordance Tables
+
+The tables are the truth. Every breadboard produces these:
+
+### Places Table
+
+| # | Place | Description |
+|---|-------|-------------|
+| P1 | Search Page | Main search interface |
+| P2 | Detail Page | Individual result view |
+
+### UI Affordances Table
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|-------|-----------|------------|---------|-----------|------------|
+| U1 | P1 | search-detail | search input | type | → N1 | — |
+| U2 | P1 | search-detail | loading spinner | render | — | — |
+| U3 | P1 | search-detail | results list | render | — | — |
+| U4 | P1 | search-detail | result row | click | → P2 | — |
+
+### Code Affordances Table
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|-------|-----------|------------|---------|-----------|------------|
+| N1 | P1 | search-detail | `activeQuery.next()` | call | → N2 | — |
+| N2 | P1 | search-detail | `activeQuery` subscription | observe | → N3 | — |
+| N3 | P1 | search-detail | `performSearch()` | call | → N4, → N5, → N6 | — |
+| N4 | P1 | search.service | `searchOneCategory()` | call | → N7 | → N3 |
+| N5 | P1 | search-detail | `loading` | write | store | → U2 |
+| N6 | P1 | search-detail | `results` | write | store | → U3 |
+| N7 | P1 | typesense.service | `rawSearch()` | call | — | → N4 |
+
+### Data Stores Table
+
+| # | Place | Store | Description |
+|---|-------|-------|-------------|
+| S1 | P1 | `results` | Array of search results |
+| S2 | P1 | `loading` | Boolean loading state |
+
+### Column Definitions
+
+| Column | Description |
+|--------|-------------|
+| **#** | Unique ID (P1, P2... for Places; U1, U2... for UI; N1, N2... for Code; S1, S2... for Stores) |
+| **Place** | Which Place this affordance belongs to (containment) |
+| **Component** | Which component/service owns this |
+| **Affordance** | The specific thing you can act upon |
+| **Control** | The triggering event: click, type, call, observe, write, render |
+| **Wires Out** | What this triggers: `→ N4`, `→ P2` (control flow, including navigation) |
+| **Returns To** | Where output flows: `→ N3` or `→ U2, U3` (data flow) |
+
+---
+
+## Procedures
+
+### For Mapping an Existing System
+
+See **Example A** below for a complete worked example.
+
+**Step 1: Identify the flow to analyze**
+
+Pick a specific user journey. Always frame it as an operator trying to do something:
+- "Land on /search, type query, scroll for more, click result"
+- "Call the payment API with a card token, expect a charge to be created"
+
+**Step 2: List all places involved**
+
+Walk through the journey and identify each distinct place the user visits or system boundary crossed.
+
+**Step 3: Trace through the code to find components**
+
+Starting from the entry point (route, API endpoint), trace through the code to find every component touched by that flow.
+
+**Step 4: For each component, list its affordances**
+
+Read the code. Identify:
+- UI: What can the user see and interact with?
+- Code: What methods, subscriptions, stores are involved?
+
+**Step 5: Name the actual thing, not an abstraction**
+
+If you write "DATABASE", stop. What's the actual method? (`userRepo.save()`). Every affordance name must be something real you can point to in the code.
+
+**Step 6: Fill in Control column**
+
+For each affordance, what triggers it? (click, type, call, observe, write, render)
+
+**Step 7: Fill in Wires Out**
+
+For each affordance, what does it trigger? Read the code — what does this method call? What does this button's handler invoke?
+
+**Step 8: Fill in Returns To**
+
+For each affordance, where does its output flow?
+- Functions that return values → list the callers that receive the return
+- Data stores → list the affordances that read from them
+- No meaningful output → use `—`
+
+**Step 9: Add data stores as affordances**
+
+When code writes to a property that is later read by another affordance, add that property as a Code affordance with control type `write`.
+
+**Step 10: Add framework mechanisms as affordances**
+
+Include things like `cdr.detectChanges()` that bridge between code and UI rendering. These show how state changes actually reach the UI.
+
+**Step 11: Verify against the code**
+
+Read the code again. Confirm every affordance exists and the wiring matches reality.
+
+---
+
+### For Designing from Shaped Parts
+
+See **Example B** below for a complete worked example including slicing.
+
+**Step 1: List each part from the shape**
+
+Take each mechanism/part identified in shaping and write it down.
+
+**Step 2: Translate parts into affordances**
+
+For each part, identify:
+- What UI affordances does this part require?
+- What Code affordances implement this part?
+
+**Step 3: Verify every U has a supporting N**
+
+For each UI affordance, check: what Code affordance provides its data or controls its rendering? If none exists, add the missing N.
+
+**Step 4: Classify places as existing or new**
+
+For each UI affordance, determine whether it lives in:
+- An existing place being modified
+- A new place being created
+
+**Step 5: Wire the affordances**
+
+Fill in Wires Out and Returns To for each affordance. Trace through the intended behavior — what calls what? What returns where?
+
+**Step 6: Connect to existing system (if applicable)**
+
+If there's an existing codebase:
+- Identify the existing affordances the new ones must connect to
+- Add those existing affordances to your tables
+- Wire the new affordances to them
+
+**Step 7: Check for completeness**
+
+- Every U should have an N that feeds it
+- Every N should have either Wires Out or Returns To (or both)
+- Handlers → should have Wires Out
+- Queries → should have Returns To
+- Data stores → should have Returns To
+
+**Step 8: Treat user-visible outputs as Us**
+
+Anything the user sees (including emails, notifications) is a UI affordance and needs an N wiring to it.
+
+---
+
+## Key Principles
+
+### Never use memory — always check the data
+
+When tracing a flow backwards, don't follow the path you remember. Scan the Wires Out column for ALL affordances that wire to your target.
+
+When filling in the tables, read each row systematically. Don't rely on what you think you know.
+
+The tables are the source of truth. Your memory is unreliable.
+
+### Every affordance name must exist (when mapping)
+
+When mapping existing code, never invent abstractions. Every name must point to something real in the codebase.
+
+### Mechanisms aren't affordances
+
+An affordance is something you can **act upon** that has meaningful identity in the system. Several things look like affordances but are actually just implementation mechanisms:
+
+| Type | Example | Why it's not an affordance |
+|------|---------|---------------------------|
+| Visual containers | `modal-frame wrapper` | You can't act on a wrapper — it's just a Place boundary |
+| Internal transforms | `letterDataTransform()` | Implementation detail of the caller — not separately actionable |
+| Navigation mechanisms | `modalService.open()` | Just the "how" of getting to a Place — wire to the destination directly |
+
+**These aren't always obvious on first draft.** When reviewing your affordance tables, double-check each Code affordance and ask:
+
+> "Is this actually an affordance, or is it just detailing the mechanism for how something happens?"
+
+If it's just the "how" — skip it and wire directly to the destination or outcome.
+
+**Examples:**
+
+```
+❌ N8 --> N22 --> P3     (N22 is modalService.open — just mechanism)
+✅ N8 --> P3             (handler navigates to modal)
+
+❌ N6 --> N20 --> S2     (N20 is data transform — internal to N6)
+✅ N6 --> S2             (callback writes to store)
+
+❌ U7: modal-frame       (wrapper — just the boundary of P3)
+✅ U8: Save button       (actionable)
+```
+
+The handler navigates to P3. The callback writes to the store. The modal IS P3. The mechanisms are implicit.
+
+### Two flows: Navigation and Data
+
+A breadboard captures two distinct flows:
+
+| Flow | What it tracks | Wiring |
+|------|----------------|--------|
+| **Navigation** | Movement from Place to Place | Wires Out → Places |
+| **Data** | How state populates displays | Returns To → Us |
+
+These are orthogonal. You can have navigation without data changes, and data changes without navigation.
+
+**When reviewing a breadboard, trace both flows:**
+
+1. **Navigation flow:** Can you follow the user's journey from Place to Place?
+2. **Data flow:** For every U that displays data, can you trace where that data comes from?
+
+### Every U that displays data needs a source
+
+A UI affordance that displays data must have something feeding it — either a data store (S) or a code affordance (N) that returns data.
+
+```
+❌ U6: letter list (no incoming wire — where does the data come from?)
+✅ S1 -.-> U6 (store feeds the display)
+✅ N4 -.-> U6 (query result feeds the display)
+```
+
+If a display U has no data source wiring into it, either:
+1. The source is missing from the breadboard
+2. The U isn't real
+
+This is easy to miss when focused on navigation. Always ask: "This U shows data — where does that data come from?"
+
+### Every N must connect
+
+If a Code affordance has no Wires Out AND no Returns To, something is wrong:
+- Handlers → should have Wires Out (what they call or write)
+- Queries → should have Returns To (who receives their return value)
+- Data stores → should have Returns To (which affordances read them)
+
+### Side effects need stores
+
+An N that appears to wire nowhere is suspicious. If it has **side effects outside the system boundary** (browser URL, localStorage, external API, analytics), add a **store node** to represent that external state:
+
+```
+❌ N41: updateUrl()           (wires to... nothing?)
+✅ N41: updateUrl() → S15     (wires to Browser URL store)
+```
+
+This makes the data flow explicit. The store can also have return wires showing how external state flows back in:
+
+```mermaid
+flowchart TB
+N42["N42: performSearch()"] --> N41["N41: updateUrl()"]
+N41 --> S15["S15: Browser URL (?q=)"]
+S15 -.->|back button / init| N40["N40: activeQuery$"]
+```
+
+Common external stores to model:
+- `Browser URL` — query params, hash fragments
+- `localStorage` / `sessionStorage` — persisted client state
+- `Clipboard` — copy/paste operations
+- `Browser History` — navigation state
+
+### Separate control flow from data flow
+
+Wires Out = control flow (what triggers what)
+Returns To = data flow (where output goes)
+
+This separation makes the system's behavior explicit.
+
+### Show navigation inline, not as loops
+
+Routing is a generic mechanism every page uses. Instead of drawing all navigation through a central Router affordance, show `Router navigate()` inline where it happens and wire directly to the destination place.
+
+### Place stores where they enable behavior, not where they're written
+
+A data store belongs in the Place where its data is *consumed* to enable some effect — not where it's produced. Writes from other Places are "reaching into" that Place's state.
+
+To determine where a store belongs:
+1. **Trace read/write relationships** — Who writes? Who reads?
+2. **The readers determine placement** — that's where behavior is enabled
+3. **If only one Place reads**, the store goes inside that Place
+
+Example: A `changedPosts` array is written by a Modal (when user confirms changes) but read by a PAGE_SAVE handler (when user clicks Save). The store belongs with the PAGE_SAVE handler — that's where it enables the persistence operation.
+
+### Only extract to shared areas when truly shared
+
+Before putting a store in a separate DATA STORES section, verify it's actually read by multiple Places. If it only enables behavior in one Place, it belongs inside that Place.
+
+### Nest stores in the subcomponent that reads them
+
+Within a Place, put stores in the subcomponent where they enable behavior. If a store is read by a specific handler, put it in that handler's component — not floating at the Place level.
+
+### Backend is a Place
+
+The database and resolvers aren't floating infrastructure — they're a Place with their own affordances. Database tables (S) belong inside the Backend Place alongside the resolvers (N) that read and write them.
+
+---
+
+## Catalog of Parts and Relationships
+
+This section provides a complete reference of everything that can appear in a breadboard.
+
+### Elements
+
+| Element | ID Pattern | What It Is | What Qualifies |
+|---------|------------|------------|----------------|
+| **Place** | P1, P2, P3... | A bounded context of interaction | Blocking test: can't interact with what's behind |
+| **Subplace** | P2.1, P2.2... | A defined subset within a Place | Groups related affordances within a larger Place |
+| **Place Reference** | _PlaceName | UI affordance pointing to a detached place | Complex nested place defined separately |
+| **UI Affordance** | U1, U2, U3... | Something the user can see or interact with | Inputs, buttons, displays, scroll regions |
+| **Code Affordance** | N1, N2, N3... | Something in code you can act upon | Methods, subscriptions, handlers, framework mechanisms |
+| **Data Store** | S1, S2, S3... | State that persists and is read/written | Properties, arrays, observables that hold data |
+| **Chunk** | — | A collapsed subsystem | One wire in, one wire out, many internals |
+| **Placeholder** | — | Out-of-scope content marker | Shows context without detailing |
+
+### Relationships
+
+| Relationship | Syntax | Meaning | Example |
+|--------------|--------|---------|---------|
+| **Containment** | Place column | Affordance belongs to Place | `U3` in Place `P2.1` |
+| **Wires Out** | `→ X` | Control flow: triggers/calls | `→ N4`, `→ P2` |
+| **Returns To** | `→ X` (in Returns To column) | Data flow: output goes to | `→ U6`, `→ N3` |
+| **Abbreviated flow** | `\|label\|` | Intermediate steps omitted | `S4 -.-> \|view query\| U6` |
+| **Parent-child** | Hierarchical ID | Subplace belongs to Place | P2.1 is child of P2 |
+
+### Containment vs Wiring
+
+| Relationship | Meaning | Where Captured |
+|--------------|---------|----------------|
+| **Containment** | Affordance belongs to / lives in a Place | Place column (set membership) |
+| **Wiring** | Affordance triggers / calls something | Wires Out column (control flow) |
+
+Containment is set membership: `U1 ∈ P1` means U1 is a member of Place P1.
+Wiring is control flow: `U1 → N1` means U1 triggers N1.
+
+### What Qualifies as Each Element
+
+**Place (P):**
+- Passes the blocking test — can't interact with what's behind
+- Examples: modal, edit mode (whole screen transforms), route/page
+- Not: dropdown, tooltip, checkbox revealing fields
+
+**Place Reference (_PlaceName):**
+- A UI affordance that represents a detached place
+- Use when a nested place has many affordances and would clutter the parent
+- Examples: `_letter-browser`, `_user-profile-widget`
+- Wires to the full place definition: `_letter-browser --> P3`
+
+**UI Affordance (U):**
+- User can see it or interact with it
+- Examples: button, input, list, spinner, displayed text
+- Not: wrapper elements, layout containers
+
+**Code Affordance (N):**
+- Has meaningful identity — you can point to it in code
+- Examples: `handleSubmit()`, `query$ subscription`, `detectChanges()`
+- Not: internal transforms, navigation mechanisms (see below)
+
+**Data Store (S):**
+- State that is written and read
+- Examples: `results` array, `loading` boolean, `changedPosts` list
+- External stores: `Browser URL`, `localStorage`, `Clipboard` — represent state outside the app boundary
+- Not: config that's set once and never changes (consider as config affordance)
+
+### Verification Checks
+
+| Check | Question | If No... |
+|-------|----------|----------|
+| **Every U that displays data** | Does it have an incoming wire (via Wires Out or Returns To)? | Add the data source |
+| **Every N** | Does it have Wires Out or Returns To (or both)? | Investigate — may be dead code or missing wiring |
+| **Every S** | Does something read from it (Returns To)? | Investigate — may be unused |
+| **Navigation mechanisms** | Is this N just the "how" of getting somewhere? | Wire directly to Place instead |
+| **N with side effects** | Does this N affect external state (URL, storage, clipboard)? | Add a store for the external state |
+
+---
+
+## Chunking
+
+Chunking collapses a subsystem into a single node in the main diagram, with details shown separately. Use chunking to manage complexity when a section of the breadboard has:
+
+- **One wire in** (single entry point)
+- **One wire out** (single output)
+- **Lots of internals** between them
+
+### When to Chunk
+
+Look for sections where tracing the wiring reveals a "pinch point" — many affordances that funnel through a single input and single output. These are natural boundaries for chunking.
+
+Example: A `dynamic-form` component receives a form definition, renders many fields (U7a-U7k), validates on change (N26), and emits a single `valid$` signal. In the main diagram, this becomes:
+
+```
+N24 -->|formDefinition| dynamicForm
+dynamicForm -.->|valid$| U8
+```
+
+### How to Chunk
+
+1. **In the main diagram**, replace the subsystem with a single stadium-shaped node:
+
+```
+dynamicForm[["CHUNK: dynamic-form"]]
+```
+
+2. **Wire to/from the chunk** using the boundary signals:
+
+```
+N24 -->|formDefinition| dynamicForm
+dynamicForm -.->|valid$| U8
+```
+
+3. **Create a separate chunk diagram** showing the internals with boundary markers:
+
+```mermaid
+flowchart TB
+    input([formDefinition])
+    output(["valid$"])
+
+    subgraph chunk["dynamic-form internals"]
+        N25["N25: generateFormConfig()"]
+        U7a["U7a: field"]
+        N26["N26: form value changes"]
+        N27["N27: valid$ emission"]
+    end
+
+    input --> N25
+    N25 --> U7a
+    U7a --> N26
+    N26 --> N27
+    N27 --> output
+
+    classDef boundary fill:#b3e5fc,stroke:#0288d1,stroke-dasharray:5 5
+    class input,output boundary
+```
+
+4. **Style chunks distinctly** in the main diagram:
+
+```
+classDef chunk fill:#b3e5fc,stroke:#0288d1,color:#000,stroke-width:2px
+class dynamicForm chunk
+```
+
+### Chunk Color Convention
+
+| Type | Color | Hex |
+|------|-------|-----|
+| Chunk node (main diagram) | Light blue | `#b3e5fc` |
+| Boundary markers (chunk diagram) | Light blue, dashed | `#b3e5fc` with `stroke-dasharray:5 5` |
+
+### Benefits
+
+- **Main diagram stays readable** — complex subsystems become single nodes
+- **Detail preserved** — chunk diagrams show the internals when needed
+- **Natural boundaries** — chunks often map to reusable components
+
+---
+
+## Visualization (Mermaid)
+
+The tables are the truth. Mermaid diagrams are optional visualizations for humans.
+
+### Basic Structure
+
+```mermaid
+flowchart TB
+    U1["U1: search input"] --> N1["N1: activeQuery.next()"]
+    N1 --> N2["N2: subscription"]
+    N2 --> N3["N3: performSearch"]
+    N3 --> N4["N4: searchOneCategory"]
+    N4 -.-> N3
+    N3 --> N5["N5: loading store"]
+    N3 --> N6["N6: results store"]
+    N5 -.-> U2["U2: loading spinner"]
+    N6 -.-> U3["U3: results list"]
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+    class U1,U2,U3 ui
+    class N1,N2,N3,N4,N5,N6 nonui
+```
+
+### Line Conventions
+
+| Line Style | Mermaid Syntax | Use |
+|------------|----------------|-----|
+| Solid (`-->`) | `A --> B` | Wires Out: calls, triggers, writes |
+| Dashed (`-.->`) | `A -.-> B` | Returns To: return values, data store reads |
+| Labeled `...` | `A -.->|...| B` | Abbreviated flow: intermediate steps omitted |
+
+#### Abbreviating Out-of-Scope Flows
+
+When a data flow has intermediate steps that aren't relevant to the breadboard's scope, abbreviate by wiring directly from source to destination with a `...` label:
+
+```
+S4 -.->|...| U6
+```
+
+This says "data flows from S4 to U6, with intermediate steps omitted." Use this when:
+- The flow exists but its internals are out of scope
+- You need to show where data originates without detailing the query chain
+- The breadboard focuses on one workflow (e.g., editing) but needs to acknowledge another (e.g., viewing)
+
+### ID Prefixes
+
+| Prefix | Type | Example |
+|--------|------|---------|
+| **P** | Places | P1, P2, P3 |
+| **U** | UI affordances | U1, U2, U3 |
+| **N** | Code affordances | N1, N2, N3 |
+| **S** | Data stores | S1, S2, S3 |
+
+### Color Conventions
+
+| Type | Color | Hex |
+|------|-------|-----|
+| Places (subgraphs) | White/transparent | — |
+| UI affordances | Pink | `#ffb6c1` |
+| Code affordances | Grey | `#d3d3d3` |
+| Data stores | Lavender | `#e6e6fa` |
+| Chunks | Light blue | `#b3e5fc` |
+| Place references | Pink, dashed border | `#ffb6c1` |
+
+```
+classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+classDef store fill:#e6e6fa,stroke:#9370db,color:#000
+classDef chunk fill:#b3e5fc,stroke:#0288d1,color:#000,stroke-width:2px
+classDef placeRef fill:#ffb6c1,stroke:#d87093,stroke-width:2px,stroke-dasharray:5 5
+```
+
+### Subgraph Labels and Place IDs
+
+Use the Place ID as the subgraph ID so navigation wiring connects properly:
+
+```mermaid
+flowchart TB
+subgraph P1["P1: CMS Page (Read Mode)"]
+    U1["U1: Edit button"]
+    N1["N1: toggleEditMode()"]
+end
+
+subgraph P2["P2: CMS Page (Edit Mode)"]
+    U2["U2: Save button"]
+    U3["U3: Add button"]
+end
+
+%% Navigation wires to Place ID
+N1 --> P2
+```
+
+| Type | ID Pattern | Label Pattern | Purpose |
+|------|------------|---------------|---------|
+| Place | `P1`, `P2`... | `P1: Page Name` | A bounded context the user visits |
+| Trigger | — | `TRIGGER: Name` | An event that kicks off a flow (not navigable) |
+| Component | — | `COMPONENT: Name` | Reusable UI+logic that appears in multiple places |
+| System | — | `SYSTEM: Name` | When spanning multiple applications |
+
+**Key point:** The subgraph ID (`P1`, `P2`) must match the Place ID from the Places table. This allows navigation wires like `N1 --> P2` to connect to the Place boundary.
+
+### When spanning multiple systems
+
+```mermaid
+flowchart TB
+    subgraph frontend["SYSTEM: Frontend"]
+        U1["U1: submit button"]
+        N1["N1: handleSubmit()"]
+    end
+
+    subgraph backend["SYSTEM: Backend API"]
+        N10["N10: POST /orders"]
+        N11["N11: orderService.create()"]
+    end
+
+    U1 --> N1
+    N1 --> N10
+    N10 --> N11
+```
+
+### Workflow Step Annotations (Optional)
+
+When breadboarding a specific workflow, you can optionally add numbered step markers to help readers follow the sequence visually. This is useful when:
+- The diagram is complex and the workflow path isn't obvious
+- You want to guide someone through a specific user journey
+- The breadboard will be used as a walkthrough or teaching tool
+
+**Format:**
+
+Add a Workflow Guide table before the diagram:
+
+```markdown
+| Step | Action | Where to look |
+|------|--------|---------------|
+| **1** | Click "Edit" button | U1 → N1 → S1 |
+| **2** | Edit mode activates | S1 → N2 → U3 |
+| **3** | Click "Add" | U3 → N3 → N8 |
+```
+
+Add step marker nodes in the Mermaid diagram using stadium-shaped nodes:
+
+```mermaid
+flowchart TB
+    %% Step markers
+    step1(["1 - CLICK EDIT"])
+    step2(["2 - EDIT MODE ON"])
+    step3(["3 - CLICK ADD"])
+
+    %% Connect steps to relevant affordances with dashed lines
+    step1 -.-> U1
+    step2 -.-> N2
+    step3 -.-> U3
+
+    %% Style step markers green
+    classDef step fill:#90EE90,stroke:#228B22,color:#000,font-weight:bold
+    class step1,step2,step3 step
+```
+
+**Formatting notes:**
+- Use `"1 - ACTION"` format (number, space, hyphen, space, action)
+- Avoid `"1. ACTION"` — the period triggers Mermaid's markdown list parser
+- Avoid `"1) ACTION"` — parentheses can also cause parsing issues
+- Connect step markers to affordances with dashed lines (`-.->`)
+- Style steps green to distinguish from UI (pink) and Code (grey) affordances
+
+---
+
+## Slicing a Breadboard
+
+Slicing takes a breadboard and groups its affordances into **vertical implementation slices**. See **Example B** below for a complete slicing example.
+
+**Input:**
+- Breadboard (affordance tables with wiring)
+- Shape (R + mechanisms) — guides what demos matter
+
+**Output:**
+- Breadboard with affordances assigned to slices V1–V9 (max 9 slices)
+
+### What is a Vertical Slice?
+
+A vertical slice is a group of UI and Code affordances that does something demo-able. It cuts through all layers (UI, logic, data) to deliver a working increment.
+
+The opposite is a horizontal slice — doing work on one layer (e.g., "set up all the data models") that isn't clickable from the interface.
+
+### The Key Constraint
+
+**Every slice must have visible UI that can be demoed.** A slice without UI is a horizontal layer, not a vertical slice.
+
+- ✅ "Self-serve Signing Path" (demo: checkout → sign → see signature)
+- ❌ "Database Schema" (no demo possible)
+
+**Demo-able means:**
+- Has an entry point (UI interaction or trigger)
+- Has an observable output (UI renders, effect occurs)
+- Shows meaningful progress toward the R
+
+The shape guides what counts as "meaningful progress" — you're not just grouping affordances arbitrarily, you're grouping them to demonstrate mechanisms working.
+
+### Slice Size
+
+- **Too small:** Only 1-2 UI affordances, no meaningful demo → merge with related slice
+- **Too big:** 15+ affordances or multiple unrelated journeys → split
+- **Right size:** A coherent journey with a clear "watch me do this" demo
+
+Aim for ≤9 slices. If you need more, the shape may be too large for one cycle.
+
+### Wires to Future Slices
+
+A slice may contain affordances with Wires Out pointing to affordances in later slices. These wires exist in the breadboard but aren't implemented yet — they're stubs or no-ops until that later slice is built.
+
+This is normal. The breadboard shows the complete system; slicing shows the order of implementation.
+
+### Procedure
+
+**Step 1: Identify the minimal demo-able increment**
+
+Look at your breadboard and shape. Ask: "What's the smallest subset that demonstrates the core mechanism working?"
+
+Usually this is:
+- The core data fetch
+- Basic rendering
+- No search, no pagination, no state persistence yet
+
+This becomes V1.
+
+**Step 2: Layer additional capabilities as slices**
+
+Look at the mechanisms in your shape. Each slice should demonstrate a mechanism working:
+- V2: Search input (demonstrates the search mechanism)
+- V3: Pagination/infinite scroll (demonstrates the pagination mechanism)
+- V4: URL state persistence (demonstrates the state preservation mechanism)
+- etc.
+
+**Max 9 slices.** If you have more, combine related mechanisms. Features that don't make sense alone should be in the same slice.
+
+**Step 3: Assign affordances to slices**
+
+Go through every affordance and assign it to the slice where it's first needed to demo that slice's mechanism:
+
+| Slice | Mechanism | Affordances |
+|-------|-----------|-------------|
+| V1 | Core display | U2, U3, N3, N4, N5, N6, N7 |
+| V2 | Search | U1, N1, N2 |
+| V3 | Pagination | U10, N11, N12, N13 |
+
+Some affordances may have Wires Out to later slices — that's fine. They're implemented in their assigned slice; the wires just don't do anything yet.
+
+**Step 4: Create per-slice affordance tables**
+
+For each slice, extract just the affordances being added:
+
+**V2: Search Works**
+
+| # | Component | Affordance | Control | Wires Out | Returns To |
+|---|-----------|------------|---------|-----------|------------|
+| U1 | search-detail | search input | type | → N1 | — |
+| N1 | search-detail | `activeQuery.next()` | call | → N2 | — |
+| N2 | search-detail | `activeQuery` subscription | observe | → N3 | — |
+
+**Step 5: Write a demo statement for each slice**
+
+Each slice needs a concrete demo that shows its mechanism working toward the R:
+- V1: "Widget shows real data from the API"
+- V2: "Type 'dharma', results filter live"
+- V3: "Scroll down, more items load"
+
+The demo should be something you can show a stakeholder that demonstrates progress.
+
+### Visualizing Slices in Mermaid
+
+Show the complete breadboard in every slice diagram, but use styling to distinguish scope:
+
+| Category | Style | Description |
+|----------|-------|-------------|
+| **This slice** | Bright color | Affordances being added |
+| **Already built** | Solid grey | Previous slices |
+| **Future** | Transparent, dashed border | Not yet built |
+
+```mermaid
+flowchart TB
+    U1["U1: search input"]
+    U2["U2: loading spinner"]
+    N1["N1: activeQuery.next()"]
+    N2["N2: subscription"]
+    N3["N3: performSearch"]
+
+    U1 --> N1
+    N1 --> N2
+    N2 --> N3
+    N3 --> U2
+
+    %% V2 scope (this slice) = green
+    classDef thisSlice fill:#90EE90,stroke:#228B22,color:#000
+    %% Already built (V1) = grey
+    classDef built fill:#d3d3d3,stroke:#808080,color:#000
+    %% Future = transparent dashed
+    classDef future fill:none,stroke:#ddd,color:#bbb,stroke-dasharray:3 3
+
+    class U1,N1,N2 thisSlice
+    class U2,N3 built
+```
+
+This lets stakeholders see:
+- What's being built now (highlighted)
+- What already exists (grey)
+- What's coming later (faded)
+
+### Slice Summary Format
+
+| # | Slice | Mechanism | Demo |
+|---|-------|-----------|------|
+| V1 | Widget with real data | F1, F4, F6 | "Widget shows letters from API" |
+| V2 | Search works | F3 | "Type to filter results" |
+| V3 | Infinite scroll | F5 | "Scroll down, more load" |
+| V4 | URL state | F2 | "Refresh preserves search" |
+
+The Mechanism column references parts from the shape, showing which mechanisms each slice demonstrates.
+
+---
+---
+
+# Examples
+
+## Example A: Mapping an Existing System
+
+This example shows breadboarding an existing system to understand how data flows through multiple entry points.
+
+### Input
+
+Workflow to understand: "How is `admin_organisation_countries` modified and read downstream? There are multiple entry points: manual edit, checkbox toggle, and batch job."
+
+### Output
+
+**UI Affordances**
+
+| # | Component | Affordance | Control | Wires Out | Returns To |
+|---|-----------|------------|---------|-----------|------------|
+| U1 | SSO Admin | `role_profiles` checkboxes | render | — | — |
+| U2 | SSO Admin | "Country Admin" checkbox | click | toggles selection | — |
+| U3 | SSO Admin | `admin_countries` filter_horizontal | render | — | — |
+| U4 | SSO Admin | Available countries list | render | — | — |
+| U5 | SSO Admin | Selected countries list | render | — | — |
+| U6 | SSO Admin | Add → / Remove ← | click | modifies selection | — |
+| U7 | SSO Admin | Save button | click | → N3 | — |
+| U20 | DWConnect | "Country admins" section | render | — | — |
+| U21 | (unknown) | System email "From" field | render | — | — |
+
+**Code Affordances**
+
+| # | Component | Affordance | Control | Wires Out | Returns To |
+|---|-----------|------------|---------|-----------|------------|
+| N1 | sso/accounts/admin | `get_fieldsets()` | call | → U3 (conditional) | — |
+| N2 | sso/accounts/models | `get_administrable_user_countries()` | call | — | → U4 |
+| N3 | sso/accounts/admin | `save_form()` | call | → N4, → N5 | — |
+| N4 | Django Admin | Form M2M save | call | → S2 | — |
+| N5 | sso/forms/mixins | `_update_user_m2m()` | call | → S1, → N6 | — |
+| N6 | sso/signals | `user_m2m_field_updated` signal | signal | → N10 | — |
+| N7 | CLI/Scheduler | `manage.py dwbn_cleanup` | invoke | → N15 | — |
+| N10 | sso-dwbn-theme | `dwbn_user_m2m_field_updated()` | receive | → N11 | — |
+| N11 | sso-dwbn-theme | `dwbn_user_m2m_field_updated_task()` | call | → N12 | — |
+| N12 | sso-dwbn-theme | Country Admin added AND zero admin countries? | conditional | → N20 | — |
+| N15 | sso-dwbn-theme | `admin_changes()` | call | → N16 | — |
+| N16 | sso-dwbn-theme | For each Country Admin: home center country missing? | loop | → N20 | — |
+| N20 | sso-dwbn-theme | Get home center's country | call | → N21 | — |
+| N21 | sso-dwbn-theme | `admin_organisation_countries.add()` | call | → S2 | — |
+| N22 | sso-dwbn-theme | `update_last_modified()` | call | — | — |
+| N30 | dwconnect2-backend | `findCenterAdmins()` | call | — | → U20 |
+| N31 | sso/api | `get_object_data()` | call | — | → external |
+
+**Data Stores**
+
+| # | Store | Description |
+|---|-------|-------------|
+| S1 | `role_profiles` | M2M: which role profiles a user has |
+| S2 | `admin_organisation_countries` | M2M: which countries a user administers |
+| S3 | `organisations` | User's home center(s) |
+
+**Mermaid Diagram**
+
+```mermaid
+flowchart TB
+    subgraph stores["DATA STORES"]
+        S1["S1: role_profiles"]
+        S2["S2: admin_organisation_countries"]
+        S3["S3: organisations"]
+    end
+
+    subgraph ssoAdmin["PLACE: SSO Admin — User Change Page"]
+        subgraph permissions["Permissions fieldset"]
+            U1["U1: role_profiles checkboxes"]
+            U2["U2: 'Country Admin' checkbox"]
+        end
+
+        subgraph userAdmin["User admin fieldset (superuser only)"]
+            U3["U3: admin_countries filter_horizontal"]
+            U4["U4: Available countries"]
+            U5["U5: Selected countries"]
+            U6["U6: Add → / Remove ←"]
+        end
+
+        U7["U7: Save button"]
+        N1["N1: get_fieldsets()"]
+        N2["N2: get_administrable_user_countries()"]
+        N3["N3: save_form()"]
+        N4["N4: Form M2M save"]
+        N5["N5: _update_user_m2m()"]
+        N6["N6: user_m2m_field_updated signal"]
+
+        N1 -->|is_superuser| userAdmin
+        U3 --> U4
+        U3 --> U5
+        U6 --> U5
+        N2 -.-> U4
+
+        U2 --> U7
+        U6 --> U7
+        U7 --> N3
+        N3 --> N4
+        N3 --> N5
+        N5 --> N6
+    end
+
+    subgraph trigger["TRIGGER: Batch Cleanup"]
+        N7["N7: manage.py dwbn_cleanup"]
+    end
+
+    subgraph theme["sso-dwbn-theme"]
+        N10["N10: dwbn_user_m2m_field_updated()"]
+        N11["N11: dwbn_user_m2m_field_updated_task()"]
+        N12["N12: Country Admin added AND zero admin countries?"]
+        N15["N15: admin_changes()"]
+        N16["N16: For each Country Admin: home center country missing?"]
+        N20["N20: Get home center's country"]
+        N21["N21: admin_organisation_countries.add()"]
+        N22["N22: update_last_modified()"]
+
+        N6 --> N10
+        N10 --> N11
+        N11 --> N12
+        N7 --> N15
+        N15 --> N16
+        N12 -->|yes| N20
+        N16 -->|yes| N20
+        N20 --> N21
+        N21 --> N22
+    end
+
+    subgraph dwconnect["PLACE: DWConnect — Center Page"]
+        N30["N30: findCenterAdmins()"]
+        U20["U20: 'Country admins' section"]
+
+        N30 --> U20
+    end
+
+    subgraph api["TRIGGER: External API Request"]
+        N31["N31: get_object_data()"]
+    end
+
+    U21["U21: System email 'From' field"]
+
+    N4 --> S2
+    N5 --> S1
+    N21 --> S2
+    S1 -.-> N15
+    S3 -.-> N16
+    S3 -.-> N20
+    S2 -.-> U5
+    S2 -.-> N30
+    S2 -.-> N31
+    S2 -.-> U21
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+    classDef store fill:#e6e6fa,stroke:#9370db,color:#000
+    classDef condition fill:#fffacd,stroke:#daa520,color:#000
+    classDef trigger fill:#98fb98,stroke:#228b22,color:#000
+
+    class U1,U2,U3,U4,U5,U6,U7,U20,U21 ui
+    class N1,N2,N3,N4,N5,N6,N10,N11,N15,N20,N21,N22,N30,N31 nonui
+    class N12,N16 condition
+    class N7 trigger
+    class S1,S2,S3 store
+```
+
+---
+
+## Example B: Designing from Shaped Parts
+
+---
+
+### Part 1: Shaping Context (Input to Breadboarding)
+
+This section shows what comes FROM shaping — the requirements, existing patterns identified, and sketched parts. This is the INPUT that breadboarding receives.
+
+> **Note:** This example uses shaping terminology. In shaping, you define requirements (Rs), identify existing patterns to reuse, and sketch a solution as parts/mechanisms. Breadboarding takes this shaped solution and details out the concrete affordances and wiring.
+
+**The R (Requirements)**
+
+| ID | Requirement |
+|----|-------------|
+| R0 | Make content searchable from the index page |
+| R2 | Navigate back to pagination state when returning from detail |
+| R3 | Navigate back to search state when returning from detail |
+| R4 | Search/pagination state survives page refresh |
+| R5 | Browser back button restores previous search/pagination state |
+| R9 | Search should debounce input (not fire on every keystroke) |
+| R10 | Search should require minimum 3 characters |
+| R11 | Loading and empty states should provide user feedback |
+
+**Existing System with Reusable Patterns (S-CUR)**
+
+The app already has a global search page that implements most of these Rs. During shaping, it was documented at the parts/mechanism level:
+
+| Part | Mechanism |
+|------|-----------|
+| **S-CUR1** | **URL state & initialization** |
+| S-CUR1.1 | Router queryParams observable provides `{q, category}` |
+| S-CUR1.2 | `initializeState(params)` sets query and category from URL |
+| S-CUR1.3 | On page load, triggers initial search from URL state |
+| **S-CUR2** | **Search input** |
+| S-CUR2.1 | Search input binds to `activeQuery` BehaviorSubject |
+| S-CUR2.2 | `activeQuery` subscription with 90ms debounce |
+| S-CUR2.3 | Min 3 chars triggers `performNewSearch()` |
+| **S-CUR3** | **Data fetching** |
+| S-CUR3.1 | `performNewSearch()` sets loading state, calls search service |
+| S-CUR3.2 | Search service builds Typesense filter, calls `rawSearch()` |
+| S-CUR3.3 | `rawSearch()` queries Typesense, returns `{found, hits}` |
+| S-CUR3.4 | Results written to `detailResult` data store |
+| **S-CUR4** | **Pagination** |
+| S-CUR4.1 | Scroll-to-bottom triggers `appendNextPage()` via intercomService |
+| S-CUR4.2 | `appendNextPage()` increments page, calls search |
+| S-CUR4.3 | New hits concatenated to existing hits |
+| S-CUR4.4 | `sendMessage()` re-arms scroll detection |
+| **S-CUR5** | **Rendering** |
+| S-CUR5.1 | `cdr.detectChanges()` triggers template re-evaluation |
+| S-CUR5.2 | Loading spinner, "no results", result count based on store |
+| S-CUR5.3 | `*ngFor` renders tiles for each hit |
+| S-CUR5.4 | Tile click navigates to detail page |
+
+**Sketched Solution: Parts that Adapt S-CUR**
+
+The new solution's parts explicitly reference which S-CUR patterns they adapt:
+
+| Part | Mechanism | Adapts |
+|------|-----------|--------|
+| F1 | Create widget (component, def, register) | — |
+| F2 | URL state & initialization (read `?q=`, restore on load) | S-CUR1 |
+| F3 | Search input (debounce, min 3 chars, triggers search) | S-CUR2 |
+| F4 | Data fetching (`rawSearch()` with filter) | S-CUR3 |
+| F5 | Pagination (scroll-to-bottom, append pages, re-arm) | S-CUR4 |
+| F6 | Rendering (loading, empty, results list, rows) | S-CUR5 |
+
+---
+
+### Part 2: Breadboarding (Transform Parts → Affordances)
+
+This is where breadboarding happens. The shaped parts become concrete affordances with explicit wiring. The output is the affordance tables and diagram.
+
+**UI Affordances**
+
+| # | Component | Affordance | Control | Wires Out | Returns To |
+|---|-----------|------------|---------|-----------|------------|
+| U1 | letter-browser | search input | type | → N1 | — |
+| U2 | letter-browser | loading spinner | render | — | — |
+| U3 | letter-browser | no results msg | render | — | — |
+| U4 | letter-browser | result count | render | — | — |
+| U5 | letter-browser | results list | render | → U6, U7, U8, U9 | — |
+| U6 | letter-row | row click | click | → LD | — |
+| U7 | letter-row | date | render | — | — |
+| U8 | letter-row | subject | render | — | — |
+| U9 | letter-row | teaser | render | — | — |
+| U10 | letter-browser | scroll | scroll | → N11 | — |
+| U11 | browser | back button | click | → N9 | — |
+| U12 | letter-browser | "See all X results" | click | → LP | — |
+| LD | — | Letter Detail | place | — | — |
+| LP | — | Full Page | place | — | — |
+
+**Code Affordances**
+
+| # | Component | Affordance | Control | Wires Out | Returns To |
+|---|-----------|------------|---------|-----------|------------|
+| N1 | letter-browser | `activeQuery.next()` | call | → N2 | → U12 |
+| N2 | letter-browser | `activeQuery` subscription | observe | → N3 | — |
+| N3 | letter-browser | `performSearch()` | call | → N4, → N6, → N7, → N8 | — |
+| N4 | typesense.service | `rawSearch()` | call | — | → N3, → N12 |
+| N5 | letter-browser | `parentId` (config) | config | — | → N4 |
+| N6 | letter-browser | `loading` store | write | — | → N8 |
+| N7 | letter-browser | `detailResult` store | write | — | → N8, → N16 |
+| N8 | letter-browser | `detectChanges()` | call | → U2, → U3, → U4, → U5 | — |
+| N9 | browser | URL `?q=` | read | → N10 | — |
+| N10 | letter-browser | `initializeState()` | call | → N1, → N3 | — |
+| N11 | intercom.service | scroll subject | observe | → N12 | — |
+| N12 | letter-browser | `appendNextPage()` | call | → N4, → N7, → N8, → N13, → N14 | — |
+| N13 | intercom.service | `sendMessage()` | call | → N11 | — |
+| N14 | router | `navigate()` | call | — | → N9 |
+| N15 | letter-browser | if `!compact` subscribe | conditional | → N11 | — |
+| N16 | letter-browser | if truncated show link | conditional | → U12 | — |
+| N17 | letter-browser | `compact` (config) | config | — | → N4, → N15, → N16 |
+| N18 | letter-browser | `fullPageRoute` (config) | config | — | → U12 |
+
+**Mermaid Diagram**
+
+```mermaid
+flowchart TB
+    subgraph lettersIndex["PLACE: Letters Index Page"]
+        subgraph letterBrowser["COMPONENT: letter-browser"]
+            U1["U1: search input"]
+            U2["U2: loading spinner"]
+            U3["U3: no results msg"]
+            U4["U4: result count"]
+            U5["U5: results list"]
+            U12["U12: See all X results"]
+
+            N1["N1: activeQuery.next"]
+            N2["N2: activeQuery sub"]
+            N3["N3: performSearch"]
+            N6["N6: loading store"]
+            N7["N7: detailResult store"]
+            N8["N8: detectChanges"]
+            N10["N10: initializeState"]
+            N16["N16: if truncated show link"]
+            N5["N5: parentId (config)"]
+            N17["N17: compact (config)"]
+            N18["N18: fullPageRoute (config)"]
+
+            subgraph pagination["PAGINATION"]
+                U10["U10: scroll"]
+                N15["N15: if !compact subscribe"]
+                N12["N12: appendNextPage"]
+            end
+        end
+    end
+
+    subgraph letterRow["COMPONENT: letter-row"]
+        U6["U6: row click"]
+        U7["U7: date"]
+        U8["U8: subject"]
+        U9["U9: teaser"]
+    end
+
+    subgraph browser["BROWSER"]
+        U11["U11: back button"]
+        N9["N9: URL ?q="]
+        N14["N14: Router.navigate"]
+    end
+
+    subgraph services["SERVICES"]
+        N4["N4: rawSearch"]
+        N11["N11: intercom subject"]
+        N13["N13: sendMessage"]
+    end
+
+    subgraph letterDetail["PLACE: Letter Detail Page"]
+        LD["Letter Detail"]
+    end
+
+    U1 -->|type| N1
+    N1 --> N2
+    N2 -->|debounce 90ms, min 3| N3
+
+    N3 --> N4
+    N3 --> N6
+    N3 --> N7
+    N3 --> N8
+
+    N4 -.-> N3
+    N4 -.-> N12
+    N6 -.-> N8
+    N7 -.-> N8
+
+    N8 --> U2
+    N8 --> U3
+    N8 --> U4
+    N8 --> U5
+
+    U5 --> U6
+    U5 --> U7
+    U5 --> U8
+    U5 --> U9
+
+    U6 -->|navigate| LD
+    U11 -->|restore| N9
+    N9 --> N10
+    N10 --> N1
+    N10 --> N3
+
+    U10 --> N11
+    N15 -->|if !compact| N11
+    N11 --> N12
+    N12 --> N4
+    N12 --> N7
+    N12 --> N8
+    N12 --> N13
+    N12 --> N14
+    N13 -->|re-arm| N11
+
+    N5 -.->|filter| N4
+    N17 -.-> N4
+    N17 -.-> N15
+    N17 -.-> N16
+    N18 -.-> U12
+    N14 -.->|URL| N9
+
+    N1 -.-> U12
+    N7 -.-> N16
+    N16 -->|if truncated| U12
+    U12 -->|navigate with ?q| LP["Full Page"]
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+
+    class U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,LD,LP ui
+    class N1,N2,N3,N4,N5,N6,N7,N8,N9,N10,N11,N12,N13,N14,N15,N16,N17,N18 nonui
+```
+
+**Slicing the Breadboard**
+
+With the full breadboard complete, slice it into vertical increments. Each slice demonstrates a mechanism working:
+
+**Slice Summary**
+
+| # | Slice | Mechanism | Affordances | Demo |
+|---|-------|-----------|-------------|------|
+| V1 | Widget with real data | F1, F4, F6 | U2-U9, N3-N8, LD | "Widget shows real data" |
+| V2 | Search works | F3 | U1, N1, N2 | "Type 'dharma', results filter" |
+| V3 | Infinite scroll | F5 | U10, N11-N13 | "Scroll down, more load" |
+| V4 | URL state | F2 | U11, N9, N10, N14 | "Refresh preserves search" |
+| V5 | Compact mode | — | U12, N15-N18, LP | "Shows 'See all' link" |
+
+**Slice Diagram**
+
+```mermaid
+flowchart TB
+    subgraph slice1["V1: WIDGET WITH REAL DATA"]
+        U2["U2: loading spinner"]
+        U3["U3: no results msg"]
+        U4["U4: result count"]
+        U5["U5: results list"]
+        U6["U6: row click"]
+        U7["U7: date"]
+        U8["U8: subject"]
+        U9["U9: teaser"]
+
+        N3["N3: performSearch"]
+        N4["N4: rawSearch"]
+        N5["N5: parentId (config)"]
+        N6["N6: loading store"]
+        N7["N7: detailResult store"]
+        N8["N8: detectChanges"]
+        LD["Letter Detail"]
+    end
+
+    subgraph slice2["V2: SEARCH WORKS"]
+        U1["U1: search input"]
+        N1["N1: activeQuery.next"]
+        N2["N2: activeQuery sub"]
+    end
+
+    subgraph slice3["V3: INFINITE SCROLL"]
+        U10["U10: scroll"]
+        N11["N11: intercom subject"]
+        N12["N12: appendNextPage"]
+        N13["N13: sendMessage"]
+    end
+
+    subgraph slice4["V4: URL STATE"]
+        U11["U11: back button"]
+        N9["N9: URL ?q="]
+        N10["N10: initializeState"]
+        N14["N14: Router.navigate"]
+    end
+
+    subgraph slice5["V5: COMPACT MODE"]
+        U12["U12: See all X results"]
+        N15["N15: if !compact subscribe"]
+        N16["N16: if truncated show link"]
+        N17["N17: compact (config)"]
+        N18["N18: fullPageRoute (config)"]
+        LP["Full Page"]
+    end
+
+    U1 -->|type| N1
+    N1 --> N2
+    N2 -->|debounce| N3
+
+    N3 --> N4
+    N3 --> N6
+    N3 --> N7
+    N3 --> N8
+    N4 -.-> N3
+    N5 -.->|filter| N4
+
+    N6 -.-> N8
+    N7 -.-> N8
+    N8 --> U2
+    N8 --> U3
+    N8 --> U4
+    N8 --> U5
+    U5 --> U6
+    U5 --> U7
+    U5 --> U8
+    U5 --> U9
+    U6 -->|navigate| LD
+
+    U11 -->|restore| N9
+    N9 --> N10
+    N10 --> N1
+    N10 --> N3
+
+    U10 --> N11
+    N11 --> N12
+    N12 --> N4
+    N12 --> N7
+    N12 --> N8
+    N12 --> N13
+    N12 --> N14
+    N13 -->|re-arm| N11
+    N4 -.-> N12
+    N14 -.->|URL| N9
+
+    N15 -->|if !compact| N11
+    N17 -.-> N4
+    N17 -.-> N15
+    N17 -.-> N16
+    N18 -.-> U12
+    N1 -.-> U12
+    N7 -.-> N16
+    N16 -->|if truncated| U12
+    U12 -->|navigate with ?q| LP
+
+    style slice1 fill:#e8f5e9,stroke:#4caf50,stroke-width:2px
+    style slice2 fill:#e3f2fd,stroke:#2196f3,stroke-width:2px
+    style slice3 fill:#fff3e0,stroke:#ff9800,stroke-width:2px
+    style slice4 fill:#f3e5f5,stroke:#9c27b0,stroke-width:2px
+    style slice5 fill:#fff8e1,stroke:#ffc107,stroke-width:2px
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+
+    class U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,LD,LP ui
+    class N1,N2,N3,N4,N5,N6,N7,N8,N9,N10,N11,N12,N13,N14,N15,N16,N17,N18 nonui
+```

--- a/base/skills/shape/references/critique-personas.md
+++ b/base/skills/shape/references/critique-personas.md
@@ -1,0 +1,35 @@
+# Critique Personas
+
+Channel a specific expert for adversarial feedback on specs, designs, or code.
+
+## Usage
+
+```
+/shape --critique <persona> [target]
+```
+
+## Personas
+
+| Persona | Lens | Challenges |
+|---------|------|------------|
+| **grug** | Complexity demon | Over-abstraction, unnecessary layers, big-brain patterns |
+| **carmack** | Shippability | Scope creep, premature optimization, not focusing |
+| **ousterhout** | Module depth | Shallow modules, pass-through layers, interface complexity |
+| **fowler** | Code smells | Duplication, long methods, feature envy, inappropriate intimacy |
+| **beck** | Test design | Untestable code, missing TDD, over-mocking |
+| **jobs** | Simplicity | Feature bloat, unclear value, lack of craft |
+| **torvalds** | Pragmatism | Over-engineering, not shipping, design astronauts |
+
+## Process
+
+1. **Load persona** — Channel the expert's perspective and values
+2. **Analyze target** — Review code, design, or plan through their lens
+3. **Challenge ruthlessly** — Find flaws the persona would hate
+4. **Recommend** — What would they demand you change?
+
+## Output
+
+Structured critique:
+- **This {persona} hates:** Specific issues found
+- **{Persona} demands:** Required changes
+- **{Persona} would approve if:** Conditions for acceptance

--- a/base/skills/shape/references/shaping-methodology.md
+++ b/base/skills/shape/references/shaping-methodology.md
@@ -1,0 +1,588 @@
+# Shaping Methodology
+
+A structured approach for collaboratively defining problems and exploring solution options.
+
+---
+
+## Multi-Level Consistency (Critical)
+
+Shaping produces documents at different levels of abstraction. **Truth must stay consistent across all levels.**
+
+### The Document Hierarchy (high to low)
+
+1. **Shaping doc** — ground truth for R's, shapes, parts, fit checks
+2. **Slices doc** — ground truth for slice definitions, breadboards
+3. **Individual slice plans** (V1-plan, etc.) — ground truth for implementation details
+
+### The Principle
+
+Each level summarizes or provides a view into the level(s) below it. Lower levels contain more detail; higher levels are designed views that help acquire context quickly.
+
+**Changes ripple in both directions:**
+
+- **Change at high level → trickles down:** If you change the shaping doc's parts table, update the slices doc too.
+- **Change at low level → trickles up:** If a slice plan reveals a new mechanism or changes the scope of a slice, the Slices doc and shaping doc must reflect that.
+
+### The Practice
+
+Whenever making a change:
+
+1. **Identify which level you're touching**
+2. **Ask: "Does this affect documents above or below?"**
+3. **Update all affected levels in the same operation**
+4. **Never let documents drift out of sync**
+
+The system only works if the levels are consistent with each other.
+
+---
+
+## Starting a Session
+
+When kicking off a new shaping session, offer the user both entry points:
+
+- **Start from R (Requirements)** — Describe the problem, pain points, or constraints. Build up requirements and let shapes emerge.
+- **Start from S (Shapes)** — Sketch a solution already in mind. Capture it as a shape and extract requirements as you go.
+
+There is no required order. Shaping is iterative — R and S inform each other throughout.
+
+## Working with an Existing Shaping Doc
+
+When the shaping doc already has a selected shape:
+
+1. **Display the fit check for the selected shape only** — Show R × [selected shape] (e.g., R × F), not all shapes
+2. **Summarize what is unsolved** — Call out any requirements that are Undecided, or where the selected shape has ❌
+
+This gives the user immediate context on where the shaping stands and what needs attention.
+
+---
+
+## Core Concepts
+
+### R: Requirements
+A numbered set defining the problem space.
+
+- **R0, R1, R2...** are members of the requirements set
+- Requirements are negotiated collaboratively - not filled in automatically
+- Track status: Core goal, Undecided, Leaning yes/no, Must-have, Nice-to-have, Out
+- Requirements extracted from fit checks should be made standalone (not dependent on any specific shape)
+- **R states what's needed, not what's satisfied** — satisfaction is always shown in a fit check (R × S)
+- **Chunking policy:** Never have more than 9 top-level requirements. When R exceeds 9, group related requirements into chunks with sub-requirements (R3.1, R3.2, etc.) so the top level stays at 9 or fewer. This keeps the requirements scannable and forces meaningful grouping.
+
+### S: Shapes (Solution Options)
+Letters represent mutually exclusive solution approaches.
+
+- **A, B, C...** are top-level shape options (you pick one)
+- **C1, C2, C3...** are components/parts of Shape C (they combine)
+- **C3-A, C3-B, C3-C...** are alternative approaches to component C3 (you pick one)
+
+### Shape Titles
+Give shapes a short descriptive title that characterizes the approach. Display the title when showing the shape:
+
+```markdown
+## E: Modify CUR in place to follow S-CUR
+
+| Part | Mechanism |
+|------|-----------|
+| E1 | ... |
+```
+
+Good titles capture the essence of the approach in a few words:
+- ✅ "E: Modify CUR in place to follow S-CUR"
+- ✅ "C: Two data sources with hybrid pagination"
+- ❌ "E: The solution" (too vague)
+- ❌ "E: Add search to widget-grid by swapping..." (too long)
+
+### Notation Hierarchy
+
+| Level | Notation | Meaning | Relationship |
+|-------|----------|---------|--------------|
+| Requirements | R0, R1, R2... | Problem constraints | Members of set R |
+| Shapes | A, B, C... | Solution options | Pick one from S |
+| Components | C1, C2, C3... | Parts of a shape | Combine within shape |
+| Alternatives | C3-A, C3-B... | Approaches to a component | Pick one per component |
+
+### Notation Persistence
+Keep notation throughout as an audit trail. When finalizing, compose new options by referencing prior components (e.g., "Shape E = C1 + C2 + C3-A").
+
+## Phases
+
+Shaping moves through two phases:
+
+```
+Shaping → Slicing
+```
+
+| Phase | Purpose | Output |
+|-------|---------|--------|
+| **Shaping** | Explore the problem and solution space, select and detail a shape | Shaping doc with R, shapes, fit checks, breadboard |
+| **Slicing** | Break down for implementation | Vertical slices with demo-able UI |
+
+### Phase Transition
+
+**Shaping → Slicing** happens when:
+- A shape is selected (passes fit check, feels right)
+- The shape has been breadboarded into concrete affordances
+- We need to plan implementation order
+
+You can't slice without a breadboarded shape.
+
+---
+
+## Fit Check (Decision Matrix)
+
+THE fit check is the single table comparing all shapes against all requirements. Requirements are rows, shapes are columns. This is how we decide which shape to pursue.
+
+### Format
+
+```markdown
+## Fit Check
+
+| Req | Requirement | Status | A | B | C |
+|-----|-------------|--------|---|---|---|
+| R0 | Make items searchable from index page | Core goal | ✅ | ✅ | ✅ |
+| R1 | State survives page refresh | Must-have | ✅ | ❌ | ✅ |
+| R2 | Back button restores state | Must-have | ❌ | ✅ | ✅ |
+
+**Notes:**
+- A fails R2: [brief explanation]
+- B fails R1: [brief explanation]
+```
+
+### Conventions
+- **Always show full requirement text** — never abbreviate or summarize requirements in fit checks
+- **Fit check is BINARY** — Use ✅ for pass, ❌ for fail. No other values.
+- **Shape columns contain only ✅ or ❌** — no inline commentary; explanations go in Notes section
+- **Never use ⚠️ or other symbols in fit check** — ⚠️ belongs only in the Parts table's flagged column
+- Keep notes minimal — just explain failures
+
+### Comparing Alternatives Within a Component
+
+When comparing alternatives for a specific component (e.g., C3-A vs C3-B), use the same format but scoped to that component:
+
+```markdown
+## C3: Component Name
+
+| Req | Requirement | Status | C3-A | C3-B |
+|-----|-------------|--------|------|------|
+| R1 | State survives page refresh | Must-have | ✅ | ❌ |
+| R2 | Back button restores state | Must-have | ✅ | ✅ |
+```
+
+### Missing Requirements
+If a shape passes all checks but still feels wrong, there's a missing requirement. Articulate the implicit constraint as a new R, then re-run the fit check.
+
+### Macro Fit Check
+
+A separate tool from the standard fit check, used when working at a high level with chunked requirements and early-stage shapes where most mechanisms are still ⚠️. Use when explicitly requested.
+
+The macro fit check has two columns per shape instead of one:
+
+- **Addressed?** — Does some part of the shape seem to speak to this requirement at a high level?
+- **Answered?** — Can you trace the concrete how? Is the mechanism actually spelled out?
+
+**Format:**
+
+```markdown
+## Macro Fit Check: R × A
+
+| Req | Requirement | Addressed? | Answered? |
+|-----|-------------|:----------:|:---------:|
+| R0 | Core goal description | ✅ | ❌ |
+| R1 | Guided workflow | ✅ | ❌ |
+| R2 | Agent boundary | ⚠️ | ❌ |
+```
+
+**Conventions:**
+- Only show top-level requirements (R0, R1, R2...), not sub-requirements
+- **No notes column** — keep the table narrow and scannable
+- Use ✅ (yes), ⚠️ (partially), ❌ (no) for Addressed
+- Use ✅ (yes) or ❌ (no) for Answered
+- Follow the macro fit check with a separate **Gaps** table listing specific missing parts and their related sub-requirements
+
+## Possible Actions
+
+These can happen in any order:
+
+- **Populate R** - Gather requirements as they emerge
+- **Sketch a shape** - Propose a high-level approach (A, B, C...)
+- **Detail (components)** - Break a shape into components (B1, B2...)
+- **Detail (affordances)** - Expand a selected shape into concrete UI/Non-UI affordances and wiring
+- **Explore alternatives** - For a component, identify options (C3-A, C3-B...)
+- **Check fit** - Build a fit check (decision matrix) playing options against R
+- **Extract Rs** - When fit checks reveal implicit requirements, add them to R as standalone items
+- **Breadboard** - Map the system to understand where changes happen and make the shape more concrete
+- **Spike** - Investigate unknowns to identify concrete steps needed
+- **Decide** - Pick alternatives, compose final solution
+- **Slice** - Break a breadboarded shape into vertical slices for implementation
+
+## Communication
+
+### Show Full Tables
+
+When displaying R (requirements) or any S (shapes), always show every row — never summarize or abbreviate. The full table is the artifact; partial views lose information and break the collaborative process.
+
+- Show all requirements, even if many
+- Show all shape parts, including sub-parts (E1.1, E1.2...)
+- Show all alternatives in fit checks
+
+### Why This Matters
+
+Shaping is collaborative negotiation. The user needs to see the complete picture to:
+- Spot missing requirements
+- Notice inconsistencies
+- Make informed decisions
+- Track what's been decided
+
+Summaries hide detail and shift control away from the user.
+
+### Mark Changes with 🟡
+
+When re-rendering a requirements table or shape table after making changes, mark every changed or added line with a 🟡 so the user can instantly spot what's different. Place the 🟡 at the start of the changed cell content. This makes iterative refinement easy to follow — the user should never have to diff the table mentally.
+
+## Spikes
+
+A spike is an investigation task to learn how the existing system works and what concrete steps are needed to implement a component. Use spikes when there's uncertainty about mechanics or feasibility.
+
+### File Management
+
+**Always create spikes in their own file** (e.g., `spike.md` or `spike-[topic].md`). Spikes are standalone investigation documents that may be shared or worked on independently from the shaping doc.
+
+### Purpose
+
+- Learn how the existing system works in the relevant area
+- Identify **what we would need to do** to achieve a result
+- Enable informed decisions about whether to proceed
+- Not about effort — effort is implicit in the steps themselves
+- **Investigate before proposing** — discover what already exists; you may find the system already satisfies requirements
+
+### Structure
+
+```markdown
+## [Component] Spike: [Title]
+
+### Context
+Why we need this investigation. What problem we're solving.
+
+### Goal
+What we're trying to learn or identify.
+
+### Questions
+
+| # | Question |
+|---|----------|
+| **X1-Q1** | Specific question about mechanics |
+| **X1-Q2** | Another specific question |
+
+### Acceptance
+Spike is complete when all questions are answered and we can describe [the understanding we'll have].
+```
+
+### Acceptance Guidelines
+
+Acceptance describes the **information/understanding** we'll have, not a conclusion or decision:
+
+- ✅ "...we can describe how users set their language and where non-English titles appear"
+- ✅ "...we can describe the steps to implement [component]"
+- ❌ "...we can answer whether this is a blocker" (that's a decision, not information)
+- ❌ "...we can decide if we should proceed" (decision comes after the spike)
+
+The spike gathers information; decisions are made afterward based on that information.
+
+### Question Guidelines
+
+Good spike questions ask about mechanics:
+- "Where is the [X] logic?"
+- "What changes are needed to [achieve Y]?"
+- "How do we [perform Z]?"
+- "Are there constraints that affect [approach]?"
+
+Avoid:
+- Effort estimates ("How long will this take?")
+- Vague questions ("Is this hard?")
+- Yes/no questions that don't reveal mechanics
+
+## Breadboards
+
+Use the `/breadboarding` skill to map existing systems or detail a shape into concrete affordances. Breadboarding produces:
+- UI Affordances table
+- Non-UI Affordances table
+- Wiring diagram grouped by Place
+
+Invoke breadboarding when you need to:
+- Map existing code to understand where changes land
+- Translate a high-level shape into concrete affordances
+- Reveal orthogonal concerns (parts that are independent of each other)
+
+### Tables Are the Source of Truth
+
+The affordance tables (UI and Non-UI) define the breadboard. The Mermaid diagram renders them.
+
+When receiving feedback on a breadboard:
+1. **First** — update the affordance tables (add/remove/modify affordances, update Wires Out)
+2. **Then** — update the Mermaid diagram to reflect those changes
+
+Never treat the diagram as the primary artifact. Changes flow from tables → diagram, not the reverse.
+
+### CURRENT as Reserved Shape Name
+
+Use **CURRENT** to describe the existing system. This provides a baseline for understanding where proposed changes fit.
+
+## Shape Parts
+
+### Flagged Unknown (⚠️)
+
+A mechanism can be described at a high level without being concretely understood. The **Flag** column tracks this:
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **F1** | Create widget (component, def, register) | |
+| **F2** | Magic authentication handler | ⚠️ |
+
+- **Empty** = mechanism is understood — we know concretely how to build it
+- **⚠️** = flagged unknown — we've described WHAT but don't yet know HOW
+
+**Why flagged unknowns fail the fit check:**
+
+1. **✅ is a claim of knowledge** — it means "we know how this shape satisfies this requirement"
+2. **Satisfaction requires a mechanism** — some part that concretely delivers the requirement
+3. **A flag means we don't know how** — we've described what we want, not how to build it
+4. **You can't claim what you don't know** — therefore it must be ❌
+
+Fit check is always binary — ✅ or ❌ only. There is no third state. A flagged unknown is a failure until resolved.
+
+This distinguishes "we have a sketch" from "we actually know how to do this." Early shapes (A, B, C) often have many flagged parts — that's fine for exploration. But a selected shape should have no flags (all ❌ resolved), or explicit spikes to resolve them.
+
+### Parts Must Be Mechanisms
+
+Shape parts describe what we BUILD or CHANGE — not intentions or constraints:
+
+- ✅ "Route `childType === 'letter'` to `typesenseService.rawSearch()`" (mechanism)
+- ❌ "Types unchanged" (constraint — belongs in R)
+
+### Avoid Tautologies Between R and S
+
+**R** states the need/constraint (what outcome). **S** describes the mechanism (how to achieve it). If they say the same thing, the shape part isn't adding information.
+
+- ❌ R17: "Admins can bulk request members to sign" + C6.3: "Admin can bulk request members to sign"
+- ✅ R17: "Admins can bring existing members into waiver tracking" + C6.3: "Bulk request UI with member filters, creates WaiverRequests in batch"
+
+The requirement describes the capability needed. The shape part describes the concrete mechanism that provides it. If you find yourself copying text from R into S, stop — the shape part should add specificity about *how*.
+
+### Parts Should Be Vertical Slices
+
+Avoid horizontal layers like "Data model" that group all tables together. Instead, co-locate data models with the features they support:
+
+- ❌ **B4: Data model** — Waivers table, WaiverSignatures table, WaiverRequests table
+- ✅ **B1: Signing handler** — includes WaiverSignatures table + handler logic
+- ✅ **B5: Request tracking** — includes WaiverRequests table + tracking logic
+
+Each part should be a vertical slice containing the mechanism AND the data it needs.
+
+### Extract Shared Logic
+
+When the same logic appears in multiple parts, extract it as a standalone part that others reference:
+
+- ❌ Duplicating "Signing handler: create WaiverSignature + set boolean" in B1 and B2
+- ✅ Extract as **B1: Signing handler**, then B2 and B3 say "→ calls B1"
+
+```markdown
+| **B1** | **Signing handler** |
+| B1.1 | WaiverSignatures table: memberId, waiverId, signedAt |
+| B1.2 | Handler: create WaiverSignature + set member.waiverUpToDate = true |
+| **B2** | **Self-serve signing** |
+| B2 | Self-serve purchase: click to sign inline → calls B1 |
+| **B3** | **POS signing via email** |
+| B3.1 | POS purchase: send waiver email |
+| B3.2 | Passwordless link to sign → calls B1 |
+```
+
+### Hierarchical Notation
+
+Start with flat notation (E1, E2, E3...). Only introduce hierarchy (E1.1, E1.2...) when:
+
+- There are too many parts to easily understand
+- You're reaching a conclusion and want to show structure
+- Grouping related mechanisms aids communication
+
+| Notation | Meaning |
+|----------|---------|
+| E1 | Top-level component of shape E |
+| E1.1, E1.2 | Sub-parts of E1 (add later if needed) |
+
+Example of hierarchical grouping (used when shape is mature):
+
+| Part | Mechanism |
+|------|-----------|
+| **E1** | **Swap data source** |
+| E1.1 | Modify backend indexer |
+| E1.2 | Route letters to new service |
+| E1.3 | Route posts to new service |
+| **E2** | **Add search input** |
+| E2.1 | Add input with debounce |
+
+## Detailing a Shape
+
+When a shape is selected, you can expand it into concrete affordances. This is called **detailing**.
+
+### Notation
+
+Use "Detail X" (not a new letter) to show this is a breakdown of Shape X, not an alternative:
+
+```markdown
+## A: First approach
+(shape table)
+
+## B: Second approach
+(shape table)
+
+## Detail B: Concrete affordances
+(affordance tables + wiring)
+```
+
+### What Detailing Produces
+
+Use the `/breadboarding` skill to produce:
+- **UI Affordances table** — Things users see and interact with (inputs, buttons, displays)
+- **Non-UI Affordances table** — Data stores, handlers, queries, services
+- **Wiring diagram** — How affordances connect across places
+
+### Why "Detail X" Not "C"
+
+Shape letters (A, B, C...) are **mutually exclusive alternatives** — you pick one. Detailing is not an alternative; it's a deeper breakdown of the selected shape. Using a new letter would incorrectly suggest it's a sibling option.
+
+```
+A, B, C = alternatives (pick one)
+Detail B = expansion of B (not a choice)
+```
+
+## Documents
+
+Shaping produces up to four documents. Each has a distinct role:
+
+| Document | Contains | Purpose |
+|----------|----------|---------|
+| **Frame** | Source, Problem, Outcome | The "why" — concise, stakeholder-level |
+| **Shaping doc** | Requirements, Shapes (CURRENT/A/B/...), Affordances, Breadboard, Fit Check | The working document — exploration and iteration happen here |
+| **Slices doc** | Slice details, affordance tables per slice, wiring diagrams | The implementation plan — how to build incrementally |
+| **Slice plans** | V1-plan.md, V2-plan.md, etc. | Individual implementation plans for each slice |
+
+### Document Lifecycle
+
+```
+Frame (problem/outcome)
+    ↓
+Shaping (explore, detail, breadboard)
+    ↓
+Slices (plan implementation)
+```
+
+**Frame** can be written first — it captures the "why" before any solution work begins. It contains:
+- **Source** — Original requests, quotes, or material that prompted the work (verbatim)
+- **Problem** — What's broken, what pain exists (distilled from source)
+- **Outcome** — What success looks like (high-level, not solution-specific)
+
+### Capturing Source Material
+
+When the user provides source material during framing (user requests, quotes, emails, slack messages, etc.), **always capture it verbatim** in a Source section at the top of the frame document.
+
+```markdown
+## Source
+
+> I'd like to ask again for your thoughts on a user scenario...
+>
+> Small reminder: at the moment, if I want to keep my country admin rights
+> for Russia and Crimea while having Europe Center as my home center...
+
+> [Additional source material added as received]
+
+---
+
+## Problem
+...
+```
+
+**Why this matters:**
+- The source is the ground truth — Problem/Outcome are interpretations
+- Preserves context that may be relevant later
+- Allows revisiting the original request if the distillation missed something
+- Multiple sources can be added as they arrive during framing
+
+**When to capture:**
+- User pastes a request or quote
+- User shares an email or message from a stakeholder
+- User describes a scenario they were told about
+- Any raw material that informs the frame
+
+**Shaping doc** is where active work happens. All exploration, requirements gathering, shape comparison, breadboarding, and fit checking happens here. This is the working document and ground truth for R, shapes, parts, and fit checks.
+
+**Slices doc** is created when the selected shape is breadboarded and ready to build. It contains the slice breakdown, affordance tables per slice, and detailed wiring.
+
+### File Management
+
+- **Shaping doc**: Update freely as you iterate — this is the ground truth
+- **Slices doc**: Created when ready to slice, updated as slice scope clarifies
+- **Slice plans**: Individual files (V1-plan.md, etc.) with implementation details
+
+### Frontmatter
+
+Every shaping document (shaping doc, frame, slices doc) must include `shaping: true` in its YAML frontmatter. This enables tooling hooks (e.g., ripple-check reminders) that help maintain consistency across documents.
+
+```markdown
+---
+shaping: true
+---
+
+# [Feature Name] — Shaping
+...
+```
+
+### Keeping Documents in Sync
+
+See **Multi-Level Consistency** at the top of this document. Changes at any level must ripple to affected levels above and below.
+
+## Slicing
+
+After a shape is breadboarded, slice it into vertical implementation increments. Use the `/breadboarding` skill for the slicing process — it defines what vertical slices are, the procedure for creating them, and visualization formats.
+
+**The flow:**
+1. **Parts** → high-level mechanisms in the shape
+2. **Breadboard** → concrete affordances with wiring (use `/breadboarding`)
+3. **Slices** → vertical increments that can each be demoed (use `/breadboarding` slicing section)
+
+**Key principle:** Every slice must end in demo-able UI. A slice without visible output is a horizontal layer, not a vertical slice.
+
+**Document outputs:**
+- **Slices doc** — slice definitions, per-slice affordance tables, sliced breadboard
+- **Slice plans** — individual implementation plans (V1-plan.md, V2-plan.md, etc.)
+
+## Example
+
+User is shaping a search feature:
+
+```markdown
+---
+shaping: true
+---
+
+## Requirements (R)
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R0 | Make items searchable from index page | Core goal |
+| R1 | State survives page refresh | Undecided |
+| R2 | Back button restores state | Undecided |
+
+---
+
+## C2: State Persistence
+
+| Req | Requirement | Status | C2-A | C2-B | C2-C |
+|-----|-------------|--------|------|------|------|
+| R0 | Make items searchable from index page | Core goal | — | — | — |
+| R1 | State survives page refresh | Undecided | ✅ | ✅ | ❌ |
+| R2 | Back button restores state | Undecided | ✅ | ✅ | ✅ |
+
+**Notes:**
+- C2-C fails R1: in-memory state lost on refresh
+- C2-B satisfies R2 but requires custom popstate handler
+```

--- a/base/skills/shape/references/writing-plans.md
+++ b/base/skills/shape/references/writing-plans.md
@@ -1,0 +1,84 @@
+# Writing Implementation Plans
+
+Write comprehensive implementation plans assuming the engineer has zero context.
+Document everything: which files to touch, code, testing, docs, how to verify.
+Give the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+## Save plans to
+
+`docs/plans/YYYY-MM-DD-<feature-name>.md`
+
+## Bite-Sized Task Granularity
+
+Each step is one action (2-5 minutes):
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+Every plan MUST start with:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+**Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## Remember
+
+- Exact file paths always
+- Complete code in plan (not "add validation")
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits

--- a/cmd/bb/setup.go
+++ b/cmd/bb/setup.go
@@ -83,41 +83,14 @@ func runSetup(ctx context.Context, spriteName, repo string, force bool, persona 
 	// 3. Upload base configs
 	_, _ = fmt.Fprintf(os.Stderr, "uploading base configs...\n")
 
-	configMap := map[string]string{
-		"base/CLAUDE.md": "/home/sprite/.claude/CLAUDE.md",
-	}
-
 	if err := uploadPatchedSettings(ctx, s, openrouterKey); err != nil {
 		return fmt.Errorf("upload settings.json: %w", err)
 	}
 
-	// hooks
-	hookFiles, _ := filepath.Glob("base/hooks/*.py")
-	for _, f := range hookFiles {
-		configMap[f] = "/home/sprite/.claude/hooks/" + filepath.Base(f)
+	configMap, err := buildBaseConfigMap(".")
+	if err != nil {
+		return fmt.Errorf("collect base configs: %w", err)
 	}
-
-	// commands
-	cmdFiles, _ := filepath.Glob("base/commands/*.md")
-	for _, f := range cmdFiles {
-		configMap[f] = "/home/sprite/.claude/commands/" + filepath.Base(f)
-	}
-
-	// prompts
-	promptFiles, _ := filepath.Glob("base/prompts/*.md")
-	for _, f := range promptFiles {
-		configMap[f] = "/home/sprite/.claude/prompts/" + filepath.Base(f)
-	}
-
-	// skills — each skill is a directory with SKILL.md
-	_ = filepath.WalkDir("base/skills", func(p string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return err
-		}
-		rel, _ := filepath.Rel("base/skills", p)
-		configMap[p] = "/home/sprite/.claude/skills/" + rel
-		return nil
-	})
 
 	for local, remote := range configMap {
 		if err := uploadFile(ctx, s, local, remote); err != nil {
@@ -209,6 +182,56 @@ git config --global --add safe.directory '*'
 
 	_, _ = fmt.Fprintf(os.Stderr, "setup complete: %s\n", spriteName)
 	return nil
+}
+
+func buildBaseConfigMap(root string) (map[string]string, error) {
+	configMap := map[string]string{
+		filepath.Join(root, "base/CLAUDE.md"): "/home/sprite/.claude/CLAUDE.md",
+	}
+
+	hookFiles, err := filepath.Glob(filepath.Join(root, "base/hooks/*.py"))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range hookFiles {
+		configMap[f] = "/home/sprite/.claude/hooks/" + filepath.Base(f)
+	}
+
+	commandFiles, err := filepath.Glob(filepath.Join(root, "base/commands/*.md"))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range commandFiles {
+		configMap[f] = "/home/sprite/.claude/commands/" + filepath.Base(f)
+	}
+
+	promptFiles, err := filepath.Glob(filepath.Join(root, "base/prompts/*.md"))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range promptFiles {
+		configMap[f] = "/home/sprite/.claude/prompts/" + filepath.Base(f)
+	}
+
+	skillsRoot := filepath.Join(root, "base/skills")
+	if err := filepath.WalkDir(skillsRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(skillsRoot, p)
+		if err != nil {
+			return err
+		}
+		configMap[p] = "/home/sprite/.claude/skills/" + rel
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return configMap, nil
 }
 
 // resolvePersona returns the local path to the persona file to use for setup.

--- a/cmd/bb/setup_test.go
+++ b/cmd/bb/setup_test.go
@@ -120,3 +120,47 @@ func TestResolvePersonaErrorWhenExplicitPersonaNotFound(t *testing.T) {
 		t.Errorf("error should mention the missing persona name, got: %v", err)
 	}
 }
+
+func TestBuildBaseConfigMapIncludesImportedSkillFilesRecursively(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite := func(rel string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(rel), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite("base/CLAUDE.md")
+	mustWrite("base/hooks/test-hook.py")
+	mustWrite("base/commands/commit.md")
+	mustWrite("base/prompts/orientation-phase.md")
+	mustWrite("base/skills/shape/SKILL.md")
+	mustWrite("base/skills/shape/references/breadboarding.md")
+
+	got, err := buildBaseConfigMap(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRemote := func(local, wantRemote string) {
+		t.Helper()
+		gotRemote, ok := got[filepath.Join(dir, local)]
+		if !ok {
+			t.Fatalf("missing local path %q in config map", local)
+		}
+		if gotRemote != wantRemote {
+			t.Fatalf("remote for %q = %q, want %q", local, gotRemote, wantRemote)
+		}
+	}
+
+	assertRemote("base/CLAUDE.md", "/home/sprite/.claude/CLAUDE.md")
+	assertRemote("base/hooks/test-hook.py", "/home/sprite/.claude/hooks/test-hook.py")
+	assertRemote("base/commands/commit.md", "/home/sprite/.claude/commands/commit.md")
+	assertRemote("base/prompts/orientation-phase.md", "/home/sprite/.claude/prompts/orientation-phase.md")
+	assertRemote("base/skills/shape/SKILL.md", "/home/sprite/.claude/skills/shape/SKILL.md")
+	assertRemote("base/skills/shape/references/breadboarding.md", "/home/sprite/.claude/skills/shape/references/breadboarding.md")
+}

--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -241,11 +241,13 @@ The conductor is designed to run on a dedicated coordinator sprite, not a develo
 sprite create coordinator
 ```
 
-2. Push the repo and toolchain:
+2. Push the repo, base prompts/hooks, imported autonomy skills, and persona/toolchain contract:
 
 ```bash
 bb setup coordinator --repo misty-step/bitterblossom
 ```
+
+`bb setup` now provisions the repo-local skill tree from `base/skills/` onto the coordinator or worker sprite under `/home/sprite/.claude/skills/`. Managed sprites should be treated as running a version-pinned imported skill surface, not an ad hoc local-only prompt pile.
 
 3. Set required secrets on the coordinator:
 

--- a/docs/plans/skill-import-inventory.md
+++ b/docs/plans/skill-import-inventory.md
@@ -1,0 +1,19 @@
+# Skill Import Inventory
+
+Imported from `phrazzld/agent-skills` into Bitterblossom `base/skills/`:
+- autopilot
+- shape
+- build
+- pr
+- pr-walkthrough
+- debug
+- pr-fix
+- pr-polish
+
+Not found as standalone skill directories in the current `phrazzld/agent-skills` clone and still pending follow-up treatment:
+- simplify
+- ux-polish
+
+Current decision:
+- import the first-wave standalone skills now
+- keep `simplify` and `ux-polish` as explicit follow-up imports or repo-local wrappers once their upstream packaging is settled

--- a/sprites/bramble.md
+++ b/sprites/bramble.md
@@ -9,6 +9,10 @@ skills:
   - naming-conventions
   - git-mastery
   - external-integration
+  - shape
+  - build
+  - debug
+  - pr
 ---
 
 # Bramble — Systems & Data

--- a/sprites/fern.md
+++ b/sprites/fern.md
@@ -9,6 +9,10 @@ skills:
   - naming-conventions
   - git-mastery
   - external-integration
+  - autopilot
+  - debug
+  - pr-walkthrough
+  - pr-fix
 ---
 
 # Fern — Platform & Operations

--- a/sprites/glance.md
+++ b/sprites/glance.md
@@ -4,7 +4,7 @@ The `/sprites` directory serves as the configuration hub for a multi-agent orche
 The architecture is modular and role-based, designed for a delegated workflow where tasks are routed based on specific "Routing Signals." The system follows a collaborative "Team Context" model, where individual agents are aware of their peers' specialties to facilitate handoffs (e.g., Foxglove identifying a bug and handing it to Clover for regression testing). 
 
 Each sprite configuration adheres to a standardized schema:
-*   **Metadata (Frontmatter):** Defines the agent's name, skill sets (e.g., `git-mastery`, `testing-philosophy`), and execution parameters such as `permissionMode: bypassPermissions` and `model: inherit`.
+*   **Metadata (Frontmatter):** Defines the agent's name, skill sets (for example imported autonomy skills such as `shape`, `build`, `debug`, `pr-fix`, or `autopilot`), and execution parameters such as `permissionMode: bypassPermissions` and `model: inherit`.
 *   **Operational Philosophy:** Establishes the high-level principles guiding the agent's logic (e.g., "Infrastructure as Code" for Fern or "Reproduce First" for Foxglove).
 *   **Working Patterns:** Provides specific algorithmic or procedural instructions for task execution.
 *   **Routing Signals:** Defines the triggers and keywords used by the orchestrator (OpenClaw) to dispatch tasks to the correct agent.
@@ -12,9 +12,9 @@ Each sprite configuration adheres to a standardized schema:
 
 ### Key File Roles
 The directory is partitioned into several functional domains:
-*   **Infrastructure & Operations:** `fern.md` (CI/CD, Docker, Deployment).
-*   **Core Development:** `bramble.md` (Backend/Data), `willow.md` (Frontend/UI), and `moss.md` (System Architecture).
-*   **Quality & Security:** `thorn.md` (General Quality), `hemlock.md` (Security Auditing), `clover.md` (Test Writing), and `foxglove.md` (Bug Investigation).
+*   **Infrastructure & Operations:** `fern.md` (CI/CD, Docker, Deployment, skill-backed remediation).
+*   **Core Development:** `bramble.md` (Backend/Data with `shape`/`build`/`pr`), `willow.md` (Frontend/UI with polish and walkthrough skills), and `moss.md` (System Architecture with autopilot/shaping/review skills).
+*   **Quality & Security:** `thorn.md` (General Quality with debug/fix/polish), `hemlock.md` (Security Auditing), `clover.md` (Test Writing), and `foxglove.md` (Bug Investigation).
 *   **Maintenance & Evolution:** `rowan.md` (Refactoring), `nettle.md` (Technical Debt), and `hazel.md` (Issue Grooming).
 *   **Support & Research:** `sage.md` (Documentation) and `beaker.md` (Scientific Experimentation/Adversarial Testing).
 

--- a/sprites/moss.md
+++ b/sprites/moss.md
@@ -8,6 +8,11 @@ skills:
   - testing-philosophy
   - naming-conventions
   - git-mastery
+  - autopilot
+  - shape
+  - debug
+  - pr-walkthrough
+  - pr-polish
 ---
 
 # Moss — Architecture & Evolution

--- a/sprites/thorn.md
+++ b/sprites/thorn.md
@@ -9,6 +9,11 @@ skills:
   - naming-conventions
   - git-mastery
   - external-integration
+  - build
+  - debug
+  - pr-walkthrough
+  - pr-fix
+  - pr-polish
 ---
 
 # Thorn — Quality & Security

--- a/sprites/willow.md
+++ b/sprites/willow.md
@@ -8,6 +8,11 @@ skills:
   - testing-philosophy
   - naming-conventions
   - git-mastery
+  - shape
+  - build
+  - pr
+  - pr-walkthrough
+  - pr-polish
 ---
 
 # Willow — Interface & Experience


### PR DESCRIPTION
## Summary
- import first-wave autonomy skills from phrazzld/agent-skills into Bitterblossom base/skills
- make sprite/base docs explicitly describe version-pinned imported skill provisioning
- add role-pack skill assignments for primary sprites and cover recursive skill upload in bb setup tests

## Context
- architecture umbrella: #569
- intake shaping issue: #474
- PR shepherding issue: #515
- kernel/brain split issue: #511

## Verification
- gofmt -w cmd/bb/setup.go cmd/bb/setup_test.go
- go test ./cmd/bb/...

## Notes
- this starts Slice A only
- simplify and ux-polish are still pending follow-up because they do not exist as standalone skill directories in the current phrazzld/agent-skills clone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Imported eight autonomous agent skills (autopilot, shape, build, debug, pr, pr-fix, pr-polish, pr-walkthrough) from agent-skills; now provisioned to managed worker sprites with full documentation.
  * Worker sprites now include comprehensive skill references and operational guidance.

* **Documentation**
  * Added detailed skill documentation including workflows, best practices, and reference guides.
  * Updated setup and conductor documentation to reflect skill provisioning model.

* **Chores**
  * Refactored base configuration provisioning to centralize skill tree collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->