### PR TITLE
fix: clarify bb logs idle-state guidance

### DIFF
--- a/cmd/bb/logs.go
+++ b/cmd/bb/logs.go
@@ -72,7 +72,7 @@ func runLogs(ctx context.Context, stdout, stderr io.Writer, spriteName string, f
 	active := spriteHasRunningAgent(ctx, s)
 	hasLog := spriteFileHasContent(ctx, s, logPath)
 	if !active && !hasLog {
-		if err := writeLogsNoTaskMsg(stderr); err != nil {
+		if err := writeLogsNoTaskMsg(stderr, spriteName); err != nil {
 			return fmt.Errorf("logs: %w", err)
 		}
 		return nil
@@ -100,11 +100,15 @@ func runLogs(ctx context.Context, stdout, stderr io.Writer, spriteName string, f
 	return nil
 }
 
-// writeLogsNoTaskMsg writes the "No active task" status message to stderr.
+// writeLogsNoTaskMsg writes the idle-state recovery message to stderr.
 // This is an operational message, not log data, so it must never appear on
 // stdout — stdout must remain parseable JSON in --json mode.
-func writeLogsNoTaskMsg(stderr io.Writer) error {
-	_, err := fmt.Fprintf(stderr, "No active task\n")
+func writeLogsNoTaskMsg(stderr io.Writer, spriteName string) error {
+	_, err := fmt.Fprintf(stderr,
+		"No active task on %q.\nThe sprite is reachable, but no agent is running and ralph.log is empty.\nTry: bb status %s\n",
+		spriteName,
+		spriteName,
+	)
 	return err
 }
 

--- a/cmd/bb/logs_test.go
+++ b/cmd/bb/logs_test.go
@@ -77,12 +77,19 @@ func TestLogsNoActiveTaskGoesToStderr(t *testing.T) {
 	t.Parallel()
 
 	var stderr bytes.Buffer
-	if err := writeLogsNoTaskMsg(&stderr); err != nil {
+	if err := writeLogsNoTaskMsg(&stderr, "fern"); err != nil {
 		t.Fatalf("writeLogsNoTaskMsg: %v", err)
 	}
 
-	if !strings.Contains(stderr.String(), "No active task") {
-		t.Errorf("stderr = %q, want to contain %q", stderr.String(), "No active task")
+	msg := stderr.String()
+	if !strings.Contains(msg, `No active task on "fern".`) {
+		t.Errorf("stderr = %q, want sprite-specific idle message", msg)
+	}
+	if !strings.Contains(msg, "ralph.log is empty") {
+		t.Errorf("stderr = %q, want explanation that no logs are available", msg)
+	}
+	if !strings.Contains(msg, "bb status fern") {
+		t.Errorf("stderr = %q, want next-step guidance", msg)
 	}
 }
 

--- a/walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md
+++ b/walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md
@@ -1,0 +1,69 @@
+# Reviewer Evidence: clarify `bb logs` idle state
+
+## Merge Claim
+
+`bb logs <sprite>` no longer strands operators on a vague `No active task` message. It now explains the observed idle state and points them to the next recovery command without polluting stdout.
+
+## Why This Matters
+
+The old message was technically correct but operationally weak. When an operator reaches for `bb logs`, they are usually debugging a sprite, not reading source. The command should say what it checked and what to do next.
+
+## Before
+
+Baseline from `HEAD:cmd/bb/logs.go`:
+
+```go
+func writeLogsNoTaskMsg(stderr io.Writer) error {
+	_, err := fmt.Fprintf(stderr, "No active task\n")
+	return err
+}
+```
+
+## After
+
+Current branch in `cmd/bb/logs.go`:
+
+```go
+func writeLogsNoTaskMsg(stderr io.Writer, spriteName string) error {
+	_, err := fmt.Fprintf(stderr,
+		"No active task on %q.\nThe sprite is reachable, but no agent is running and ralph.log is empty.\nTry: bb status %s\n",
+		spriteName,
+		spriteName,
+	)
+	return err
+}
+```
+
+## Terminal Walkthrough
+
+### 1. Full package check
+
+```text
+$ go test ./cmd/bb/...
+ok  	github.com/misty-step/bitterblossom/cmd/bb	(cached)
+```
+
+### 2. Regression guard for the idle-state copy
+
+```text
+$ go test -run TestLogsNoActiveTaskGoesToStderr ./cmd/bb
+ok  	github.com/misty-step/bitterblossom/cmd/bb	(cached)
+```
+
+### 3. Diff scope
+
+```text
+$ git diff --stat
+ cmd/bb/logs.go      | 12 ++++++++----
+ cmd/bb/logs_test.go | 13 ++++++++++---
+ 2 files changed, 18 insertions(+), 7 deletions(-)
+```
+
+## Persistent Verification
+
+- `go test ./cmd/bb/...`
+- `go test -run TestLogsNoActiveTaskGoesToStderr ./cmd/bb`
+
+## Residual Gap
+
+This branch improves the idle-state copy only. The `bb status` empty-workspace state still has room for a similar recovery hint, but that is intentionally out of scope here.


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Terminal walkthrough artifact](../blob/69af399cb94a694088b7e476f293596ae4b05e23/walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md?raw=true)
- Direct video download: Not applicable; this is a terminal walkthrough for a CLI-only polish pass.
- Walkthrough notes: [Reviewer evidence bundle](../blob/69af399cb94a694088b7e476f293596ae4b05e23/walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md?raw=true)
- Fast claim: `bb logs <sprite>` now explains the idle state and points operators to `bb status <sprite>` instead of stopping at a vague `No active task` line.

## Why This Matters
- Problem: `bb logs` is part of the operator recovery path, but its idle-state copy did not explain what the command had observed or what an operator should do next.
- Value: This keeps a common debugging seam local and self-explanatory without changing command behavior or stdout parsing guarantees.
- Why now: The fix is small, testable, and removes real operator friction from a high-signal recovery command.
- Issue: None; standalone CLI polish.

## Trade-offs / Risks
- Value gained: Better operator feedback at the exact point of confusion.
- Cost / risk incurred: Slightly more stderr copy and one repo-hosted walkthrough artifact.
- Why this is still the right trade: The branch keeps stdout untouched, preserves existing exit behavior, and adds a regression test around the new message.
- Reviewer watch-outs: Pressure-test whether `bb status <sprite>` is the right first recovery command and whether the added wording stays accurate if idle-state detection changes later.

## What Changed
This PR turns the `bb logs` idle state from a dead-end into a recovery hint. When the sprite is reachable but no agent is running and `ralph.log` is empty, the command now says that explicitly and suggests `bb status <sprite>` as the next step. The regression test now asserts the sprite-specific wording, the empty-log explanation, and the recovery command while preserving the stderr-only contract.

### Base Branch
```mermaid
graph TD
  A["Operator runs bb logs <sprite>"] --> B["Sprite is reachable"]
  B --> C["No running agent and empty ralph.log"]
  C --> D["stderr: No active task"]
  D --> E["Operator must infer next step from docs or source"]
```

### This PR
```mermaid
graph TD
  A["Operator runs bb logs <sprite>"] --> B["Sprite is reachable"]
  B --> C["No running agent and empty ralph.log"]
  C --> D["stderr explains idle state"]
  D --> E["Suggested next step: bb status <sprite>"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> InspectIdleState
  InspectIdleState --> StreamLogs: agent active or log exists
  InspectIdleState --> ExplainIdleState: no agent and empty log
  ExplainIdleState --> RecoverViaStatus: operator runs bb status <sprite>
```

Why this is better:
- The command now explains the observed state instead of making the operator reverse-engineer it.
- The new copy stays local to stderr, so `--json` and stdout consumers remain safe.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Surface: `bb logs` operator recovery path.
- Intent: reduce avoidable confusion in a working CLI flow with the smallest reversible change.
- Source: repo docs describe `bb status` and `bb logs` as the operator recovery path, so the idle state should help an operator recover, not just stop.

</details>

<details>
<summary>Changes</summary>

## Changes
- Updated `cmd/bb/logs.go` so the idle-state helper includes the sprite name, explains that the sprite is reachable with no running agent and an empty `ralph.log`, and suggests `bb status <sprite>`.
- Expanded `cmd/bb/logs_test.go` to assert the new guidance while keeping the stderr-only contract.
- Added a branch-scoped walkthrough artifact under `walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md`.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] `bb logs <sprite>` gives actionable guidance when no agent is running and no log content exists.
- [x] The idle-state message remains on stderr only.
- [x] The change is covered by automated tests.
- [x] Reviewer evidence points to a durable walkthrough artifact.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero churn.
- Downside: operators still hit a dead-end message on a recovery path.
- Why rejected: the confusion is real and the fix is cheap.

### Option B — Push the guidance into docs only
- Upside: no code change.
- Downside: the operator still has to leave the failing command to learn the next step.
- Why rejected: this is exactly the kind of local feedback the CLI should provide itself.

### Option C — Current approach
- Upside: fixes the confusion at the point of failure with a tiny, reversible diff.
- Downside: adds a few more words to stderr.
- Why chosen: it solves the actual friction without broadening scope.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
go test ./cmd/bb/...
go test -run TestLogsNoActiveTaskGoesToStderr ./cmd/bb
```

- Visual QA: not applicable; no frontend files changed.
- Dogfood QA: not applicable; this repo change is a CLI-only polish pass and there is no browser flow to dogfood.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Terminal walkthrough
- Artifact: [Reviewer evidence bundle](../blob/69af399cb94a694088b7e476f293596ae4b05e23/walkthrough/codex-clarify-logs-idle-state/reviewer-evidence.md?raw=true)
- Claim: the idle `bb logs` state is now self-explanatory and points to recovery without changing stdout semantics.
- Before / After scope: `cmd/bb/logs.go`, its regression test, and the operator-facing idle-state message.
- Persistent verification: `go test ./cmd/bb/...`
- Residual gap: `bb status` still has an opportunity for similar empty-state recovery copy, but that is intentionally deferred.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: `bb logs` printed `No active task` and stopped.
- After: `bb logs` identifies the idle condition and suggests `bb status <sprite>` as the next recovery command.
- Screenshots: not needed for this internal CLI change; the terminal walkthrough artifact contains the relevant before/after snippets and proof commands.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `cmd/bb/logs_test.go`
- `go test ./cmd/bb/...`
- `go test -run TestLogsNoActiveTaskGoesToStderr ./cmd/bb`

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: High.
- Strongest evidence: package tests pass and the new regression test nails the operator-facing copy contract.
- Remaining uncertainty: only whether reviewers want even stronger recovery guidance than `bb status <sprite>`.
- What could still go wrong after merge: if idle-state detection semantics change later, the new wording may need to be updated to match.

</details>
