### PR TITLE
refactor: deepen conductor governance session

### DIFF
--- a/docs/walkthroughs/codex-simplify-governance-session-terminal.txt
+++ b/docs/walkthroughs/codex-simplify-governance-session-terminal.txt
@@ -5,9 +5,9 @@
 All checks passed!
 
 == Governance regression slice ==
-..................................                                       [100%]
-34 passed, 209 deselected in 0.55s
+....................................                                     [100%]
+36 passed, 209 deselected in 0.86s
 
 == External-only regression slice ==
-...                                                                      [100%]
-3 passed, 240 deselected in 0.35s
+.....                                                                    [100%]
+5 passed, 240 deselected in 0.44s

--- a/docs/walkthroughs/codex-simplify-governance-session.md
+++ b/docs/walkthroughs/codex-simplify-governance-session.md
@@ -6,7 +6,7 @@ Collapse `govern_pr_flow` into a state-owning `GovernanceSession`.
 
 ## Why Now
 
-Before this branch, the conductor's governor lane lived in one 426-line temporal script. It mixed review policy, CI policy, PR-thread policy, external-review waiting, final polish, and merge handoff in one function, so even a small governance tweak required threading the same mutable state through several branches.
+Before this branch, the conductor's governor lane lived in one 434-line temporal script. It mixed review policy, CI policy, PR-thread policy, external-review waiting, final polish, and merge handoff in one function, so even a small governance tweak required threading the same mutable state through several branches.
 
 ## Before
 
@@ -68,6 +68,8 @@ Observable improvements:
 - revision requests follow one internal path instead of five hand-built call sites
 - PR-thread revisions preserve the pre-refactor event log shape instead of introducing a new `pr_review_threads` revision event path
 - external-only governance still re-enters the `"governing"` phase before each pass, matching the base-branch run contract
+- post-polish revisions now force another final-polish pass before merge instead of letting stale polish state slip through
+- governance-side builder turns and the merge handoff now renew the issue lease for the full operation budget
 - tests still exercise the same operator-visible run contract
 
 ## Verification
@@ -84,7 +86,7 @@ Supporting checks:
 
 - `python3 -m ruff check scripts/conductor.py scripts/test_conductor.py`
 - targeted external-only regression:
-  - `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr_uses_external_authority_without_internal_reviewers or run_once_uses_external_authority_without_internal_reviewers or run_once_thread_revision_keeps_original_event_log_shape'`
+  - `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr_refreshes_lease_for_governance_builder_turns_and_merge or run_once_reruns_final_polish_after_post_polish_thread_revision or govern_pr_uses_external_authority_without_internal_reviewers or run_once_uses_external_authority_without_internal_reviewers or run_once_thread_revision_keeps_original_event_log_shape'`
 - AST shape check captured in the transcript:
   - base branch `govern_pr_flow`: `434` lines
   - this branch `govern_pr_flow`: `27` lines

--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -4742,6 +4742,9 @@ class GovernanceSession:
             return "block"
         if thread_action == "revise" and feedback is not None:
             self.last_pr_feedback_thread_ids = thread_ids
+            # handle_pr_review_threads() already recorded revision_requested and
+            # phase="revising", so calling _request_builder_turn() here would
+            # duplicate the run-state transition and event log entry.
             self.builder = self._run_builder_turn(
                 event_type="builder_revised",
                 feedback=feedback,
@@ -4791,6 +4794,8 @@ class GovernanceSession:
         )
 
     def _run_builder_turn(self, *, event_type: str, feedback: str, feedback_source: str) -> BuilderResult:
+        self.polish_completed = False
+        self._touch_run(self.args.builder_timeout * 60 + DEFAULT_LEASE_BUFFER_SECONDS)
         return run_builder_turn(
             self.runner,
             self.conn,
@@ -4812,7 +4817,8 @@ class GovernanceSession:
 
     def _merge(self) -> int:
         update_run(self.conn, self.run_id, phase="merge_ready")
-        self._touch_run(600)
+        merge_budget_seconds = 2 * 120 + 600 + DEFAULT_LEASE_BUFFER_SECONDS
+        self._touch_run(merge_budget_seconds)
         merge_pr(self.runner, self.args.repo, self.builder.pr_number)
         update_run(self.conn, self.run_id, phase="merged", status="merged")
         record_event(

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -6920,6 +6920,127 @@ def test_govern_pr_uses_external_authority_without_internal_reviewers(
     assert phase_updates.count("governing") >= events.count(("external_wait", 490))
 
 
+def test_govern_pr_refreshes_lease_for_governance_builder_turns_and_merge(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    issue = conductor.Issue(number=495, title="govern", body="", url="https://example.com/495", labels=["autopilot"])
+    merge_calls: list[int] = []
+    ttl_updates: list[int] = []
+    trusted_thread = conductor.ReviewThread(
+        id="thread-1",
+        path="scripts/conductor.py",
+        line=2034,
+        author_login="review-bot",
+        author_association="MEMBER",
+        body=(
+            "This thread reopened after the earlier clear.\n\n"
+            "<!-- bitterblossom: {\"classification\":\"bug\",\"severity\":\"high\",\"decision\":\"fix_now\"} -->"
+        ),
+        url="https://example.com/thread-1",
+    )
+    thread_reads = iter([[trusted_thread], [], [], [], []])
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    assert conductor.acquire_lease(conn, "misty-step/bitterblossom", issue.number, "run-495-1") is True
+    conductor.create_run(conn, "run-495-1", "misty-step/bitterblossom", issue, "default")
+    conductor.update_run(
+        conn,
+        "run-495-1",
+        phase="awaiting_governance",
+        status="active",
+        builder_sprite="noble-blue-serpent",
+        worktree_path="/tmp/run-495-1-builder",
+        branch="factory/495-handoff-1",
+        pr_number=496,
+        pr_url="https://github.com/misty-step/bitterblossom/pull/496",
+    )
+
+    original_touch_run = conductor.touch_run
+
+    def tracking_touch_run(
+        conn: sqlite3.Connection,
+        repo: str,
+        issue_number: int,
+        run_id: str,
+        ttl_seconds: int,
+    ) -> None:
+        if run_id == "run-495-1":
+            ttl_updates.append(ttl_seconds)
+        original_touch_run(conn, repo, issue_number, run_id, ttl_seconds)
+
+    monkeypatch.setattr(conductor, "touch_run", tracking_touch_run)
+    monkeypatch.setattr(conductor, "cleanup_builder_workspace", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        conductor,
+        "ensure_governance_run",
+        lambda *_a, **_kw: conductor.GovernanceRun(
+            issue=issue,
+            run_id="run-495-1",
+            worker="noble-blue-serpent",
+            worker_slot=conductor.WorkerSlot(
+                id=7,
+                repo="misty-step/bitterblossom",
+                worker="noble-blue-serpent",
+                slot_index=1,
+                state=conductor.WORKER_SLOT_ACTIVE,
+                consecutive_failures=0,
+                current_run_id="run-495-1",
+                last_probe_at=None,
+                last_error=None,
+                updated_at="2026-03-12T12:00:00Z",
+            ),
+            branch="factory/495-handoff-1",
+            pr_number=496,
+            pr_url="https://github.com/misty-step/bitterblossom/pull/496",
+            builder_workspace="/tmp/run-495-1-builder",
+        ),
+    )
+    monkeypatch.setattr(
+        conductor,
+        "run_review_round",
+        lambda *_a, **_kw: (_ for _ in ()).throw(AssertionError("review council should be skipped")),
+    )
+    monkeypatch.setattr(conductor, "ensure_pr_ready", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "wait_for_pr_checks", lambda *_a, **_kw: (True, "merge-gate: SUCCESS"))
+    monkeypatch.setattr(conductor, "ensure_required_checks_present", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "list_unresolved_review_threads", lambda *_a, **_kw: next(thread_reads))
+    monkeypatch.setattr(conductor, "wait_for_external_reviews", lambda *_a, **_kw: (True, "CodeRabbit: SUCCESS"))
+    monkeypatch.setattr(
+        conductor,
+        "run_builder",
+        lambda *_a, **_kw: (
+            conductor.BuilderResult(
+                status="ready_for_review",
+                branch="factory/495-handoff-1",
+                pr_number=496,
+                pr_url="https://github.com/misty-step/bitterblossom/pull/496",
+                summary="polished",
+                tests=[],
+            ),
+            {"status": "ready_for_review"},
+        ),
+    )
+    monkeypatch.setattr(conductor, "comment_pr", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "comment_issue", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "merge_pr", lambda _r, _repo, pr_num: merge_calls.append(pr_num))
+
+    args = _make_govern_pr_args(
+        tmp_path,
+        issue_number=495,
+        pr_number=496,
+        run_id="run-495-1",
+        reviewers=[],
+        trusted_external_surfaces=["CodeRabbit"],
+    )
+    args.builder_timeout = 7
+
+    rc = conductor.govern_pr(args)
+
+    assert rc == 0
+    assert merge_calls == [496]
+    assert ttl_updates.count(args.builder_timeout * 60 + conductor.DEFAULT_LEASE_BUFFER_SECONDS) >= 2
+    assert 2 * 120 + 600 + conductor.DEFAULT_LEASE_BUFFER_SECONDS in ttl_updates
+
+
 def test_govern_pr_marks_run_failed_when_lease_is_lost(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
@@ -7505,6 +7626,70 @@ def test_run_once_uses_external_authority_without_internal_reviewers(
     event_types = [row["event_type"] for row in conn.execute("select event_type from events where run_id = ? order by id", (run_row["run_id"],))]
     assert "reviewers_ready" not in event_types
     assert "external_review_wait_complete" in event_types
+
+
+def test_run_once_reruns_final_polish_after_post_polish_thread_revision(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    issue = conductor.Issue(number=497, title="post-polish", body="", url="https://example.com/497", labels=["autopilot"])
+    builder = conductor.BuilderResult(
+        status="ready_for_review",
+        branch="factory/497-gov-1",
+        pr_number=498,
+        pr_url="https://github.com/misty-step/bitterblossom/pull/498",
+        summary="done",
+        tests=[],
+    )
+    reviews = [
+        conductor.ReviewResult(reviewer="fern", verdict="pass", summary="ok", findings=[]),
+        conductor.ReviewResult(reviewer="sage", verdict="pass", summary="ok", findings=[]),
+        conductor.ReviewResult(reviewer="thorn", verdict="pass", summary="ok", findings=[]),
+    ]
+    builder_turns: list[tuple[str | None, str | None]] = []
+    merge_calls: list[int] = []
+    trusted_thread = conductor.ReviewThread(
+        id="thread-1",
+        path="scripts/conductor.py",
+        line=2034,
+        author_login="review-bot",
+        author_association="MEMBER",
+        body=(
+            "This thread reopened after the earlier clear.\n\n"
+            "<!-- bitterblossom: {\"classification\":\"bug\",\"severity\":\"high\",\"decision\":\"fix_now\"} -->"
+        ),
+        url="https://example.com/thread-1",
+    )
+    thread_reads = iter([[], [trusted_thread], [], []])
+    check_results = iter([(True, "green"), (True, "green"), (True, "green"), (True, "green")])
+
+    monkeypatch.setattr(conductor, "get_issue", lambda *_a, **_kw: issue)
+    monkeypatch.setattr(conductor, "select_worker_slot", _select_named_worker_slot("noble-blue-serpent"))
+    monkeypatch.setattr(conductor, "ensure_reviewers_ready", lambda *_a, **_kw: None)
+
+    def fake_run_builder(*_args: object, **kwargs: object) -> tuple[conductor.BuilderResult, dict[str, object]]:
+        builder_turns.append((kwargs.get("feedback"), kwargs.get("feedback_source")))  # type: ignore[arg-type]
+        return builder, {"status": "ready_for_review"}
+
+    monkeypatch.setattr(conductor, "run_builder", fake_run_builder)
+    monkeypatch.setattr(conductor, "run_review_round", lambda *_a, **_kw: reviews)
+    monkeypatch.setattr(conductor, "ensure_pr_ready", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "wait_for_pr_checks", lambda *_a, **_kw: next(check_results))
+    monkeypatch.setattr(conductor, "ensure_required_checks_present", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "list_unresolved_review_threads", lambda *_a, **_kw: next(thread_reads))
+    monkeypatch.setattr(conductor, "merge_pr", lambda _r, _repo, pr_num: merge_calls.append(pr_num))
+    monkeypatch.setattr(conductor, "comment_pr", lambda *_a, **_kw: None)
+    monkeypatch.setattr(conductor, "comment_issue", lambda *_a, **_kw: None)
+
+    rc = conductor.run_once(_make_run_once_args(tmp_path, issue_number=497))
+
+    assert rc == 0
+    assert merge_calls == [498]
+    assert [feedback_source for _feedback, feedback_source in builder_turns] == [
+        "review",
+        "polish",
+        "pr_review_threads",
+        "polish",
+    ]
 
 
 def test_run_once_merges_normally_when_no_trusted_surfaces_configured(


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Walkthrough note](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session.md)
- Direct terminal artifact: [Command transcript](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session-terminal.txt?raw=1)
- Walkthrough notes: the transcript shows the structural delta (`govern_pr_flow` from `434` lines to `27`, with state moved into `GovernanceSession`) and the refreshed 36-test governance slice plus 5-test external-only safety slice passing on this branch.
- Fast claim: this refactor keeps the conductor contract intact while moving governor bookkeeping behind one deeper module boundary.

## Why This Matters
- Problem: the governor lane lived in one long temporal script, so review, CI, PR-thread, external-review, polish, and merge policy all depended on the same parameter-threaded function.
- Value: the session object now owns builder state, revision counters, and thread history in one place, which lowers the cost and risk of future governance changes.
- Why now: recent work already centralized builder turns; this is the next simplification step that removes incidental control-flow duplication without changing the external run contract.
- Issue: no linked issue for this refactor branch.

## Trade-offs / Risks
- Value gained: the governor seam is deeper and easier to reason about, with repeated builder-turn plumbing collapsed behind session methods.
- Cost / risk incurred: this is still a large internal move inside the conductor's most critical path.
- Why this is still the right trade: the repo already has heavy scenario coverage for run adoption, review rounds, PR threads, external reviews, polish, and merge, and the refreshed local governance slices pass after the refactor, and GitHub CI remains the whole-file gate because the local full-file run is flaky on this macOS host.
- Reviewer watch-outs: pressure-test the PR-thread revision path and external-review wait path, because those were the most repetition-heavy branches before this change.

## What Changed
`govern_pr_flow` is now a thin entry wrapper that hands control to `GovernanceSession`, a state-owning module for one governor lane. The policy sequence stays the same, but the state and repeated builder-turn mechanics are no longer scattered across a 434-line procedural script.

### Base Branch
```mermaid
flowchart TD
    A["govern_pr_flow"] --> B["review round"]
    A --> C["CI wait"]
    A --> D["PR threads"]
    A --> E["external review wait"]
    A --> F["final polish"]
    A --> G["merge"]
    B --> H["shared counters + builder state threaded through branches"]
    C --> H
    D --> H
    E --> H
    F --> H
```

### This PR
```mermaid
flowchart TD
    A["govern_pr_flow"] --> B["GovernanceSession.run()"]
    B --> C["wait_for_minimum_age"]
    B --> D["run_review_round"]
    B --> E["ci_decision"]
    B --> F["thread_decision"]
    B --> G["external_review_decision"]
    B --> H["run_final_polish"]
    B --> I["merge"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
    [*] --> GovernanceSession
    GovernanceSession --> ReviewRound
    ReviewRound --> BuilderRevision: review / CI / thread feedback
    BuilderRevision --> GovernanceSession
    ReviewRound --> ExternalReviewWait
    ExternalReviewWait --> BuilderRevision: trusted thread feedback
    ExternalReviewWait --> FinalPolish
    FinalPolish --> GovernanceSession
    GovernanceSession --> Merged
```

Why this is better:
- The governor's mutable state is now owned in one place instead of being passed through every branch.
- Repeated revision requests use one internal path, which reduces change amplification for future governance work.
- The operator-facing run lifecycle stays the same, and the existing regression suite remains the proof surface.

<details>
<summary>Intent Reference</summary>

## Intent Reference
This branch follows the repo's stated architecture goal from [`docs/architecture/conductor.md`](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/architecture/conductor.md): the conductor should stay deep, with a small operator surface and rich internal orchestration.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero risk in the short term.
- Downside: every governor change keeps paying the same bookkeeping and repetition tax.
- Why rejected: the repetition-heavy governor lane is already the hottest internal control-flow seam in the conductor.

### Option B — Extract shared run-lifecycle policy from `run_once` and `govern_pr`
- Upside: removes duplicated termination semantics across entrypoints.
- Downside: touches failure handling, lease release, and workspace cleanup across two top-level commands at once.
- Why rejected: good follow-up target, but riskier than first simplifying the governor's internal state boundary.

### Option C — Introduce `GovernanceSession`
- Upside: deepens the governor seam without changing the external command contract.
- Downside: still leaves the broader conductor in one large file.
- Why chosen: best ratio of complexity removed to delivery risk in one PR.

</details>

<details>
<summary>Changes</summary>

## Changes
- Refactored [`scripts/conductor.py`](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/scripts/conductor.py) so `govern_pr_flow` delegates to `GovernanceSession`.
- Centralized builder-turn requests, PR-thread feedback handling, CI handling, external-review waiting, final polish, and merge completion inside the session object.
- Added a branch-scoped walkthrough note and terminal transcript under [`docs/walkthroughs/codex-simplify-governance-session.md`](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session.md) and [`docs/walkthroughs/codex-simplify-governance-session-terminal.txt`](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session-terminal.txt?raw=1).

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] `govern_pr_flow` becomes a thin wrapper around a state-owning governor module.
- [x] Repeated builder-turn request plumbing is centralized instead of repeated across review, CI, and PR-thread branches.
- [x] The focused local governance regression slices pass after the refactor, and GitHub CI remains the whole-file gate.
- [x] Reviewer evidence includes a real execution artifact from this branch.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
python3 -m ruff check scripts/conductor.py scripts/test_conductor.py
python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr or run_once or external_review_wait or pr_threads or final_polish'
python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr_refreshes_lease_for_governance_builder_turns_and_merge or run_once_reruns_final_polish_after_post_polish_thread_revision or govern_pr_uses_external_authority_without_internal_reviewers or run_once_uses_external_authority_without_internal_reviewers or run_once_thread_revision_keeps_original_event_log_shape'
```

Expected:
- Ruff passes cleanly.
- The focused governance and external-only regression slices pass locally.
- The walkthrough transcript captures the AST shape delta and both verification commands.
- Whole-file `scripts/test_conductor.py` confidence comes from GitHub CI because `test_cleanup_run_workspace_waits_for_lock_release` is flaky on this macOS host.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal walkthrough + markdown summary
- Artifact: [Walkthrough note](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session.md) and [command transcript](../blob/b36301f1056ff9625acfb296266e1bb3181be89d/docs/walkthroughs/codex-simplify-governance-session-terminal.txt?raw=1)
- Claim: the governor state is now hidden behind `GovernanceSession`, while the same run contract and regression surface remain intact.
- Before / After scope: governor control-flow shape and branch-wide conductor verification.
- Persistent verification: `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr or run_once or external_review_wait or pr_threads or final_polish'`
- Supporting verification: `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr_refreshes_lease_for_governance_builder_turns_and_merge or run_once_reruns_final_polish_after_post_polish_thread_revision or govern_pr_uses_external_authority_without_internal_reviewers or run_once_uses_external_authority_without_internal_reviewers or run_once_thread_revision_keeps_original_event_log_shape'`
- Residual gap: this PR improves the governor seam, not the top-level duplicated run-lifecycle policy in `run_once` and `govern_pr`.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: one 434-line `govern_pr_flow` function owned every branch and its bookkeeping state directly.
- After: a 27-line `govern_pr_flow` wrapper delegates to `GovernanceSession`, which owns the governor lane state and helper decisions internally.
- Screenshots are not needed because this is an internal refactor with no user-visible surface.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr or run_once or external_review_wait or pr_threads or final_polish'`
- `python3 -m pytest -q scripts/test_conductor.py -k 'govern_pr_refreshes_lease_for_governance_builder_turns_and_merge or run_once_reruns_final_polish_after_post_polish_thread_revision or govern_pr_uses_external_authority_without_internal_reviewers or run_once_uses_external_authority_without_internal_reviewers or run_once_thread_revision_keeps_original_event_log_shape'`
- Key high-signal paths exercised by the refreshed local slices and GitHub CI:
  - `govern_pr`
  - `run_once`
  - PR-thread blocking / revision behavior
  - trusted external review wait behavior
  - final polish rerun behavior after post-polish revisions
  - governance lease renewal across builder turns and merge

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: medium-high locally, high once current PR CI and review automation settle green
- Strongest evidence: the 36-test governance regression slice, the 5-test external-only safety slice, and a transcript that captures the structural delta directly from the branch.
- Remaining uncertainty: the local full-file `scripts/test_conductor.py` run is flaky on this macOS host (`test_cleanup_run_workspace_waits_for_lock_release`), so whole-file confidence comes from GitHub CI rather than local whole-suite output alone.
- What could still go wrong after merge: future refactors could still pay duplication costs in top-level run finalization until that path is simplified separately, and this branch still depends on CI plus settled review automation for final merge confidence.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed governance walkthrough and terminal transcript with before/after diagrams, verification steps, and CI/regression notes.

* **Refactor**
  * Reorganized governance flow into a session-driven, stateful orchestration while preserving existing public interfaces and observable behavior.

* **Tests**
  * Added tests covering thread-revision scenarios, ensuring event-log shape is preserved and final-polish re-run behavior is exercised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

