### PR TITLE
test: cover show_run reviewer-event filtering for worktree recovery (#538)

### DIFF
--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -8908,6 +8908,8 @@ def test_show_run_ignores_reviewer_workspace_cleanup_warning(
     run = payload["run"]
     assert run["worktree_recovery_status"] is None
     assert run["worktree_recovery_error"] is None
+    assert run["worktree_recovery_event_type"] is None
+    assert run["worktree_recovery_event_at"] is None
 
 
 def test_show_run_ignores_reviewer_workspace_preparation_failure(
@@ -8949,6 +8951,8 @@ def test_show_run_ignores_reviewer_workspace_preparation_failure(
     run = payload["run"]
     assert run["worktree_recovery_status"] is None
     assert run["worktree_recovery_error"] is None
+    assert run["worktree_recovery_event_type"] is None
+    assert run["worktree_recovery_event_at"] is None
     assert run["blocking_event_type"] is None
     assert run["blocking_reason"] is None
 


### PR DESCRIPTION
## Summary

Closes #538.

`show_runs` had explicit tests verifying that reviewer `cleanup_warning` and `workspace_preparation_failed` events do not pollute the builder `worktree_recovery_*` fields. `show_run` used the same SQL-filtered `latest_worktree_recovery_event` path but had no parallel tests.

Adds:
- `test_show_run_ignores_reviewer_workspace_cleanup_warning` — mirrors `test_show_runs_ignores_reviewer_workspace_cleanup_warnings` for the single-run surface
- `test_show_run_ignores_reviewer_workspace_preparation_failure` — mirrors `test_show_runs_ignores_reviewer_workspace_preparation_failures` for the single-run surface

Both tests confirm that reviewer-lane events are excluded from the builder worktree recovery status visible via `show-run --run-id <id>`.

## Test plan

- [x] `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` — 44 passed
- [x] `python3 -m pytest -q scripts/test_conductor.py` — 258 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added two tests verifying that reviewer workspace cleanup and preparation-failure events are not reported as builder worktree recovery, leaving worktree recovery status and error unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->