### PR TITLE
perf: bulk-fetch recovery and blocking events in show_runs (#538)

### DIFF
--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -5262,8 +5262,20 @@ def show_runs(args: argparse.Namespace) -> int:
         """,
         (args.limit,),
     ).fetchall()
+    run_ids = [row["run_id"] for row in rows]
+    recovery_by_run = latest_worktree_recovery_events(conn, run_ids)
+    blocking_by_run = blocking_events_for_runs(conn, run_ids)
     for row in rows:
-        print(json.dumps(serialize_run_surface(conn, row)))
+        print(
+            json.dumps(
+                serialize_run_surface(
+                    conn,
+                    row,
+                    worktree_recovery_event=recovery_by_run.get(row["run_id"]),
+                    blocking_event=blocking_by_run.get(row["run_id"]),
+                )
+            )
+        )
     return 0
 
 

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -8614,3 +8614,87 @@ def test_show_runs_surfaces_cleaned_workspace_recovery_status(
     assert payload["worktree_recovery_status"] == "cleaned"
     assert payload["worktree_recovery_event_type"] == "builder_workspace_cleaned"
     assert payload["worktree_recovery_error"] is None
+
+
+def test_show_runs_bulk_recovery_across_mixed_states(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """show_runs resolves recovery state correctly for each run when multiple
+    runs with different recovery statuses are returned in one query."""
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    event_log = tmp_path / "events.jsonl"
+
+    # Run A: cleanup_failed — worktree_path stays populated
+    issue_a = conductor.Issue(number=538, title="cleanup fail", body="", url="ua", labels=["autopilot"])
+    conductor.create_run(conn, "run-bulk-a", "misty-step/bitterblossom", issue_a, "default")
+    conductor.update_run(
+        conn,
+        "run-bulk-a",
+        phase="awaiting_governance",
+        status="active",
+        builder_sprite="noble-blue-serpent",
+        worktree_path="/tmp/run-bulk-a/builder-worktree",
+    )
+    conductor.record_event(
+        conn,
+        event_log,
+        "run-bulk-a",
+        "cleanup_warning",
+        {
+            "kind": conductor.BUILDER_WORKSPACE_CLEANUP_KIND,
+            "workspace": "/tmp/run-bulk-a/builder-worktree",
+            "error": "builder workspace cleanup failed: transport error",
+        },
+    )
+
+    # Run B: cleaned — worktree_path cleared
+    issue_b = conductor.Issue(number=539, title="cleaned", body="", url="ub", labels=["autopilot"])
+    conductor.create_run(conn, "run-bulk-b", "misty-step/bitterblossom", issue_b, "default")
+    conductor.update_run(
+        conn,
+        "run-bulk-b",
+        phase="awaiting_governance",
+        status="active",
+        builder_sprite="noble-blue-serpent",
+        worktree_path=None,
+    )
+    conductor.record_event(
+        conn,
+        event_log,
+        "run-bulk-b",
+        "builder_workspace_cleaned",
+        {"workspace": "/tmp/run-bulk-b/builder-worktree"},
+    )
+
+    # Run C: no recovery event — no worktree recovery context
+    issue_c = conductor.Issue(number=540, title="no recovery", body="", url="uc", labels=["autopilot"])
+    conductor.create_run(conn, "run-bulk-c", "misty-step/bitterblossom", issue_c, "default")
+    conductor.update_run(
+        conn,
+        "run-bulk-c",
+        phase="running_builder",
+        status="active",
+        builder_sprite="noble-blue-serpent",
+        worktree_path="/tmp/run-bulk-c/builder-worktree",
+    )
+
+    rc = conductor.show_runs(argparse.Namespace(db=str(tmp_path / "conductor.db"), limit=10))
+
+    assert rc == 0
+    lines = {
+        json.loads(line)["run_id"]: json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    }
+
+    assert lines["run-bulk-a"]["worktree_recovery_status"] == "cleanup_failed"
+    assert lines["run-bulk-a"]["worktree_recovery_error"] == "builder workspace cleanup failed: transport error"
+    assert lines["run-bulk-a"]["worktree_path"] == "/tmp/run-bulk-a/builder-worktree"
+
+    assert lines["run-bulk-b"]["worktree_recovery_status"] == "cleaned"
+    assert lines["run-bulk-b"]["worktree_recovery_error"] is None
+    assert lines["run-bulk-b"]["worktree_path"] is None
+
+    assert lines["run-bulk-c"]["worktree_recovery_status"] is None
+    assert lines["run-bulk-c"]["worktree_recovery_error"] is None


### PR DESCRIPTION
## Summary

Follow-up efficiency fix springing from the #538 worktree lifecycle hardening work.

`show_runs` was making **N+1 SQLite round-trips**: one call each to `latest_worktree_recovery_event` and `blocking_event_for_run` per row inside `serialize_run_surface`. `show_metrics` already used the bulk variants (`latest_worktree_recovery_events`, `blocking_events_for_runs`) for the same data.

This PR pre-fetches both maps once before the row loop so the query count is O(1) regardless of `--limit`, matching `show_metrics`.

## Changes

- `scripts/conductor.py`: update `show_runs` to pre-fetch recovery and blocking event maps in bulk, then pass them explicitly into `serialize_run_surface`
- `scripts/test_conductor.py`: add `test_show_runs_bulk_recovery_across_mixed_states` — three runs with different recovery states (`cleanup_failed`, `cleaned`, none) in one `show_runs` call

## Test results

```
python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup or bulk_recovery"
43 passed, 206 deselected in 7.71s

python3 -m pytest -q scripts/test_conductor.py
249 passed in 10.91s
```

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Run status queries now include per-run recovery and blocking event details, providing enhanced visibility into operational events and recovery contexts across multiple executed runs.

* **Tests**
  * Added comprehensive test coverage validating that recovery status, error information, and recovery context data is correctly surfaced and aggregated across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->