### PR TITLE
refactor: centralize default-branch detection in dispatch

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,37 +1,29 @@
-# PLAN: Issue #538 — Harden conductor worktree lifecycle
+# Plan: Centralize default-branch detection (#432)
 
-## Status
+## Problem
 
-The core hardening is already in master (PR #545):
-- Bash-level `flock` per-repo mirror lock serializing fetch, worktree add/remove, and prune
-- `prepare_run_workspace_with_retry` with 3 attempts and explicit `workspace_preparation_failed` events
-- `cleanup_builder_workspace` records `cleanup_warning` + preserves `worktree_path` for operator recovery
-- `show-runs` / `show-run` expose `worktree_path` and `worktree_recovery_*` fields
-- `docs/CONDUCTOR.md` documents worktree lifecycle semantics and operator recovery
+`dispatch.go` hard-codes `master || main` in two independent places:
+1. Sync script — `git checkout master 2>/dev/null || git checkout main`
+2. Verify script — `git log origin/master..HEAD || git log origin/main..HEAD`
 
-## Gap Identified
+If the default branch is neither `master` nor `main`, both paths fail independently.
 
-No test explicitly verified the cross-operation lock contention case: that
-`cleanup_run_workspace` must wait when the per-repo mirror lock is held by a
-concurrent `prepare_run_workspace` (or any other mirror mutation). The existing
-tests covered prepare+external-lock-holder and cleanup+lock-timeout, but not
-the symmetric case that proves cleanup and prepare share and respect the same flock.
+## Solution
+
+Detect once (`origin/HEAD`), thread value through both paths.
 
 ## Steps
 
-- [x] Audit existing implementation and tests
-- [x] Add `test_cleanup_run_workspace_waits_for_lock_release` to `scripts/test_conductor.py`
-- [x] Run `python3 -m pytest -q scripts/test_conductor.py -k "worktree or workspace or cleanup"` — 36 passed
-- [x] Run full `python3 -m pytest -q scripts/test_conductor.py` — 237 passed
-- [x] Push branch, open draft PR with `Closes #538`
-- [x] Write builder artifact
+- [x] Read codebase, understand duplication
+- [ ] Add `detectDefaultBranchScript` const and `detectDefaultBranchWithRunner` func to `dispatch_checks.go`
+- [ ] Update `verifyWorkScriptFor` in `dispatch.go` to accept `defaultBranch string` param
+- [ ] In `runDispatch`, detect default branch after workspace is resolved; thread into sync script and `verifyWorkScriptFor`
+- [ ] Add regression tests for `detectDefaultBranchWithRunner` in `dispatch_test.go`
+- [ ] Update `TestVerifyWorkScriptForQuotesWorkspace` for new signature
+- [ ] `go test ./cmd/bb/...` — all pass
 
-## Review
+## Constraints
 
-- New test `test_cleanup_run_workspace_waits_for_lock_release` reuses the `_init_local_worktree_mirror`,
-  `_install_flock_shim`, `_local_sprite_bash`, and `_hold_lock` helpers already in place for the
-  prepare+lock tests.
-- Cleanup first creates a real worktree via prepare, then a lock holder simulates a concurrent
-  prepare on the same sprite mirror. Cleanup must demonstrably block for ≥1 second before the
-  lock holder releases and cleanup completes.
-- All 237 tests pass.
+- No new packages, no new Go files (all in `cmd/bb/`)
+- Narrow diff — do not touch anything outside dispatch transport
+- Fallback to `"main"` when `origin/HEAD` is unset (sane default)

--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -75,10 +75,10 @@ func dispatchWorkspace(repo, override string) string {
 	return spriteRepoWorkspace(repo)
 }
 
-func verifyWorkScriptFor(workspace, ghToken string) string {
+func verifyWorkScriptFor(workspace, ghToken, defaultBranch string) string {
 	return fmt.Sprintf(
-		`export GH_TOKEN=%q WORKSPACE=%q; cd "$WORKSPACE" && echo "--- commits ---" && git log --oneline origin/master..HEAD 2>/dev/null || git log --oneline origin/main..HEAD 2>/dev/null; echo "--- PRs ---" && gh pr list --json url,title 2>/dev/null || echo "(gh not available)"`,
-		ghToken, workspace,
+		`export GH_TOKEN=%q WORKSPACE=%q; cd "$WORKSPACE" && echo "--- commits ---" && git log --oneline origin/%s..HEAD 2>/dev/null; echo "--- PRs ---" && gh pr list --json url,title 2>/dev/null || echo "(gh not available)"`,
+		ghToken, workspace, defaultBranch,
 	)
 }
 
@@ -130,11 +130,14 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 	// Conductor-owned worktrees pass --workspace and handle preparation separately.
 	workspace := dispatchWorkspace(repo, workspaceOverride)
 
+	// Detect the remote default branch once; reused for sync and verification.
+	defaultBranch := detectDefaultBranchWithRunner(ctx, spriteBashRunner(s), workspace)
+
 	if workspaceOverride == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "syncing repo %s...\n", repo)
 		syncScript := fmt.Sprintf(
-			`git config --global --add safe.directory %q 2>/dev/null; export GH_TOKEN=%q && cd %q && git checkout master 2>/dev/null || git checkout main 2>/dev/null; git pull --ff-only 2>&1`,
-			workspace, ghToken, workspace,
+			`git config --global --add safe.directory %q 2>/dev/null; export GH_TOKEN=%q && cd %q && git checkout %s 2>/dev/null; git pull --ff-only 2>&1`,
+			workspace, ghToken, workspace, defaultBranch,
 		)
 		syncCmd := s.CommandContext(ctx, "bash", "-c", syncScript)
 		if out, err := syncCmd.Output(); err != nil {
@@ -246,7 +249,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 
 	// 9. Verify work produced
 	_, _ = fmt.Fprintf(os.Stderr, "\n=== work produced ===\n")
-	verifyScript := verifyWorkScriptFor(workspace, ghToken)
+	verifyScript := verifyWorkScriptFor(workspace, ghToken, defaultBranch)
 	verifyCmd := s.CommandContext(ctx, "bash", "-c", verifyScript)
 	verifyCmd.Stdout = os.Stderr
 	verifyCmd.Stderr = os.Stderr

--- a/cmd/bb/dispatch_checks.go
+++ b/cmd/bb/dispatch_checks.go
@@ -63,6 +63,33 @@ if [ -n "$commits" ]; then
 fi
 exit 1`
 
+// detectDefaultBranchScript resolves the remote default branch from origin/HEAD.
+// Exits 0 with the branch name (e.g. "main", "master", "trunk") on stdout.
+// Exits 1 when origin/HEAD is unset; caller should fall back to "main".
+// Exits 2 when the workspace is not a git repo.
+const detectDefaultBranchScript = `
+cd "$WORKSPACE" 2>/dev/null || exit 2
+branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+if [ -n "$branch" ]; then
+  printf '%s\n' "$branch"
+  exit 0
+fi
+exit 1`
+
+// detectDefaultBranchWithRunner resolves the remote default branch from
+// origin/HEAD. Falls back to "main" when origin/HEAD is unset, when the
+// workspace is not a git repo, or when the runner fails.
+func detectDefaultBranchWithRunner(ctx context.Context, run spriteScriptRunner, workspace string) string {
+	output, exitCode, err := runDispatchCheck(ctx, run, dispatchCheck{
+		timeout: 10 * time.Second,
+		script:  fmt.Sprintf("export WORKSPACE=%q\n%s", workspace, detectDefaultBranchScript),
+	})
+	if err != nil || exitCode != 0 || output == "" {
+		return "main"
+	}
+	return output
+}
+
 // prChecksScript checks whether all PR CI checks for the current HEAD have passed.
 // Exits 0 when all checks pass, 1 when checks are still pending, 2 on error (no PR, no git, etc.).
 const prChecksScript = `

--- a/cmd/bb/dispatch_test.go
+++ b/cmd/bb/dispatch_test.go
@@ -594,13 +594,25 @@ func TestVerifyWorkScriptForQuotesWorkspace(t *testing.T) {
 	t.Parallel()
 
 	workspace := `/tmp/run 123; touch /tmp/pwned`
-	script := verifyWorkScriptFor(workspace, "ghtoken123")
+	script := verifyWorkScriptFor(workspace, "ghtoken123", "main")
 
 	if !strings.Contains(script, `WORKSPACE="/tmp/run 123; touch /tmp/pwned"`) {
 		t.Fatalf("verifyWorkScriptFor() missing quoted workspace: %q", script)
 	}
 	if !strings.Contains(script, `cd "$WORKSPACE"`) {
 		t.Fatalf("verifyWorkScriptFor() should cd via WORKSPACE env var: %q", script)
+	}
+}
+
+func TestVerifyWorkScriptForUsesDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	script := verifyWorkScriptFor("/tmp/ws", "tok", "trunk")
+	if !strings.Contains(script, "origin/trunk") {
+		t.Fatalf("verifyWorkScriptFor() should use detected branch: %q", script)
+	}
+	if strings.Contains(script, "origin/master") || strings.Contains(script, "origin/main") {
+		t.Fatalf("verifyWorkScriptFor() should not contain hard-coded branch names: %q", script)
 	}
 }
 
@@ -1310,5 +1322,90 @@ func TestPRChecksScriptForIncludesWorkspaceAndToken(t *testing.T) {
 	}
 	if !strings.Contains(script, "gh pr checks HEAD") {
 		t.Fatalf("script = %q, want to contain gh pr checks command", script)
+	}
+}
+
+// detectDefaultBranch tests
+
+func TestDetectDefaultBranchReturnsDetectedBranch(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("trunk\n"), err: nil}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "trunk" {
+		t.Fatalf("got %q, want %q", got, "trunk")
+	}
+}
+
+func TestDetectDefaultBranchFallsBackToMainOnExit1(t *testing.T) {
+	t.Parallel()
+
+	// origin/HEAD unset — exit 1
+	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "main" {
+		t.Fatalf("got %q, want %q", got, "main")
+	}
+}
+
+func TestDetectDefaultBranchFallsBackToMainOnExit2(t *testing.T) {
+	t.Parallel()
+
+	// workspace not a git repo — exit 2
+	r := &fakeSpriteScriptRunner{exitCode: 2, out: nil, err: nil}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "main" {
+		t.Fatalf("got %q, want %q", got, "main")
+	}
+}
+
+func TestDetectDefaultBranchFallsBackToMainOnRunnerError(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: nil, err: errors.New("network")}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "main" {
+		t.Fatalf("got %q, want %q", got, "main")
+	}
+}
+
+func TestDetectDefaultBranchFallsBackToMainOnEmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("\n"), err: nil}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "main" {
+		t.Fatalf("got %q, want %q", got, "main")
+	}
+}
+
+func TestDetectDefaultBranchUsesWorkspace(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("main\n"), err: nil}
+	_ = detectDefaultBranchWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo")
+	if !strings.Contains(r.script, "/home/sprite/workspace/myrepo") {
+		t.Fatalf("script = %q, want to contain workspace path", r.script)
+	}
+}
+
+func TestDetectDefaultBranchHasDeadline(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("main\n"), err: nil}
+	_ = detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if !r.gotDeadline {
+		t.Fatal("expected context to carry a deadline")
+	}
+}
+
+func TestDetectDefaultBranchNonStandardBranchName(t *testing.T) {
+	t.Parallel()
+
+	// Verify a non-standard branch (neither master nor main) is preserved exactly.
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("develop\n"), err: nil}
+	got := detectDefaultBranchWithRunner(context.Background(), r.run, "/tmp/ws")
+	if got != "develop" {
+		t.Fatalf("got %q, want %q", got, "develop")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `detectDefaultBranchWithRunner` in `dispatch_checks.go` that resolves the remote default branch from `origin/HEAD`, falling back to `"main"` on unset or runner error.
- Calls it once after workspace is resolved in `runDispatch`, threading `defaultBranch` into both the sync script (`git checkout`) and `verifyWorkScriptFor` (`git log origin/<branch>..HEAD`).
- Removes the duplicated `master || main` fallback pattern from both paths.
- Adds 8 focused regression tests covering all branch detection scenarios.

## Test plan

- [x] `go test ./cmd/bb/...` passes
- [x] `TestDetectDefaultBranchReturnsDetectedBranch` — non-standard branch detected correctly
- [x] `TestDetectDefaultBranchFallsBackToMainOnExit1` — unset origin/HEAD falls back to main
- [x] `TestDetectDefaultBranchFallsBackToMainOnExit2` — non-git workspace falls back to main
- [x] `TestDetectDefaultBranchFallsBackToMainOnRunnerError` — runner failure falls back to main
- [x] `TestDetectDefaultBranchFallsBackToMainOnEmptyOutput` — empty git output falls back to main
- [x] `TestDetectDefaultBranchUsesWorkspace` — workspace path threaded through script
- [x] `TestDetectDefaultBranchHasDeadline` — context carries 10s deadline
- [x] `TestDetectDefaultBranchNonStandardBranchName` — arbitrary branch name preserved verbatim
- [x] `TestVerifyWorkScriptForUsesDefaultBranch` — verify script uses detected branch, not hard-coded names

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository operations to automatically detect the correct remote default branch instead of hard-coding master or main, enabling full compatibility with repositories using any default branch naming convention.

* **Tests**
  * Added comprehensive test coverage for default branch detection logic, including fallback handling and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->