### PR TITLE
refactor: centralize default-branch detection for dispatch (#432)

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -140,7 +140,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 	if workspaceOverride == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "syncing repo %s (branch: %s)...\n", repo, defaultBranch)
 		syncScript := fmt.Sprintf(
-			`git config --global --add safe.directory %q 2>/dev/null; export GH_TOKEN=%q && cd %q && git checkout %q; git pull --ff-only 2>&1`,
+			`git config --global --add safe.directory %q 2>/dev/null; export GH_TOKEN=%q && cd %q && git checkout %q && git pull --ff-only 2>&1`,
 			workspace, ghToken, workspace, defaultBranch,
 		)
 		syncCmd := s.CommandContext(ctx, "bash", "-c", syncScript)
@@ -287,7 +287,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 			hasWork, checkErr = hasNewCommitsSinceSHAWithRunner(ctx, spriteBashRunner(s), workspace, preSHA)
 		} else {
 			_, _ = fmt.Fprintf(os.Stderr, "\n=== off-rails: no pre-dispatch SHA — falling back to origin baseline check ===\n")
-			hasWork, checkErr = hasNewCommitsWithRunner(ctx, spriteBashRunner(s), workspace)
+			hasWork, checkErr = hasNewCommitsWithRunner(ctx, spriteBashRunner(s), workspace, defaultBranch)
 		}
 		if checkErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "\n=== off-rails: new commits check failed: %v — treating as failure ===\n", checkErr)

--- a/cmd/bb/dispatch_checks.go
+++ b/cmd/bb/dispatch_checks.go
@@ -31,13 +31,13 @@ fi
 echo "$busy" >&2
 exit "$status"`
 
-// newCommitsCheckScript checks if any commits on HEAD are not yet on origin/master or
-// origin/main. Exits 0 with commit list on stdout when new commits exist, exits 1 when
-// the branch is flush with upstream (no new work). Exits 2 when not a git repo or when
-// neither origin/master nor origin/main exists (no valid upstream baseline).
+// newCommitsCheckScript checks if any commits on HEAD are not yet on the remote
+// default branch ($BRANCH). Exits 0 with commit list on stdout when new commits
+// exist, exits 1 when the branch is flush with upstream (no new work). Exits 2
+// when not a git repo or origin/$BRANCH does not exist.
 const newCommitsCheckScript = `
 cd "$WORKSPACE" 2>/dev/null || exit 2
-commits="$(git log origin/master..HEAD --oneline 2>/dev/null || git log origin/main..HEAD --oneline 2>/dev/null)" || exit 2
+commits="$(git log "origin/$BRANCH"..HEAD --oneline 2>/dev/null)" || exit 2
 if [ -n "$commits" ]; then
   printf '%s\n' "$commits"
   exit 0
@@ -273,13 +273,13 @@ func isValidBranchName(name string) bool {
 }
 
 // hasNewCommitsWithRunner returns true when commits exist on HEAD that are not
-// present on origin/master or origin/main. This is used as a secondary off-rails
+// present on origin/<defaultBranch>. This is used as a secondary off-rails
 // backstop: if the detector fired while the agent was mid-task (e.g. waiting for CI),
 // and work exists on the branch, dispatch succeeds with a warning rather than failing.
-func hasNewCommitsWithRunner(ctx context.Context, run spriteScriptRunner, workspace string) (bool, error) {
+func hasNewCommitsWithRunner(ctx context.Context, run spriteScriptRunner, workspace, defaultBranch string) (bool, error) {
 	output, exitCode, err := runDispatchCheck(ctx, run, dispatchCheck{
 		timeout: 15 * time.Second,
-		script:  fmt.Sprintf("export WORKSPACE=%q\n%s", workspace, newCommitsCheckScript),
+		script:  fmt.Sprintf("export WORKSPACE=%q BRANCH=%q\n%s", workspace, defaultBranch, newCommitsCheckScript),
 	})
 	if err != nil {
 		return false, fmt.Errorf("check new commits: %w", err)

--- a/cmd/bb/dispatch_test.go
+++ b/cmd/bb/dispatch_test.go
@@ -393,7 +393,7 @@ func TestHasNewCommitsReturnsTrue(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("abc123 feat: something\n"), err: nil}
-	hasWork, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws")
+	hasWork, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "main")
 	if err != nil {
 		t.Fatalf("hasNewCommitsWithRunner() error = %v", err)
 	}
@@ -406,7 +406,7 @@ func TestHasNewCommitsReturnsFalseWhenNone(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
-	hasWork, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws")
+	hasWork, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "main")
 	if err != nil {
 		t.Fatalf("hasNewCommitsWithRunner() error = %v", err)
 	}
@@ -419,7 +419,7 @@ func TestHasNewCommitsReturnsErrorOnRunnerFailure(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: nil, err: errors.New("network")}
-	_, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws")
+	_, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "main")
 	if err == nil {
 		t.Fatal("expected error for runner failure")
 	}
@@ -435,7 +435,7 @@ func TestHasNewCommitsReturnsErrorOnUnexpectedExitCode(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 2, out: []byte("fatal: not a git repo"), err: nil}
-	_, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws")
+	_, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "main")
 	if err == nil {
 		t.Fatal("expected error for unexpected exit code")
 	}
@@ -448,7 +448,7 @@ func TestHasNewCommitsUsesWorkspace(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("abc123\n"), err: nil}
-	if _, err := hasNewCommitsWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo"); err != nil {
+	if _, err := hasNewCommitsWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo", "main"); err != nil {
 		t.Fatalf("hasNewCommitsWithRunner() error = %v", err)
 	}
 	if !strings.Contains(r.script, "/home/sprite/workspace/myrepo") {
@@ -456,11 +456,29 @@ func TestHasNewCommitsUsesWorkspace(t *testing.T) {
 	}
 }
 
+func TestHasNewCommitsUsesDetectedBranch(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("abc123\n"), err: nil}
+	if _, err := hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "development"); err != nil {
+		t.Fatalf("hasNewCommitsWithRunner() error = %v", err)
+	}
+	if !strings.Contains(r.script, `BRANCH="development"`) {
+		t.Fatalf("script = %q, want BRANCH set to detected branch", r.script)
+	}
+	if strings.Contains(r.script, "origin/master") {
+		t.Fatalf("script = %q, should not hardcode origin/master", r.script)
+	}
+	if strings.Contains(r.script, "origin/main") {
+		t.Fatalf("script = %q, should not hardcode origin/main", r.script)
+	}
+}
+
 func TestHasNewCommitsHasDeadline(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("abc123\n"), err: nil}
-	_, _ = hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws")
+	_, _ = hasNewCommitsWithRunner(context.Background(), r.run, "/tmp/ws", "main")
 	if !r.gotDeadline {
 		t.Fatal("expected context to carry a deadline (15s timeout)")
 	}


### PR DESCRIPTION
## Summary

Closes #432.

Duplicate `master`/`main` fallback logic existed in two dispatch paths:
- `verifyWorkScriptFor`: tried `origin/master..HEAD` then `origin/main..HEAD` via `||`
- sync script in `runDispatch`: tried `git checkout master` then `git checkout main`

This refactor:
- Adds `detectDefaultBranchScript` (bash constant) that reads `origin/HEAD` via `git rev-parse --abbrev-ref`, strips the `origin/` prefix, falls back to checking `origin/master`, then defaults to `"main"`
- Adds `detectDefaultBranchWithRunner` following the existing runner pattern used throughout `dispatch_checks.go`
- Updates `verifyWorkScriptFor` to accept an explicit `branch` parameter (no more hardcoded fallback chain)
- In `runDispatch`, calls detection once after workspace resolution, threads the result into both sync and verify paths

## Test plan

- [ ] 7 new regression tests: `TestDetectDefaultBranch*` and `TestVerifyWorkScriptForUsesDetectedBranch`
- [ ] `TestVerifyWorkScriptForQuotesWorkspace` updated to new 3-arg signature
- [ ] `go test ./cmd/bb/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects the repository default branch once per dispatch and uses it for sync and verification, with branch printed in logs.
  * Validates detected branch names and falls back to "main" with a warning if detection fails.

* **Bug Fixes**
  * Removes hard-coded master/main assumptions when checking out and comparing commits; uses detected branch instead.

* **Tests**
  * Adds comprehensive tests for branch detection, validation, fallbacks, error cases, and propagation into commit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->