### PR TITLE
refactor: centralize bb sprite transport setup

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -92,10 +92,6 @@ func verifyWorkScriptFor(workspace, ghToken string) string {
 
 func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverride, promptTemplate string, maxIter int, timeout time.Duration, noOutputTimeout time.Duration, dryRun bool, prCheckTimeout time.Duration, waitForComplete bool) error {
 	// Validate credentials
-	token, err := spriteToken()
-	if err != nil {
-		return err
-	}
 	ghToken, err := requireEnv("GITHUB_TOKEN")
 	if err != nil {
 		return err
@@ -103,18 +99,13 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 
 	// LLM auth is handled by settings.json on the sprite (baked in during setup).
 	// Dispatch only validates that GITHUB_TOKEN is set for git operations.
-
-	client := sprites.New(token)
-	defer func() { _ = client.Close() }()
-	s := client.Sprite(spriteName)
-
-	// 1. Probe connectivity (15s)
 	_, _ = fmt.Fprintf(os.Stderr, "probing %s...\n", spriteName)
-	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
-		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
+	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 15 * time.Second})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = session.close() }()
+	s := session.sprite
 
 	// 2. Check that setup was run (ralph.sh must exist)
 	ralphScript := "/home/sprite/workspace/.ralph.sh"

--- a/cmd/bb/kill.go
+++ b/cmd/bb/kill.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	sprites "github.com/superfly/sprites-go"
-
 	"github.com/spf13/cobra"
 )
 
@@ -24,20 +22,12 @@ func newKillCmd() *cobra.Command {
 }
 
 func runKill(ctx context.Context, out io.Writer, spriteName string) error {
-	token, err := spriteToken()
+	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 10 * time.Second})
 	if err != nil {
 		return err
 	}
-
-	client := sprites.New(token)
-	defer func() { _ = client.Close() }()
-	s := client.Sprite(spriteName)
-
-	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
-		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
-	}
+	defer func() { _ = session.close() }()
+	s := session.sprite
 
 	killCtx, killCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer killCancel()

--- a/cmd/bb/logs.go
+++ b/cmd/bb/logs.go
@@ -44,20 +44,12 @@ func runLogs(ctx context.Context, stdout, stderr io.Writer, spriteName string, f
 		return fmt.Errorf("--lines must be >= 0")
 	}
 
-	token, err := spriteToken()
+	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 10 * time.Second})
 	if err != nil {
 		return err
 	}
-
-	client := sprites.New(token)
-	defer func() { _ = client.Close() }()
-	s := client.Sprite(spriteName)
-
-	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
-		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
-	}
+	defer func() { _ = session.close() }()
+	s := session.sprite
 
 	workspace, err := findSpriteWorkspace(ctx, s)
 	if err != nil {

--- a/cmd/bb/setup.go
+++ b/cmd/bb/setup.go
@@ -45,26 +45,19 @@ Without --persona, bb falls back to the first available file in sprites/.`,
 }
 
 func runSetup(ctx context.Context, spriteName, repo string, force bool, persona string) error {
-	token, err := spriteToken()
-	if err != nil {
-		return err
-	}
 	openrouterKey, err := requireEnv("OPENROUTER_API_KEY")
 	if err != nil {
 		return err
 	}
 
-	client := sprites.New(token)
-	defer func() { _ = client.Close() }()
-	s := client.Sprite(spriteName)
-
 	// 1. Probe
 	_, _ = fmt.Fprintf(os.Stderr, "probing %s...\n", spriteName)
-	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
-		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
+	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 15 * time.Second})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = session.close() }()
+	s := session.sprite
 
 	// 2. Create remote directories
 	dirs := []string{

--- a/cmd/bb/sprite_transport.go
+++ b/cmd/bb/sprite_transport.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+type spriteClientOptions struct {
+	disableControl bool
+}
+
+type spriteSessionOptions struct {
+	disableControl bool
+	probeTimeout   time.Duration
+}
+
+type spriteSession struct {
+	client *sprites.Client
+	sprite *sprites.Sprite
+}
+
+func newSpritesClientFromEnv(opts spriteClientOptions) (*sprites.Client, error) {
+	token, err := spriteToken()
+	if err != nil {
+		return nil, err
+	}
+	return newSpritesClient(token, opts), nil
+}
+
+func newSpritesClient(token string, opts spriteClientOptions) *sprites.Client {
+	if opts.disableControl {
+		return sprites.New(token, sprites.WithDisableControl())
+	}
+	return sprites.New(token)
+}
+
+func newSpriteSession(ctx context.Context, spriteName string, opts spriteSessionOptions) (*spriteSession, error) {
+	client, err := newSpritesClientFromEnv(spriteClientOptions{disableControl: opts.disableControl})
+	if err != nil {
+		return nil, err
+	}
+
+	session := &spriteSession{
+		client: client,
+		sprite: client.Sprite(spriteName),
+	}
+	if err := probeSprite(ctx, session.sprite, spriteName, opts.probeTimeout); err != nil {
+		_ = session.close()
+		return nil, err
+	}
+	return session, nil
+}
+
+func (s *spriteSession) close() error {
+	if s == nil || s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+func probeSprite(ctx context.Context, s *sprites.Sprite, spriteName string, timeout time.Duration) error {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
+		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
+	}
+	return nil
+}

--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -44,18 +44,11 @@ func newStatusCmd() *cobra.Command {
 	}
 }
 
-func statusClient(token string) *sprites.Client {
-	client := sprites.New(token, sprites.WithDisableControl())
-	return client
-}
-
 func fleetStatus(ctx context.Context) error {
-	token, err := spriteToken()
+	client, err := newSpritesClientFromEnv(spriteClientOptions{disableControl: true})
 	if err != nil {
 		return err
 	}
-
-	client := statusClient(token)
 	defer func() { _ = client.Close() }()
 
 	all, err := client.ListAllSprites(ctx, "")
@@ -89,11 +82,7 @@ func fleetStatus(ctx context.Context) error {
 			defer wg.Done()
 			r := probeResult{name: s.Name(), status: s.Status, reach: "?", avail: "-"}
 
-			probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			_, probeErr := s.CommandContext(probeCtx, "echo", "ok").Output()
-			cancel()
-
-			if probeErr != nil {
+			if err := probeSprite(ctx, s, s.Name(), 3*time.Second); err != nil {
 				r.reach = "no"
 				r.note = "unreachable"
 			} else {
@@ -125,21 +114,15 @@ func fleetStatus(ctx context.Context) error {
 }
 
 func spriteStatus(ctx context.Context, spriteName string) error {
-	token, err := spriteToken()
+	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{
+		disableControl: true,
+		probeTimeout:   10 * time.Second,
+	})
 	if err != nil {
 		return err
 	}
-
-	client := statusClient(token)
-	defer func() { _ = client.Close() }()
-	s := client.Sprite(spriteName)
-
-	// Probe
-	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if _, err := s.CommandContext(probeCtx, "echo", "ok").Output(); err != nil {
-		return fmt.Errorf("sprite %q unreachable: %w", spriteName, err)
-	}
+	defer func() { _ = session.close() }()
+	s := session.sprite
 
 	// Gather status info.
 	// Uses --porcelain=v1 for stable machine-readable output. When dirty files

--- a/docs/walkthroughs/codex-simplify-bb-sprite-transport-terminal.txt
+++ b/docs/walkthroughs/codex-simplify-bb-sprite-transport-terminal.txt
@@ -1,0 +1,27 @@
+== Transport helper call sites ==
+$ rg -n 'newSpriteSession|newSpritesClientFromEnv|probeSprite' cmd/bb/*.go
+cmd/bb/status.go:48:	client, err := newSpritesClientFromEnv(spriteClientOptions{disableControl: true})
+cmd/bb/status.go:85:			if err := probeSprite(ctx, s, s.Name(), 3*time.Second); err != nil {
+cmd/bb/status.go:117:	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{
+cmd/bb/logs.go:47:	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 10 * time.Second})
+cmd/bb/kill.go:25:	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 10 * time.Second})
+cmd/bb/sprite_transport.go:25:func newSpritesClientFromEnv(opts spriteClientOptions) (*sprites.Client, error) {
+cmd/bb/sprite_transport.go:40:func newSpriteSession(ctx context.Context, spriteName string, opts spriteSessionOptions) (*spriteSession, error) {
+cmd/bb/sprite_transport.go:41:	client, err := newSpritesClientFromEnv(spriteClientOptions{disableControl: opts.disableControl})
+cmd/bb/sprite_transport.go:50:	if err := probeSprite(ctx, session.sprite, spriteName, opts.probeTimeout); err != nil {
+cmd/bb/sprite_transport.go:64:func probeSprite(ctx context.Context, s *sprites.Sprite, spriteName string, timeout time.Duration) error {
+cmd/bb/setup.go:55:	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 15 * time.Second})
+cmd/bb/dispatch.go:103:	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 15 * time.Second})
+
+== Remaining spriteToken call sites ==
+$ rg -n 'spriteToken\(' cmd/bb/*.go
+cmd/bb/main_test.go:108:	_, err := spriteToken()
+cmd/bb/main.go:93:func spriteToken() (string, error) {
+cmd/bb/sprite_transport.go:26:	token, err := spriteToken()
+
+== cmd/bb tests ==
+$ go test ./cmd/bb/...
+ok  	github.com/misty-step/bitterblossom/cmd/bb	(cached)
+
+== Build ==
+$ go build -o bin/bb ./cmd/bb

--- a/docs/walkthroughs/codex-simplify-bb-sprite-transport.md
+++ b/docs/walkthroughs/codex-simplify-bb-sprite-transport.md
@@ -1,0 +1,90 @@
+# Walkthrough: Simplify bb Sprite Transport
+
+## Title
+
+Collapse repeated sprite client, probe, and session setup into one transport module.
+
+## Why Now
+
+ADR-002 says `bb` should stay thin and deterministic. Before this branch, five commands each reimplemented the same transport ceremony: read sprite auth, build a client, select a sprite, probe reachability, and only then do command-specific work. That made the boundary shallow. A transport tweak such as probe policy or client options required touching several command files instead of one module.
+
+## Before
+
+```mermaid
+flowchart TD
+    A["dispatch"] --> Z["token -> client -> sprite -> probe"]
+    B["setup"] --> Z
+    C["logs"] --> Z
+    D["kill"] --> Z
+    E["status"] --> Z2["status-specific token -> client(disableControl) -> probe"]
+```
+
+- Command files owned transport setup and command behavior at the same time.
+- `status` carried a slightly different client path, so transport policy was split across the package.
+- A routine transport change required editing multiple files before any command-specific logic changed.
+
+## What Changed
+
+```mermaid
+flowchart TD
+    A["dispatch"] --> T["newSpriteSession(...)"]
+    B["setup"] --> T
+    C["logs"] --> T
+    D["kill"] --> T
+    E["sprite status"] --> T2["newSpriteSession(..., disableControl=true)"]
+    F["fleet status"] --> C2["newSpritesClientFromEnv(..., disableControl=true)"]
+    T --> H["probeSprite(...)"]
+    T2 --> H
+```
+
+- `cmd/bb/sprite_transport.go` now owns sprite-token lookup, client construction, session creation, and reachability probes.
+- The command files keep their flags, scripts, and remote behavior, but they stop carrying transport boilerplate.
+- `status` still uses `disableControl`, but that transport choice now lives in the helper contract instead of a separate ad hoc client path.
+
+## After
+
+```mermaid
+stateDiagram-v2
+    [*] --> TransportHelper
+    TransportHelper --> ClientFromEnv
+    ClientFromEnv --> Session
+    Session --> Probe
+    Probe --> CommandLogic
+    CommandLogic --> [*]
+```
+
+Observable improvements:
+
+- transport setup now has one home instead of five call-site copies
+- the command files each lost more setup than they gained
+- future transport changes such as probe timeout policy or client options can land in one module
+- command behavior is preserved because the refactor stops at the setup seam, not the command scripts
+
+## Verification
+
+Primary walkthrough artifact:
+
+- [`codex-simplify-bb-sprite-transport-terminal.txt`](./codex-simplify-bb-sprite-transport-terminal.txt)
+
+Persistent protecting check:
+
+- `go test ./cmd/bb/...`
+
+Supporting check:
+
+- `go build -o bin/bb ./cmd/bb`
+
+Code-shape proof captured in the terminal artifact:
+
+- every command now routes through `newSpriteSession(...)` or `newSpritesClientFromEnv(...)`
+- `spriteToken()` now has one transport call site outside `main.go`
+
+## Residual Risk
+
+- This simplifies transport setup, not the larger `dispatch.go` script-check surface.
+- The helper still returns concrete `sprites-go` types; deeper test seams for transport failures would be a separate follow-up.
+- The walkthrough proves compile and package-test safety locally. It does not prove real sprite network behavior without PR CI or a live sprite exercise.
+
+## Merge Case
+
+This branch makes `bb` closer to the design the repo already claims to want: command files describe command behavior, while one helper owns the mechanical transport path. The gain is not new capability. The gain is a deeper module boundary that reduces how many files future transport changes have to touch.


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [walkthrough note](../blob/codex/simplify-bb-sprite-transport/docs/walkthroughs/codex-simplify-bb-sprite-transport.md?raw=true)
- Direct artifact: [terminal walkthrough](../blob/codex/simplify-bb-sprite-transport/docs/walkthroughs/codex-simplify-bb-sprite-transport-terminal.txt?raw=1)
- Walkthrough notes: branch-scoped walkthrough explains the before/after boundary and points to the protecting check
- Fast claim: `bb` now has one transport helper for auth, client setup, and reachability probes; command behavior stays the same and `go test ./cmd/bb/...` still passes

## Why This Matters
- Problem: `dispatch`, `setup`, `logs`, `kill`, and `status` each carried their own sprite auth/client/probe setup, so a transport tweak required editing several command files before any command-specific behavior changed
- Value: this deepens the transport boundary so command files focus on command logic and future transport policy changes have one home
- Why now: ADR-002 explicitly wants a thin deterministic CLI; this duplicated setup was accidental growth away from that boundary
- Issue: none; repo-wide simplify pass against [ADR-002](../blob/codex/simplify-bb-sprite-transport/docs/adr/002-architecture-minimalism.md?raw=true)

## Trade-offs / Risks
- Value gained: less boilerplate in command files and one place to evolve sprite transport behavior
- Cost / risk incurred: one new helper file now owns connection and probe setup, so a bug there would affect multiple commands
- Why this is still the right trade: the helper only centralizes existing mechanics and leaves command scripts, flags, and remote workflows unchanged
- Reviewer watch-outs: pressure-test that `status` still gets `disableControl` and that error wording remains actionable for unreachable sprites

## What Changed
This PR introduces `cmd/bb/sprite_transport.go` as the single place that turns env auth into a sprites client or session, then routes the existing commands through it. The net effect is architectural, not behavioral: less repeated transport ceremony in command files, with the same command-level work afterward.

### Base Branch
```mermaid
flowchart TD
    A["dispatch"] --> Z["token -> client -> sprite -> probe"]
    B["setup"] --> Z
    C["logs"] --> Z
    D["kill"] --> Z
    E["status"] --> Z2["status-specific token -> client(disableControl) -> probe"]
```

### This PR
```mermaid
flowchart TD
    A["dispatch"] --> T["newSpriteSession(...)"]
    B["setup"] --> T
    C["logs"] --> T
    D["kill"] --> T
    E["sprite status"] --> T2["newSpriteSession(..., disableControl=true)"]
    F["fleet status"] --> C2["newSpritesClientFromEnv(..., disableControl=true)"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
    [*] --> TransportHelper
    TransportHelper --> ClientFromEnv
    ClientFromEnv --> Session
    Session --> Probe
    Probe --> CommandLogic
    CommandLogic --> [*]
```

Why this is better:
- transport setup now has one boundary instead of five call-site copies
- routine transport changes no longer require editing every command file
- the refactor preserves the command surface because it stops at the setup seam

<details>
<summary>Intent Reference</summary>

## Intent Reference
- [ADR-002](../blob/codex/simplify-bb-sprite-transport/docs/adr/002-architecture-minimalism.md?raw=true) says `bb` should remain a thin deterministic transport and explicitly warns against growing more scattered transport logic
- This branch applies that intent to the current `cmd/bb` shape by consolidating repeated auth/client/probe setup instead of adding new behavior

</details>

<details>
<summary>Changes</summary>

## Changes
- add [`cmd/bb/sprite_transport.go`](../blob/codex/simplify-bb-sprite-transport/cmd/bb/sprite_transport.go?raw=true) with shared client/session/probe helpers
- route `dispatch`, `setup`, `logs`, `kill`, and `status` through the helper without changing their flags or remote scripts
- add branch-scoped walkthrough artifacts under [`docs/walkthroughs/`](../blob/codex/simplify-bb-sprite-transport/docs/walkthroughs/codex-simplify-bb-sprite-transport.md?raw=true)

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] repeated sprite session setup is centralized in one `cmd/bb` module
- [x] `bb` command behavior and CLI surface remain unchanged
- [x] `go test ./cmd/bb/...` passes
- [x] `go build -o bin/bb ./cmd/bb` succeeds

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero code churn
- Downside: transport policy stays scattered across five command files
- Why rejected: it leaves the current shallow boundary in place even though ADR-002 argues for the opposite shape

### Option B — Simplify only `dispatch.go`
- Upside: reduces the largest command file first
- Downside: leaves the cross-command duplication intact, so transport changes still fan out across the package
- Why rejected: lower leverage per unit of risk than consolidating the shared setup seam

### Option C — Centralize sprite transport setup
- Upside: deletes repeated ceremony across the whole CLI surface and creates one deeper module
- Downside: a bad helper change would affect several commands
- Why chosen: it removes the most repeated complexity while preserving behavior and staying review-sized

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
go test ./cmd/bb/...
go build -o bin/bb ./cmd/bb
rg -n 'newSpriteSession|newSpritesClientFromEnv|probeSprite' cmd/bb/*.go
```

Expected:
- package tests pass
- the CLI still builds
- transport helper usage is visible from the command call sites

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal artifact plus branch-scoped markdown note
- Artifact: [terminal walkthrough](../blob/codex/simplify-bb-sprite-transport/docs/walkthroughs/codex-simplify-bb-sprite-transport-terminal.txt?raw=1)
- Claim: repeated sprite transport setup now lives behind one helper boundary
- Before / After scope: `cmd/bb` transport setup before vs after helper consolidation
- Persistent check: `go test ./cmd/bb/...`
- Residual gap: no live-sprite exercise was recorded on this branch; runtime confidence beyond build/tests still relies on normal PR checks or manual sprite usage
- Observable artifact from actual execution on this branch: the terminal transcript includes the helper call-site scan plus the local test and build runs

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: five commands owned their own auth/client/probe ceremony, and `status` carried a separate client path for `disableControl`
- After: one helper owns those mechanics, while the commands keep only their command-specific work
- Screenshots are not needed because this change is internal to the Go CLI and the walkthrough evidence is terminal-based

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `go test ./cmd/bb/...`
- `go build -o bin/bb ./cmd/bb`

Gap:
- no live integration run against a real sprite was captured in this PR

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: medium-high
- Strongest evidence: the refactor is one commit, `cmd/bb` tests pass, and the walkthrough shows every command now routes through the helper
- Remaining uncertainty: no live sprite command was exercised after the refactor
- What could still go wrong after merge: a real sprite environment could expose a transport assumption that unit tests do not cover

</details>
