### PR TITLE
test: cover show_runs prepare_failed worktree recovery path (#538)

### DIFF
--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -4335,6 +4335,45 @@ def test_show_runs_surfaces_worktree_recovery_context(tmp_path: pathlib.Path, ca
     assert payload["worktree_recovery_error"] == "builder workspace cleanup failed: permission denied"
 
 
+def test_show_runs_surfaces_builder_workspace_preparation_failure(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    issue = conductor.Issue(number=45, title="prepare", body="body", url="https://example.com/45", labels=["autopilot"])
+    conductor.create_run(conn, "run-45b", "misty-step/bitterblossom", issue, "claude-sonnet")
+    conductor.update_run(
+        conn,
+        "run-45b",
+        phase="failed",
+        status="failed",
+        builder_sprite="noble-blue-serpent",
+        worktree_path="/tmp/run-45b/builder-worktree",
+    )
+    conductor.record_event(
+        conn,
+        tmp_path / "events.jsonl",
+        "run-45b",
+        "workspace_preparation_failed",
+        {
+            "sprite": "noble-blue-serpent",
+            "lane": "builder",
+            "workspace": "/tmp/run-45b/builder-worktree",
+            "attempt": 3,
+            "attempts": 3,
+            "error": "mirror lock acquisition timed out",
+        },
+    )
+
+    rc = conductor.show_runs(argparse.Namespace(db=str(tmp_path / "conductor.db"), limit=5))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["worktree_path"] == "/tmp/run-45b/builder-worktree"
+    assert payload["worktree_recovery_status"] == "prepare_failed"
+    assert payload["worktree_recovery_event_type"] == "workspace_preparation_failed"
+    assert payload["worktree_recovery_error"] == "mirror lock acquisition timed out"
+
+
 def test_show_runs_ignores_non_workspace_cleanup_warnings(
     tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #538

The core hardening for issue #538 landed in master via #545, #549, #555, #557, #573, #574, and #578:
- Bash-level `flock` per-repo mirror lock serializing `fetch`, `worktree add/remove`, and `prune`
- `prepare_run_workspace_with_retry` with 3 attempts and explicit `workspace_preparation_failed` events
- `OSError` (broken pipe, ENOENT) treated as transient and retried alongside `CmdError` and `TimeoutExpired`
- `cleanup_builder_workspace` records `cleanup_warning` + preserves `worktree_path` for operator recovery
- `show-runs` / `show-run` expose `worktree_path` and `worktree_recovery_*` fields
- `docs/CONDUCTOR.md` documents worktree lifecycle semantics and recovery

This PR closes one remaining test gap: `show_runs` had a test for the `cleanup_failed` recovery path but no symmetrical test for the `prepare_failed` path.

**Added**: `test_show_runs_surfaces_builder_workspace_preparation_failure` — verifies that when a builder-lane `workspace_preparation_failed` event exists, `show_runs` emits `worktree_recovery_status=prepare_failed` and `worktree_recovery_error` with the exhaustion message.

All four acceptance criteria from #538 are now directly regression-tested:
- Mirror mutation serialization: `test_prepare_run_workspace_waits_for_lock_release`, `test_cleanup_run_workspace_waits_for_lock_release`
- Transient failure retry: `test_prepare_run_workspace_with_retry_recovers_after_transient_failure`, `*_retries_os_error`, `*_records_explicit_failure`
- Cleanup failure recovery context: `test_cleanup_builder_workspace_records_cleanup_warning_on_error`, `*_preserves_worktree_path_on_failure`
- Operator inspection via show-runs/show-run: `test_show_runs_surfaces_worktree_recovery_context`, `test_show_runs_surfaces_builder_workspace_preparation_failure`, `test_show_run_surfaces_workspace_preparation_failure_reason`, `test_show_run_includes_worktree_path`

## Test plan

- [x] `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` — 39 passed
- [x] `python3 -m pytest -q scripts/test_conductor.py` — 245 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for workspace preparation failure recovery scenarios, ensuring proper error messaging and recovery status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->