### PR TITLE
refactor: centralize bb workspace contract

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
 	"time"
 
@@ -73,14 +72,7 @@ func dispatchWorkspace(repo, override string) string {
 	if override != "" {
 		return override
 	}
-	return "/home/sprite/workspace/" + path.Base(repo)
-}
-
-func cleanSignalsScriptFor(workspace string) string {
-	return fmt.Sprintf(
-		`export WORKSPACE=%q; rm -f "$WORKSPACE"/TASK_COMPLETE "$WORKSPACE"/TASK_COMPLETE.md "$WORKSPACE"/BLOCKED.md`,
-		workspace,
-	)
+	return spriteRepoWorkspace(repo)
 }
 
 func verifyWorkScriptFor(workspace, ghToken string) string {
@@ -117,7 +109,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 	}
 
 	// 2. Check that setup was run (ralph.sh must exist)
-	ralphScript := "/home/sprite/workspace/.ralph.sh"
+	ralphScript := spriteRalphScriptPath
 	checkCtx, checkCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer checkCancel()
 	if _, err := s.CommandContext(checkCtx, "test", "-f", ralphScript).Output(); err != nil {
@@ -185,7 +177,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 		return fmt.Errorf("render prompt: %w", err)
 	}
 
-	promptPath := workspace + "/.dispatch-prompt.md"
+	promptPath := workspaceDispatchPromptPath(workspace)
 	if err := s.Filesystem().WriteFileContext(ctx, promptPath, []byte(rendered), 0644); err != nil {
 		return fmt.Errorf("upload prompt: %w", err)
 	}
@@ -366,11 +358,6 @@ if [ "$status" -eq 1 ]; then
 fi
 echo "$busy" >&2
 exit "$status"`
-
-const taskCompleteSignalCheckScript = `if [ -f "$WORKSPACE/TASK_COMPLETE" ] || [ -f "$WORKSPACE/TASK_COMPLETE.md" ]; then
-  exit 0
-fi
-exit 1`
 
 // newCommitsCheckScript checks if any commits on HEAD are not yet on origin/master or
 // origin/main. Exits 0 with commit list on stdout when new commits exist, exits 1 when
@@ -559,7 +546,7 @@ func hasTaskCompleteSignalWithRunner(ctx context.Context, run spriteScriptRunner
 	checkCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	checkScript := fmt.Sprintf("export WORKSPACE=%q\n%s", workspace, taskCompleteSignalCheckScript)
+	checkScript := taskCompleteSignalCheckScriptFor(workspace)
 	out, exitCode, err := run(checkCtx, checkScript)
 	if err != nil {
 		return false, fmt.Errorf("check completion signal command failed: %w", err)
@@ -666,7 +653,7 @@ func waitForTaskCompleteWithRunner(ctx context.Context, run spriteScriptRunner, 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	taskCheckScript := fmt.Sprintf("WORKSPACE=%q\n%s", workspace, taskCompleteSignalCheckScript)
+	taskCheckScript := taskCompleteSignalCheckScriptFor(workspace)
 
 	for {
 		checkCtx, checkCancel := context.WithTimeout(pollCtx, 30*time.Second)

--- a/cmd/bb/logs.go
+++ b/cmd/bb/logs.go
@@ -67,7 +67,7 @@ func runLogs(ctx context.Context, stdout, stderr io.Writer, spriteName string, f
 		return fmt.Errorf("sprite %q has no workspace repo (run: bb setup %s --repo owner/repo)", spriteName, spriteName)
 	}
 
-	logPath := workspace + "/ralph.log"
+	logPath := workspaceRalphLogPath(workspace)
 
 	active := spriteHasRunningAgent(ctx, s)
 	hasLog := spriteFileHasContent(ctx, s, logPath)

--- a/cmd/bb/setup.go
+++ b/cmd/bb/setup.go
@@ -68,12 +68,12 @@ func runSetup(ctx context.Context, spriteName, repo string, force bool, persona 
 
 	// 2. Create remote directories
 	dirs := []string{
-		"/home/sprite/.claude",
-		"/home/sprite/.claude/hooks",
-		"/home/sprite/.claude/skills",
-		"/home/sprite/.claude/commands",
-		"/home/sprite/.claude/prompts",
-		"/home/sprite/workspace",
+		spriteClaudeDir,
+		spriteClaudeDir + "/hooks",
+		spriteClaudeDir + "/skills",
+		spriteClaudeDir + "/commands",
+		spriteClaudeDir + "/prompts",
+		spriteWorkspaceRoot,
 	}
 	mkdirScript := "mkdir -p " + strings.Join(dirs, " ")
 	if _, err := s.CommandContext(ctx, "bash", "-c", mkdirScript).Output(); err != nil {
@@ -104,20 +104,20 @@ func runSetup(ctx context.Context, spriteName, repo string, force bool, persona 
 		return err
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "uploading persona from %s...\n", personaFile)
-	if err := uploadFile(ctx, s, personaFile, "/home/sprite/workspace/PERSONA.md"); err != nil {
+	if err := uploadFile(ctx, s, personaFile, spritePersonaPath); err != nil {
 		return fmt.Errorf("upload persona: %w", err)
 	}
 
 	// 5. Upload ralph script + prompt template
-	if err := uploadFile(ctx, s, "scripts/ralph.sh", "/home/sprite/workspace/.ralph.sh"); err != nil {
+	if err := uploadFile(ctx, s, "scripts/ralph.sh", spriteRalphScriptPath); err != nil {
 		return fmt.Errorf("upload ralph.sh: %w", err)
 	}
 	// Make executable
-	if _, err := s.CommandContext(ctx, "chmod", "+x", "/home/sprite/workspace/.ralph.sh").Output(); err != nil {
+	if _, err := s.CommandContext(ctx, "chmod", "+x", spriteRalphScriptPath).Output(); err != nil {
 		return fmt.Errorf("chmod ralph.sh: %w", err)
 	}
 
-	if err := uploadFile(ctx, s, "scripts/ralph-prompt-template.md", "/home/sprite/workspace/.ralph-prompt-template.md"); err != nil {
+	if err := uploadFile(ctx, s, "scripts/ralph-prompt-template.md", spriteRalphPromptTemplatePath); err != nil {
 		return fmt.Errorf("upload prompt template: %w", err)
 	}
 
@@ -142,19 +142,18 @@ git config --global --add safe.directory '*'
 			return fmt.Errorf("GITHUB_TOKEN must be set to clone repo")
 		}
 
-		repoName := filepath.Base(repo)
-		repoDir := "/home/sprite/workspace/" + repoName
+		repoDir := spriteRepoWorkspace(repo)
 
 		var cloneScript string
 		if force {
 			cloneScript = fmt.Sprintf(
-				`rm -rf %s && cd /home/sprite/workspace && git clone https://github.com/%s.git`,
-				repoDir, repo,
+				`rm -rf %s && cd %s && git clone https://github.com/%s.git`,
+				repoDir, spriteWorkspaceRoot, repo,
 			)
 		} else {
 			cloneScript = fmt.Sprintf(
-				`if [ -d %s ]; then cd %s && git checkout master 2>/dev/null || git checkout main 2>/dev/null && git pull --ff-only; else cd /home/sprite/workspace && git clone https://github.com/%s.git; fi`,
-				repoDir, repoDir, repo,
+				`if [ -d %s ]; then cd %s && git checkout master 2>/dev/null || git checkout main 2>/dev/null && git pull --ff-only; else cd %s && git clone https://github.com/%s.git; fi`,
+				repoDir, repoDir, spriteWorkspaceRoot, repo,
 			)
 		}
 
@@ -186,7 +185,7 @@ git config --global --add safe.directory '*'
 
 func buildBaseConfigMap(root string) (map[string]string, error) {
 	configMap := map[string]string{
-		filepath.Join(root, "base/CLAUDE.md"): "/home/sprite/.claude/CLAUDE.md",
+		filepath.Join(root, "base/CLAUDE.md"): spriteClaudeDir + "/CLAUDE.md",
 	}
 
 	hookFiles, err := filepath.Glob(filepath.Join(root, "base/hooks/*.py"))
@@ -194,7 +193,7 @@ func buildBaseConfigMap(root string) (map[string]string, error) {
 		return nil, err
 	}
 	for _, f := range hookFiles {
-		configMap[f] = "/home/sprite/.claude/hooks/" + filepath.Base(f)
+		configMap[f] = spriteClaudeDir + "/hooks/" + filepath.Base(f)
 	}
 
 	commandFiles, err := filepath.Glob(filepath.Join(root, "base/commands/*.md"))
@@ -202,7 +201,7 @@ func buildBaseConfigMap(root string) (map[string]string, error) {
 		return nil, err
 	}
 	for _, f := range commandFiles {
-		configMap[f] = "/home/sprite/.claude/commands/" + filepath.Base(f)
+		configMap[f] = spriteClaudeDir + "/commands/" + filepath.Base(f)
 	}
 
 	promptFiles, err := filepath.Glob(filepath.Join(root, "base/prompts/*.md"))
@@ -210,7 +209,7 @@ func buildBaseConfigMap(root string) (map[string]string, error) {
 		return nil, err
 	}
 	for _, f := range promptFiles {
-		configMap[f] = "/home/sprite/.claude/prompts/" + filepath.Base(f)
+		configMap[f] = spriteClaudeDir + "/prompts/" + filepath.Base(f)
 	}
 
 	skillsRoot := filepath.Join(root, "base/skills")
@@ -225,7 +224,7 @@ func buildBaseConfigMap(root string) (map[string]string, error) {
 		if err != nil {
 			return err
 		}
-		configMap[p] = "/home/sprite/.claude/skills/" + rel
+		configMap[p] = spriteClaudeDir + "/skills/" + rel
 		return nil
 	}); err != nil {
 		return nil, err
@@ -297,5 +296,5 @@ func uploadPatchedSettings(ctx context.Context, s *sprites.Sprite, openrouterKey
 
 	patched := strings.ReplaceAll(string(data), "__SET_VIA_OPENROUTER_API_KEY_ENV__", openrouterKey)
 
-	return s.Filesystem().WriteFileContext(ctx, "/home/sprite/.claude/settings.json", []byte(patched), 0644)
+	return s.Filesystem().WriteFileContext(ctx, spriteClaudeDir+"/settings.json", []byte(patched), 0644)
 }

--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -146,9 +146,7 @@ func spriteStatus(ctx context.Context, spriteName string) error {
 	// are present, they are listed below the count line (like git status --short).
 	statusScript := `
 echo "=== signals ==="
-for f in TASK_COMPLETE TASK_COMPLETE.md BLOCKED.md; do
-  [ -f "$WS/$f" ] && echo "$f: present" || echo "$f: absent"
-done
+` + workspaceStatusSignalsScript("WS") + `
 
 echo ""
 echo "=== git ==="

--- a/cmd/bb/workspace_contract.go
+++ b/cmd/bb/workspace_contract.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+const (
+	spriteHomeDir       = "/home/sprite"
+	spriteClaudeDir     = spriteHomeDir + "/.claude"
+	spriteWorkspaceRoot = spriteHomeDir + "/workspace"
+
+	spritePersonaPath             = spriteWorkspaceRoot + "/PERSONA.md"
+	spriteRalphScriptPath         = spriteWorkspaceRoot + "/.ralph.sh"
+	spriteRalphPromptTemplatePath = spriteWorkspaceRoot + "/.ralph-prompt-template.md"
+
+	workspaceMetadataRelPath   = ".bb/workspace.json"
+	dispatchPromptFileName     = ".dispatch-prompt.md"
+	ralphLogFileName           = "ralph.log"
+	taskCompleteFileName       = "TASK_COMPLETE"
+	legacyTaskCompleteFileName = "TASK_COMPLETE.md"
+	blockedFileName            = "BLOCKED.md"
+)
+
+var (
+	taskCompleteSignalFileNames = []string{
+		taskCompleteFileName,
+		legacyTaskCompleteFileName,
+	}
+	workspaceStatusSignalFileNames = []string{
+		taskCompleteFileName,
+		legacyTaskCompleteFileName,
+		blockedFileName,
+	}
+)
+
+func spriteRepoWorkspace(repo string) string {
+	return path.Join(spriteWorkspaceRoot, path.Base(repo))
+}
+
+func workspaceFilePath(workspace, name string) string {
+	return path.Join(workspace, name)
+}
+
+func workspaceDispatchPromptPath(workspace string) string {
+	return workspaceFilePath(workspace, dispatchPromptFileName)
+}
+
+func workspaceRalphLogPath(workspace string) string {
+	return workspaceFilePath(workspace, ralphLogFileName)
+}
+
+func cleanSignalsScriptFor(workspace string) string {
+	targets := make([]string, 0, len(workspaceStatusSignalFileNames))
+	for _, name := range workspaceStatusSignalFileNames {
+		targets = append(targets, fmt.Sprintf(`"$WORKSPACE"/%s`, name))
+	}
+
+	return fmt.Sprintf(`export WORKSPACE=%q; rm -f %s`, workspace, strings.Join(targets, " "))
+}
+
+func taskCompleteSignalCheckScriptFor(workspace string) string {
+	checks := make([]string, 0, len(taskCompleteSignalFileNames))
+	for _, name := range taskCompleteSignalFileNames {
+		checks = append(checks, fmt.Sprintf(`[ -f "$WORKSPACE/%s" ]`, name))
+	}
+
+	return fmt.Sprintf("export WORKSPACE=%q\nif %s; then\n  exit 0\nfi\nexit 1", workspace, strings.Join(checks, " || "))
+}
+
+func workspaceStatusSignalsScript(envName string) string {
+	quotedNames := make([]string, 0, len(workspaceStatusSignalFileNames))
+	for _, name := range workspaceStatusSignalFileNames {
+		quotedNames = append(quotedNames, fmt.Sprintf("%q", name))
+	}
+
+	return fmt.Sprintf("for f in %s; do\n  [ -f \"$%s/$f\" ] && echo \"$f: present\" || echo \"$f: absent\"\ndone", strings.Join(quotedNames, " "), envName)
+}

--- a/cmd/bb/workspace_metadata.go
+++ b/cmd/bb/workspace_metadata.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-const workspaceMetadataRelPath = ".bb/workspace.json"
-
 type workspaceMetadata struct {
 	SchemaVersion int    `json:"schema_version"`
 	Repo          string `json:"repo"`
@@ -42,28 +40,37 @@ func marshalWorkspaceMetadata(meta workspaceMetadata) ([]byte, error) {
 }
 
 func workspaceDiscoveryScript() string {
-	return `
+	return fmt.Sprintf(`
 set -euo pipefail
 
-meta=$(ls -dt /home/sprite/workspace/*/.bb/workspace.json 2>/dev/null | head -1 || true)
+meta=$(ls -dt %s/*/%s 2>/dev/null | head -1 || true)
 if [[ -n "$meta" ]]; then
-  printf '%s\n' "${meta%/.bb/workspace.json}"
+  printf '%%s\n' "${meta%%/%s}"
   exit 0
 fi
 
-prompt=$(ls -dt /home/sprite/workspace/*/.dispatch-prompt.md 2>/dev/null | head -1 || true)
+prompt=$(ls -dt %s/*/%s 2>/dev/null | head -1 || true)
 if [[ -n "$prompt" ]]; then
-  printf '%s\n' "${prompt%/*}"
+  printf '%%s\n' "${prompt%%/*}"
   exit 0
 fi
 
-log=$(ls -dt /home/sprite/workspace/*/ralph.log 2>/dev/null | head -1 || true)
+log=$(ls -dt %s/*/%s 2>/dev/null | head -1 || true)
 if [[ -n "$log" ]]; then
-  printf '%s\n' "${log%/*}"
+  printf '%%s\n' "${log%%/*}"
   exit 0
 fi
 
-ws=$(ls -d /home/sprite/workspace/*/ 2>/dev/null | head -1 || true)
-printf '%s\n' "${ws%/}"
-`
+ws=$(ls -d %s/*/ 2>/dev/null | head -1 || true)
+printf '%%s\n' "${ws%%/}"
+`,
+		spriteWorkspaceRoot,
+		workspaceMetadataRelPath,
+		workspaceMetadataRelPath,
+		spriteWorkspaceRoot,
+		dispatchPromptFileName,
+		spriteWorkspaceRoot,
+		ralphLogFileName,
+		spriteWorkspaceRoot,
+	)
 }

--- a/docs/COMPLETION-PROTOCOL.md
+++ b/docs/COMPLETION-PROTOCOL.md
@@ -45,10 +45,11 @@ Exit code 4 indicates an off-rails abort where neither signal files nor new comm
 
 ## Where Signal Knowledge Lives
 
-Signal filenames are checked as string literals in two places:
+The Go transport now keeps the workspace/signal contract in one place and reuses it across commands:
 
 | System | What it checks | File |
 |--------|---------------|------|
+| Workspace contract | Canonical sprite paths, signal filenames, prompt/log filenames, cleanup/check shell snippets | `cmd/bb/workspace_contract.go` |
 | Ralph loop | Completion + blocked between iterations | `scripts/ralph.sh` |
-| Dispatch cleanup | Removes stale signals before ralph start | `cmd/bb/dispatch.go` |
+| Dispatch cleanup | Removes stale signals before ralph start via the shared contract helpers | `cmd/bb/dispatch.go` |
 | Status check | Reports signal file presence | `cmd/bb/status.go` |

--- a/docs/walkthroughs/codex-simplify-bb-workspace-contract-terminal.txt
+++ b/docs/walkthroughs/codex-simplify-bb-workspace-contract-terminal.txt
@@ -1,0 +1,27 @@
+$ go test ./cmd/bb
+ok  	github.com/misty-step/bitterblossom/cmd/bb	(cached)
+
+$ git diff --stat -- cmd/bb/dispatch.go cmd/bb/logs.go cmd/bb/setup.go cmd/bb/status.go cmd/bb/workspace_metadata.go docs/COMPLETION-PROTOCOL.md
+ cmd/bb/dispatch.go           | 23 +++++------------------
+ cmd/bb/logs.go               |  2 +-
+ cmd/bb/setup.go              | 43 +++++++++++++++++++++----------------------
+ cmd/bb/status.go             |  4 +---
+ cmd/bb/workspace_metadata.go | 31 +++++++++++++++++++------------
+ docs/COMPLETION-PROTOCOL.md  |  5 +++--
+ 6 files changed, 50 insertions(+), 58 deletions(-)
+
+$ rg -n "spriteRepoWorkspace|workspaceDispatchPromptPath|workspaceRalphLogPath|taskCompleteSignalCheckScriptFor|workspaceStatusSignalsScript|cleanSignalsScriptFor" cmd/bb
+cmd/bb/workspace_contract.go:38:func spriteRepoWorkspace(repo string) string {
+cmd/bb/workspace_contract.go:46:func workspaceDispatchPromptPath(workspace string) string {
+cmd/bb/workspace_contract.go:50:func workspaceRalphLogPath(workspace string) string {
+cmd/bb/workspace_contract.go:54:func cleanSignalsScriptFor(workspace string) string {
+cmd/bb/workspace_contract.go:63:func taskCompleteSignalCheckScriptFor(workspace string) string {
+cmd/bb/workspace_contract.go:72:func workspaceStatusSignalsScript(envName string) string {
+cmd/bb/setup.go:145:		repoDir := spriteRepoWorkspace(repo)
+cmd/bb/dispatch.go:75:	return spriteRepoWorkspace(repo)
+cmd/bb/dispatch.go:164:	cleanScript := cleanSignalsScriptFor(workspace)
+cmd/bb/dispatch.go:180:	promptPath := workspaceDispatchPromptPath(workspace)
+cmd/bb/dispatch.go:549:	checkScript := taskCompleteSignalCheckScriptFor(workspace)
+cmd/bb/dispatch.go:656:	taskCheckScript := taskCompleteSignalCheckScriptFor(workspace)
+cmd/bb/logs.go:70:	logPath := workspaceRalphLogPath(workspace)
+cmd/bb/status.go:149:` + workspaceStatusSignalsScript("WS") + `

--- a/docs/walkthroughs/codex-simplify-bb-workspace-contract.md
+++ b/docs/walkthroughs/codex-simplify-bb-workspace-contract.md
@@ -1,0 +1,62 @@
+# Walkthrough: Simplify bb Workspace Contract
+
+## Title
+
+Centralize the sprite workspace and completion-signal contract behind one Go module.
+
+## Why Now
+
+Before this branch, the thin `bb` transport still leaked one low-level protocol across several commands: workspace root paths, prompt/log filenames, and completion signal names were re-encoded in `setup`, `dispatch`, `status`, `logs`, and workspace discovery. That made a small contract change require touching multiple files that should not need to know those details.
+
+## Before
+
+- `dispatch.go` owned signal cleanup plus task-complete checks.
+- `status.go` hard-coded the signal list for operator output.
+- `logs.go` rebuilt the Ralph log path at the call site.
+- `workspace_metadata.go` hard-coded prompt/log discovery names and the workspace root.
+- `setup.go` repeated the same sprite path layout while provisioning the workspace.
+
+The behavior was correct, but the module boundary was shallow: callers needed protocol details instead of asking one module for them.
+
+## What Changed
+
+- Added [`cmd/bb/workspace_contract.go`](../../cmd/bb/workspace_contract.go) as the Go-side source of truth for:
+  - sprite workspace roots
+  - Ralph/persona/prompt paths
+  - completion/blocking signal filenames
+  - shared shell snippets for cleanup, status display, and completion checks
+- Updated `setup`, `dispatch`, `status`, `logs`, and workspace discovery to consume those helpers instead of carrying their own copies.
+- Updated [`docs/COMPLETION-PROTOCOL.md`](../COMPLETION-PROTOCOL.md) so the protocol docs point at the new source of truth.
+
+## After
+
+Observable improvements:
+
+- one file now owns the Go transport's workspace contract
+- command code talks in terms of intent (`cleanSignalsScriptFor`, `workspaceRalphLogPath`) instead of raw filenames
+- the refactor deleted more lines than it added in the touched command files while preserving behavior
+- the completion protocol doc now matches the code structure reviewers will actually maintain
+
+## Verification
+
+Primary walkthrough artifact:
+
+- [`codex-simplify-bb-workspace-contract-terminal.txt`](./codex-simplify-bb-workspace-contract-terminal.txt)
+
+Persistent protecting check:
+
+- `go test ./cmd/bb`
+
+Supporting evidence captured in the transcript:
+
+- diff stat for the touched transport/docs files
+- `rg` output showing the new helper module and its call sites
+
+## Residual Risk
+
+- `scripts/ralph.sh` still has to know the shell-side signal filenames, so the contract is centralized for Go callers, not fully generated across languages.
+- Process-pattern constants in `dispatch.go` and `kill.go` still encode the Ralph loop path separately; that is adjacent cleanup, not part of this PR.
+
+## Merge Case
+
+This branch keeps the transport behavior and tests intact while making the `bb` workspace contract deeper and easier to change safely. The win is not a new feature. The win is that operators and maintainers now have one Go module to update when the sprite workspace protocol changes.


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Walkthrough notes](../blob/codex/simplify-bb-workspace-contract/docs/walkthroughs/codex-simplify-bb-workspace-contract.md?raw=true)
- Terminal artifact: [codex-simplify-bb-workspace-contract-terminal.txt](../blob/codex/simplify-bb-workspace-contract/docs/walkthroughs/codex-simplify-bb-workspace-contract-terminal.txt?raw=true)
- Fast claim: `bb` now has one Go-side source of truth for sprite workspace paths, prompt/log filenames, and completion signal handling, so transport commands stop re-encoding the same protocol details.

## Why This Matters
- Problem: the thin transport still leaked one low-level contract across multiple commands, so a small workspace or signal change required touching `setup`, `dispatch`, `status`, `logs`, and workspace discovery separately.
- Value: the transport gets a deeper module boundary without changing behavior; callers now ask for intent-level helpers instead of hard-coding filenames and shell snippets.
- Why now: this is the highest-leverage simplification that fits in one low-risk PR after reviewing the repo-wide `bb` surface, ADR-002, and recent history.
- Issue: none; this came from a repo-wide `/simplify` pass.

## Trade-offs / Risks
- Value gained: lower protocol leakage, fewer duplicated literals, and one file to update when the sprite workspace contract changes on the Go side.
- Cost / risk incurred: one new helper module and two walkthrough artifacts were added, and `scripts/ralph.sh` still carries the shell-side copy of the signal contract.
- Why this is still the right trade: it removes repeated maintenance burden from the core transport without changing the cross-language runtime contract in a risky way.
- Reviewer watch-outs: pressure-test the new helper names and confirm the remaining shell-side constants are intentionally out of scope for this PR.

## What Changed
This PR centralizes the Go transport's sprite workspace contract in one module, then rewires the existing command surfaces to use that module instead of carrying their own copies of workspace roots, prompt/log filenames, and completion-signal checks.

### Base Branch
```mermaid
graph TD
    A["setup.go"] --> P["hard-coded workspace paths"]
    B["dispatch.go"] --> P
    B --> S["signal cleanup + task-complete shell"]
    C["status.go"] --> T["inline signal list"]
    D["logs.go"] --> L["inline ralph.log path"]
    E["workspace_metadata.go"] --> W["inline prompt/log discovery names"]
```

### This PR
```mermaid
graph TD
    F["workspace_contract.go"] --> G["sprite paths"]
    F --> H["signal filenames"]
    F --> I["shared shell helpers"]
    A["setup.go"] --> F
    B["dispatch.go"] --> F
    C["status.go"] --> F
    D["logs.go"] --> F
    E["workspace_metadata.go"] --> F
```

### Architecture / State Change
```mermaid
graph TD
    Contract["workspace_contract.go"] --> Paths["spriteRepoWorkspace / prompt / log paths"]
    Contract --> Signals["TASK_COMPLETE / TASK_COMPLETE.md / BLOCKED.md"]
    Contract --> Shell["cleanup, status, completion-check snippets"]
    Commands["setup + dispatch + status + logs + workspace discovery"] --> Contract
```

Why this is better:
- command files stop owning raw protocol details they should not need to know
- the Go-side completion/workspace contract becomes easier to audit and safer to change
- the touched command files shrink overall even after adding the deeper module

<details>
<summary>Intent Reference</summary>

## Intent Reference
- User intent: run a repo-wide `/simplify` pass and ship the single best one-PR simplification.
- Architectural constraint: ADR-002 says `bb` should stay thin, deterministic, and small; logic that remains in Go should improve the transport boundary rather than grow new workflow behavior.
- This PR follows that constraint by simplifying an existing transport seam instead of adding new surface area.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero churn.
- Downside: the workspace/signal protocol remains spread across multiple commands and docs.
- Why rejected: it leaves a known maintenance seam shallow inside the core transport.

### Option B — Split `dispatch.go` into multiple new execution modules
- Upside: bigger visual cleanup in the largest file.
- Downside: more files and abstractions, higher behavior risk, and less confidence that complexity actually disappears.
- Why rejected: it is a larger refactor with weaker proof that the public transport contract stays untouched.

### Option C — Current approach
- Upside: deletes duplication at the protocol seam, keeps behavior stable, and fits in one reviewable PR.
- Downside: the shell-side copy in `scripts/ralph.sh` still exists.
- Why chosen: best ratio of complexity removed to delivery risk.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `cmd/bb/workspace_contract.go` for sprite workspace roots, prompt/log paths, signal names, and shared shell helpers.
- Updated `cmd/bb/setup.go`, `cmd/bb/dispatch.go`, `cmd/bb/status.go`, `cmd/bb/logs.go`, and `cmd/bb/workspace_metadata.go` to consume the shared contract.
- Updated `docs/COMPLETION-PROTOCOL.md` so the doc points at the new Go-side source of truth.
- Added a walkthrough note plus terminal artifact under `docs/walkthroughs/`.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] One Go module owns the sprite workspace path and completion-signal contract.
- [x] `setup`, `dispatch`, `status`, `logs`, and workspace discovery reuse that module.
- [x] Completion protocol docs point reviewers to the new source of truth.
- [x] Focused `bb` tests still pass.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
go test ./cmd/bb
```

Expected result: the `cmd/bb` suite passes.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal walkthrough
- Artifact: [codex-simplify-bb-workspace-contract-terminal.txt](../blob/codex/simplify-bb-workspace-contract/docs/walkthroughs/codex-simplify-bb-workspace-contract-terminal.txt?raw=true)
- Claim: the Go transport now routes workspace/signal behavior through one shared module and still passes the focused `bb` regression suite.
- Before / After scope: base branch repeated the contract across multiple commands; this branch centralizes it in `workspace_contract.go`.
- Persistent verification: `go test ./cmd/bb`
- Residual gap: `scripts/ralph.sh` still keeps the shell-side signal copy; this PR only centralizes the Go side.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: command files carried their own copies of sprite workspace paths, prompt/log filenames, and signal shell snippets.
- After: command files import those details from `workspace_contract.go` and operate at the intent level.
- Screenshots are not included because this is an internal transport refactor with no user-visible UI change.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `go test ./cmd/bb`
- Existing targeted tests in `cmd/bb/dispatch_test.go` and `cmd/bb/workspace_metadata_test.go` continue to cover the shared shell/path contract indirectly.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high.
- Strongest evidence: the refactor is narrow, the helper module is reused by all affected command paths, and `go test ./cmd/bb` passes.
- Remaining uncertainty: only the shell-side duplication in `scripts/ralph.sh` remains outside the new boundary.
- What could still go wrong after merge: a future shell-side contract change could still drift if it is made only in `scripts/ralph.sh` and not mirrored in Go.

</details>
