### PR TITLE
test: cover show_run cleanup_failed worktree recovery path (#538)

### DIFF
--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -8499,3 +8499,45 @@ def test_show_run_includes_worktree_path(
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["run"]["worktree_path"] == "/home/sprite/workspace/bitterblossom/.bb/conductor/run-538-1/builder-worktree"
+
+
+def test_show_run_surfaces_builder_workspace_cleanup_failure(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    issue = conductor.Issue(number=538, title="cleanup failure", body="", url="u538c", labels=["autopilot"])
+    conductor.create_run(conn, "run-538-2", "misty-step/bitterblossom", issue, "default")
+    conductor.update_run(
+        conn,
+        "run-538-2",
+        phase="awaiting_governance",
+        status="active",
+        builder_sprite="noble-blue-serpent",
+        pr_number=999,
+        pr_url="https://github.com/misty-step/bitterblossom/pull/999",
+        worktree_path="/home/sprite/workspace/bitterblossom/.bb/conductor/run-538-2/builder-worktree",
+    )
+    conductor.record_event(
+        conn,
+        tmp_path / "events.jsonl",
+        "run-538-2",
+        "cleanup_warning",
+        {
+            "kind": conductor.BUILDER_WORKSPACE_CLEANUP_KIND,
+            "workspace": "/home/sprite/workspace/bitterblossom/.bb/conductor/run-538-2/builder-worktree",
+            "error": "builder workspace cleanup failed: stale worktree",
+        },
+    )
+
+    rc = conductor.show_run(
+        argparse.Namespace(db=str(tmp_path / "conductor.db"), run_id="run-538-2", event_limit=5)
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    run = payload["run"]
+    assert run["worktree_path"] == "/home/sprite/workspace/bitterblossom/.bb/conductor/run-538-2/builder-worktree"
+    assert run["worktree_recovery_status"] == "cleanup_failed"
+    assert run["worktree_recovery_event_type"] == "cleanup_warning"
+    assert run["worktree_recovery_error"] == "builder workspace cleanup failed: stale worktree"


### PR DESCRIPTION
## Summary

- `show_run` (single-run inspector) had `prepare_failed` coverage but no `cleanup_failed` test
- Add `test_show_run_surfaces_builder_workspace_cleanup_failure` to complete the recovery-status coverage matrix
- Both `show_runs` and `show_run` now have explicit tests for all three `worktree_recovery_status` values: `cleaned`, `cleanup_failed`, `prepare_failed`

## Context

This is the final closure commit for #538. The implementation work landed across:

- **#545** — serialized mirror mutation (`flock`), retry logic (`prepare_run_workspace_with_retry`), cleanup truth (`cleanup_builder_workspace` + `cleanup_warning` event), and `show-runs`/`show-run` observer surface
- **#573** — verified `cleanup_run_workspace` serializes with `prepare_run_workspace` via shared flock
- **#574** — extended retry catch to `OSError` for broken-pipe transport failures
- **#578** — documented worktree lifecycle semantics in `CONDUCTOR.md`
- **#579** — covered `show_runs` `prepare_failed` recovery path

This PR covers the one remaining gap: `show_run` + `cleanup_failed`.

## Test plan

- [x] `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` — 39 passed (was 38 before this PR)
- [x] `python3 -m pytest -q scripts/test_conductor.py` — 246 passed

```bash
python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"
python3 scripts/conductor.py show-runs --limit 20
```

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for builder workspace cleanup failure recovery scenarios, ensuring errors are properly surfaced when cleanup operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->