### PR TITLE
fix: reconcile durable builder workspaces

### DIFF
--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -497,6 +497,14 @@ If builder cleanup fails, `worktree_path` remains populated so the surviving bui
 without reading the sprite filesystem first. Reviewer cleanup and reviewer workspace-preparation failures stay in the event
 ledger rather than the top-level run row.
 
+The builder workspace is the durable execution surface for one run. `run-once` prepares it before the first builder turn,
+`govern-pr` adopts that same workspace for repair and final-polish turns, and `reconcile-run` now performs the same cleanup
+path when a PR is already merged or closed outside the active governor loop. A terminal run should therefore end in one of
+two truthful states:
+
+- `worktree_path = null` plus `worktree_recovery_status = "cleaned"` when the durable workspace was released successfully
+- `worktree_path = <path>` plus `worktree_recovery_status = "cleanup_failed"` when operator recovery is still required
+
 Manual cleanup on the sprite:
 
 ```bash

--- a/docs/walkthroughs/issue-591-durable-workspace-reconcile.md
+++ b/docs/walkthroughs/issue-591-durable-workspace-reconcile.md
@@ -1,0 +1,33 @@
+# Issue 591 Walkthrough: Durable Workspace Reconcile Cleanup
+
+Issue [#591](https://github.com/misty-step/bitterblossom/issues/591) requires one work item to own one durable workspace until the run is either cleanly released or explicitly left for operator recovery.
+
+This branch closes the gap where `reconcile-run` could mark a run merged or closed without attempting the normal builder workspace cleanup path. That left a terminal run attached to a stale durable workspace even though the active governor path would have tried to release it.
+
+## Before
+
+- `run-once` created a builder workspace and persisted `worktree_path`
+- `govern-pr` reused that same workspace for repair and final polish
+- `reconcile-run` only updated run status fields when a PR was already merged or closed
+- a reconciled terminal run could therefore keep a stale `worktree_path` without any cleanup attempt
+
+## After
+
+- `reconcile-run` now loads the stored builder sprite and `worktree_path`
+- merged and closed PR reconciliation runs through the existing builder workspace cleanup helper
+- successful reconcile cleanup clears `worktree_path` and records `builder_workspace_cleaned`
+- failed reconcile cleanup preserves `worktree_path` and records the standard `cleanup_warning` recovery context
+
+## Verification
+
+```bash
+python3 -m pytest -q scripts/test_conductor.py -k 'reconcile_run or cleanup_builder_workspace or worktree_recovery'
+python3 -m pytest -q scripts/test_conductor.py
+ruff check scripts/conductor.py scripts/test_conductor.py
+```
+
+## Reviewer Notes
+
+- Persistent verification: the focused reconcile/worktree pytest slice above
+- Strongest evidence: the full `scripts/test_conductor.py` suite stays green with terminal reconcile cleanup enabled
+- Residual risk: runs missing `builder_sprite` can only record a cleanup warning because the conductor lacks the sprite identity needed to remove the worktree remotely

--- a/scripts/conductor.py
+++ b/scripts/conductor.py
@@ -4340,6 +4340,36 @@ def cleanup_builder_workspace(
     record_event(conn, event_log, run_id, "builder_workspace_cleaned", {"workspace": workspace})
 
 
+def reconcile_builder_workspace(
+    runner: Runner,
+    conn: sqlite3.Connection,
+    event_log: pathlib.Path,
+    *,
+    run_id: str,
+    repo: str,
+    builder_sprite: str | None,
+    workspace: str | None,
+) -> None:
+    builder = (builder_sprite or "").strip()
+    workspace_path = (workspace or "").strip()
+    if not workspace_path:
+        return
+    if not builder:
+        record_event(
+            conn,
+            event_log,
+            run_id,
+            "cleanup_warning",
+            {
+                "kind": BUILDER_WORKSPACE_CLEANUP_KIND,
+                "workspace": workspace_path,
+                "error": "builder workspace cleanup failed: missing builder sprite for reconcile cleanup",
+            },
+        )
+        return
+    cleanup_builder_workspace(runner, conn, event_log, run_id, repo, builder, workspace_path)
+
+
 def dispatch(
     runner: Runner,
     sprite: str,
@@ -6176,7 +6206,7 @@ def reconcile_run(args: argparse.Namespace) -> int:
     event_log = pathlib.Path(args.event_log)
     row = conn.execute(
         """
-        select run_id, repo, issue_number, phase, status, pr_number, pr_url
+        select run_id, repo, issue_number, phase, status, pr_number, pr_url, builder_sprite, worktree_path
         from runs
         where run_id = ?
         """,
@@ -6207,12 +6237,30 @@ def reconcile_run(args: argparse.Namespace) -> int:
     }
     if pr.get("mergedAt"):
         update_run(conn, args.run_id, phase="merged", status="merged", pr_url=pr["url"])
+        reconcile_builder_workspace(
+            runner,
+            conn,
+            event_log,
+            run_id=args.run_id,
+            repo=str(row["repo"]),
+            builder_sprite=str(row["builder_sprite"] or ""),
+            workspace=str(row["worktree_path"] or ""),
+        )
         record_event(conn, event_log, args.run_id, "reconciled_merged", payload)
     elif pr["state"] == "OPEN":
         update_run(conn, args.run_id, pr_url=pr["url"])
         record_event(conn, event_log, args.run_id, "reconciled_open", payload)
     else:
         update_run(conn, args.run_id, phase="closed", status="closed", pr_url=pr["url"])
+        reconcile_builder_workspace(
+            runner,
+            conn,
+            event_log,
+            run_id=args.run_id,
+            repo=str(row["repo"]),
+            builder_sprite=str(row["builder_sprite"] or ""),
+            workspace=str(row["worktree_path"] or ""),
+        )
         record_event(conn, event_log, args.run_id, "reconciled_closed", payload)
 
     print(json.dumps({"run_id": args.run_id, **payload}))

--- a/scripts/test_conductor.py
+++ b/scripts/test_conductor.py
@@ -4900,7 +4900,16 @@ def test_reconcile_run_marks_merged(monkeypatch: pytest.MonkeyPatch, tmp_path: p
     conn = conductor.open_db(tmp_path / "conductor.db")
     issue = conductor.Issue(number=450, title="test", body="body", url="https://example.com/450", labels=["autopilot"])
     conductor.create_run(conn, "run-450-1", "misty-step/bitterblossom", issue, "default")
-    conductor.update_run(conn, "run-450-1", phase="failed", status="failed", pr_number=452, pr_url="https://example.com/pr/452")
+    conductor.update_run(
+        conn,
+        "run-450-1",
+        phase="failed",
+        status="failed",
+        pr_number=452,
+        pr_url="https://example.com/pr/452",
+        builder_sprite="fern",
+        worktree_path="/tmp/run-450-1/builder-worktree",
+    )
 
     monkeypatch.setattr(
         conductor,
@@ -4912,6 +4921,7 @@ def test_reconcile_run_marks_merged(monkeypatch: pytest.MonkeyPatch, tmp_path: p
             "mergedAt": "2026-03-06T16:33:51Z",
         },
     )
+    monkeypatch.setattr(conductor, "cleanup_run_workspace", lambda *_args, **_kwargs: None)
 
     args = argparse.Namespace(
         db=str(tmp_path / "conductor.db"),
@@ -4925,11 +4935,78 @@ def test_reconcile_run_marks_merged(monkeypatch: pytest.MonkeyPatch, tmp_path: p
     out = capsys.readouterr().out
     assert '"run_id": "run-450-1"' in out
 
-    run = conn.execute("select phase, status, pr_url from runs where run_id = 'run-450-1'").fetchone()
+    run = conn.execute("select phase, status, pr_url, worktree_path from runs where run_id = 'run-450-1'").fetchone()
     assert run is not None
     assert run["phase"] == "merged"
     assert run["status"] == "merged"
     assert run["pr_url"] == "https://github.com/misty-step/bitterblossom/pull/452"
+    assert run["worktree_path"] is None
+    events = conn.execute(
+        "select event_type from events where run_id = 'run-450-1' order by id"
+    ).fetchall()
+    assert [row["event_type"] for row in events] == ["builder_workspace_cleaned", "reconciled_merged"]
+
+
+def test_reconcile_run_preserves_builder_workspace_when_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    conn = conductor.open_db(tmp_path / "conductor.db")
+    issue = conductor.Issue(number=451, title="test", body="body", url="https://example.com/451", labels=["autopilot"])
+    conductor.create_run(conn, "run-451-1", "misty-step/bitterblossom", issue, "default")
+    conductor.update_run(
+        conn,
+        "run-451-1",
+        phase="failed",
+        status="failed",
+        pr_number=453,
+        pr_url="https://example.com/pr/453",
+        builder_sprite="fern",
+        worktree_path="/tmp/run-451-1/builder-worktree",
+    )
+
+    monkeypatch.setattr(
+        conductor,
+        "gh_json",
+        lambda *_args, **_kwargs: {
+            "number": 453,
+            "url": "https://github.com/misty-step/bitterblossom/pull/453",
+            "state": "MERGED",
+            "mergedAt": "2026-03-06T16:33:51Z",
+        },
+    )
+    monkeypatch.setattr(
+        conductor,
+        "cleanup_run_workspace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(conductor.CmdError("stale worktree")),
+    )
+
+    args = argparse.Namespace(
+        db=str(tmp_path / "conductor.db"),
+        event_log=str(tmp_path / "events.jsonl"),
+        run_id="run-451-1",
+    )
+
+    rc = conductor.reconcile_run(args)
+
+    assert rc == 0
+    assert '"run_id": "run-451-1"' in capsys.readouterr().out
+
+    run = conn.execute("select phase, status, worktree_path from runs where run_id = 'run-451-1'").fetchone()
+    assert run is not None
+    assert run["phase"] == "merged"
+    assert run["status"] == "merged"
+    assert run["worktree_path"] == "/tmp/run-451-1/builder-worktree"
+
+    warning = conn.execute(
+        "select payload_json from events where run_id = 'run-451-1' and event_type = 'cleanup_warning'"
+    ).fetchone()
+    assert warning is not None
+    payload = json.loads(warning["payload_json"])
+    assert payload["kind"] == conductor.BUILDER_WORKSPACE_CLEANUP_KIND
+    assert payload["workspace"] == "/tmp/run-451-1/builder-worktree"
+    assert payload["error"] == "builder workspace cleanup failed: stale worktree"
 
 
 def test_show_events_prints_recent_events(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Walkthrough artifact](../blob/codex/issue-591-durable-workspaces/docs/walkthroughs/issue-591-durable-workspace-reconcile.md?raw=1)
- Walkthrough notes: terminal/doc walkthrough covering the terminal reconcile cleanup path, updated operator contract, focused reconcile/worktree tests, and the full conductor suite
- Fast claim: terminal `reconcile-run` now uses the same builder workspace cleanup contract as the active governor path, so merged/closed runs leave truthful durable-workspace state instead of silently keeping stale worktrees

## Why This Matters
- Problem: Bitterblossom already persisted a durable builder workspace per run, but `reconcile-run` only updated run status when a PR had already merged or closed. That left terminal runs able to keep stale `worktree_path` state without any cleanup attempt.
- Value: the same work item now keeps one durable builder workspace through builder and governance turns, and terminal reconciliation either releases it cleanly or records explicit recovery context.
- Why now: issue [#591](https://github.com/misty-step/bitterblossom/issues/591) is about making the durable-workspace contract truthful across issue work, repair/polish, and recovery paths.
- Issue: Closes #591.

## Trade-offs / Risks
- Value gained: terminal reconcile behavior now matches the active governor cleanup contract, and operators can trust `worktree_path` plus `worktree_recovery_*` after post-hoc reconciliation.
- Cost / risk incurred: `reconcile-run` now performs remote cleanup work and may emit cleanup warnings for malformed legacy runs that lack a stored builder sprite.
- Why this is still the right trade: the old behavior was cheaper but false, because it could report a merged or closed run while leaving stale durable workspace state behind with no recovery signal.
- Reviewer watch-outs: runs missing `builder_sprite` can only be marked with a cleanup warning; they cannot be auto-cleaned because the sprite identity is gone.

## Intent Reference
Issue [#591](https://github.com/misty-step/bitterblossom/issues/591) now defines the durable-workspace contract this way: one run owns one durable builder workspace until the run is cleanly reconciled or explicitly left for operator recovery; `run-once` prepares it, `govern-pr` reuses it, and `reconcile-run` must apply the same cleanup semantics when the PR is already terminal.

## Changes
- Added `reconcile_builder_workspace(...)` in `scripts/conductor.py` to route terminal reconcile cleanup through the existing builder cleanup helper.
- Taught `reconcile-run` to load `builder_sprite` and `worktree_path` so merged/closed reconciliation can clean the durable workspace.
- Preserved truthful failure behavior: reconcile cleanup keeps `worktree_path` and records the standard builder `cleanup_warning` when cleanup fails or the builder sprite is missing.
- Added focused conductor regressions for successful and failed reconcile cleanup.
- Updated `docs/CONDUCTOR.md` with the run-owned durable workspace contract and terminal reconcile semantics.
- Added a walkthrough artifact at `docs/walkthroughs/issue-591-durable-workspace-reconcile.md`.

## Alternatives Considered
### Option A — Do nothing
- Upside: no additional remote cleanup on reconcile.
- Downside: merged/closed runs can keep stale durable workspace state with no cleanup attempt.
- Why rejected: it leaves the core workspace contract false in a recovery path operators already use.

### Option B — Add a second reconcile-specific cleanup path
- Upside: keeps the active governor path untouched.
- Downside: two cleanup contracts would drift and reintroduce ambiguity.
- Why rejected: issue #591 is specifically about one workspace contract, not two parallel ones.

### Option C — Current approach
- Upside: one existing cleanup helper owns both active governance and post-hoc reconcile cleanup semantics.
- Downside: reconcile now depends on persisted builder metadata being present.
- Why chosen: it is the smallest reversible change that makes terminal workspace state truthful.

## Acceptance Criteria
- [x] Given `reconcile-run` observes a merged or closed PR, when a builder workspace exists, then Bitterblossom runs the normal builder workspace cleanup path and clears `worktree_path` only on success.
- [x] Given reconcile cleanup fails, when the run is inspected, then `worktree_path` survives and the cleanup failure is visible through the normal recovery fields.
- [x] Given the branch implementation, when `python3 -m pytest -q scripts/test_conductor.py -k 'reconcile_run or cleanup_builder_workspace or worktree_recovery'` runs, then the focused workspace lifecycle slice passes.
- [x] Given the full conductor regression gate, when `python3 -m pytest -q scripts/test_conductor.py` runs, then it passes.

## Manual QA
```bash
python3 -m pytest -q scripts/test_conductor.py -k 'reconcile_run or cleanup_builder_workspace or worktree_recovery'
python3 -m pytest -q scripts/test_conductor.py
ruff check scripts/conductor.py scripts/test_conductor.py
```

Expected outcome:
- reconcile cleanup clears `worktree_path` only when remote cleanup succeeds
- failed reconcile cleanup preserves `worktree_path` and records the standard builder cleanup warning
- the full conductor suite remains green

## What Changed
### Base Branch
```mermaid
graph TD
  A["run-once prepares builder workspace"] --> B["govern-pr reuses builder workspace"]
  B --> C["PR already merged or closed elsewhere"]
  C --> D["reconcile-run updates phase/status only"]
  D --> E["stale worktree_path may survive with no cleanup attempt"]
```

### This PR
```mermaid
graph TD
  A["run-once prepares builder workspace"] --> B["govern-pr reuses builder workspace"]
  B --> C["PR already merged or closed elsewhere"]
  C --> D["reconcile-run loads builder_sprite + worktree_path"]
  D --> E["reuse cleanup_builder_workspace contract"]
  E --> F["success: worktree_path cleared + builder_workspace_cleaned"]
  E --> G["failure: worktree_path preserved + cleanup_warning"]
```

### Architecture / State Change
```mermaid
graph TD
  A["runs row"] --> B["builder_sprite"]
  A --> C["worktree_path"]
  B --> D["reconcile_builder_workspace"]
  C --> D
  D --> E["cleanup_builder_workspace"]
  E --> F["builder_workspace_cleaned event"]
  E --> G["cleanup_warning event"]
  F --> H["truthful terminal run state"]
  G --> H
```

Why this is better:
- one helper now owns builder workspace cleanup semantics in both active governance and recovery cleanup paths
- merged/closed runs no longer silently keep stale durable workspace state
- operator recovery remains truthful because cleanup failures still preserve the surviving path

## Walkthrough
- Renderer: markdown walkthrough
- Artifact: [docs/walkthroughs/issue-591-durable-workspace-reconcile.md](../blob/codex/issue-591-durable-workspaces/docs/walkthroughs/issue-591-durable-workspace-reconcile.md?raw=1)
- Claim: terminal reconcile now enforces the durable builder workspace contract instead of only changing run status fields
- Before / After scope: status-only reconcile before; cleanup-aware reconcile after
- Persistent verification: `python3 -m pytest -q scripts/test_conductor.py -k 'reconcile_run or cleanup_builder_workspace or worktree_recovery'`
- Residual gap: legacy runs without stored `builder_sprite` can only surface cleanup recovery, not auto-clean successfully

## Before / After
Before: `reconcile-run` could mark a run merged or closed while leaving the durable builder workspace untouched and `worktree_path` populated with no cleanup signal.

After: `reconcile-run` reuses the builder cleanup helper. Clean releases clear `worktree_path`; cleanup failures keep the path and emit the same recovery warning operators already use elsewhere.

Screenshots are not needed because the change is internal and the walkthrough artifact is text-first.

## Test Coverage
- `python3 -m pytest -q scripts/test_conductor.py -k 'reconcile_run or cleanup_builder_workspace or worktree_recovery'`
- `python3 -m pytest -q scripts/test_conductor.py`
- `ruff check scripts/conductor.py scripts/test_conductor.py`

Coverage details:
- added reconcile success coverage proving `builder_workspace_cleaned` and `worktree_path = null`
- added reconcile failure coverage proving the surviving workspace path and `cleanup_warning` recovery payload remain visible
- existing worktree recovery tests continue to protect the read-model contract

Gap:
- no live sprite cleanup command was exercised against a remote worker in this branch; coverage is through the conductor regression harness

## Merge Confidence
- Confidence level: high
- Strongest evidence: focused reconcile/worktree coverage plus the full `scripts/test_conductor.py` suite (`297 passed`)
- Remaining uncertainty: legacy runs missing `builder_sprite` cannot be auto-cleaned and will rely on operator recovery
- What could still go wrong after merge: a malformed historic run row could generate a cleanup warning more often than expected, but that is preferable to silently reporting a clean release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded builder worktree lifecycle documentation, including terminal states and recovery procedures.
  * Added detailed walkthrough for durable workspace reconciliation cleanup improvements.

* **New Features**
  * Added automatic builder workspace cleanup during run reconciliation with failure recovery handling.

* **Tests**
  * Added test coverage for workspace cleanup behavior and recovery scenarios during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->