### PR TITLE
docs: record worktree lifecycle hardening patterns from #538

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,38 @@
 # MEMORY
 
+## Worktree Lifecycle Hardening (#538)
+
+### 2026-03-13 — patterns locked in after PRs #545, #573, #574
+
+**Serialization model**: one `flock` per repo mirror, shared by both
+`prepare_run_workspace` and `cleanup_run_workspace`. Bash-level `exec 9>"$lockfile" && flock -w N 9`
+with separate wait budgets (`WORKSPACE_PREPARE_LOCK_WAIT_SECONDS = 240`,
+`WORKSPACE_CLEANUP_LOCK_WAIT_SECONDS = 120`). Tests verify that each
+operation actually blocks when the other holds the lock.
+
+**Retry clause**: `prepare_run_workspace_with_retry` catches `(CmdError,
+subprocess.TimeoutExpired, OSError)`. OSError was added in PR #574 after
+breaking-pipe transport errors fell outside the original `CmdError` catch.
+Three attempts, 2-second delay, `workspace_preparation_retry` event per attempt,
+then `workspace_preparation_failed` on exhaustion. Lease checked between attempts.
+
+**Cleanup truth**: `cleanup_builder_workspace` catches all exceptions. On
+failure it records a `cleanup_warning` event with `kind=builder_workspace_cleanup`
+and leaves `worktree_path` **intact** in the run row so operators can recover
+the surviving path from `show-run` without touching the sprite filesystem.
+On success it clears `worktree_path` and writes `builder_workspace_cleaned`.
+
+**Observer surface**: `show-runs` and `show-run` expose `worktree_path` plus
+four recovery fields: `worktree_recovery_status`, `worktree_recovery_error`,
+`worktree_recovery_event_type`, `worktree_recovery_event_at`. The status field
+takes one of three values: `cleaned`, `cleanup_failed`, `prepare_failed`.
+
+**Testing approach**: lock-contention tests use a real local git repo, a
+`flock` shim that routes to the system binary, and `_hold_lock` (a background
+subprocess) to hold the file descriptor. All lock-wait assertions check elapsed
+≥ 1.0 s. This is the only reliable way to verify flock behavior without mocking
+the entire bash execution path.
+
 ## Filed Issues
 
 ### 2026-02-18 e2e-test shakedown


### PR DESCRIPTION
## Summary

- Records worktree lifecycle hardening patterns in MEMORY.md established across PRs #545, #573, and #574
- Documents serialization model, retry clause (including OSError added in #574), cleanup truth contract, and observer surface
- Captures the lock-contention testing approach for future sprite reference

## What this closes

All acceptance criteria for [#538](https://github.com/misty-step/bitterblossom/issues/538) were implemented across:

| PR | Description |
|---|---|
| #545 | Core hardening: flock serialization, retry, cleanup truth, show-runs surface |
| #573 | Test: verify `cleanup_run_workspace` serializes with prepare via shared flock |
| #574 | Fix: retry OSError (broken pipe, ENOENT) in `prepare_run_workspace_with_retry` |

All 244 conductor tests pass:

```
python3 -m pytest -q scripts/test_conductor.py
244 passed in 10.62s

python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"
38 passed in 8.11s
```

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on worktree lifecycle hardening, covering serialization models, retry handling, cleanup behavior, and recovery status mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->