### PR TITLE
feat: absorb dispatch into Elixir — direct sprite exec, no bb/ralph.sh

### DIFF
--- a/conductor/lib/conductor/claude_code.ex
+++ b/conductor/lib/conductor/claude_code.ex
@@ -30,4 +30,19 @@ defmodule Conductor.ClaudeCode do
       "--verbose"
     ]
   end
+
+  @impl Conductor.Harness
+  def continue_command(opts \\ []) do
+    model = Keyword.get(opts, :model, @default_model)
+
+    [
+      "claude",
+      "--continue",
+      "-p",
+      "--dangerously-skip-permissions",
+      "--model",
+      model,
+      "--verbose"
+    ]
+  end
 end

--- a/conductor/lib/conductor/config.ex
+++ b/conductor/lib/conductor/config.ex
@@ -9,22 +9,6 @@ defmodule Conductor.Config do
     System.get_env("SPRITES_ORG") || System.fetch_env!("FLY_ORG")
   end
 
-  @spec bb_path() :: binary()
-  def bb_path do
-    System.get_env("BB_PATH") || resolve_bb_path()
-  end
-
-  defp resolve_bb_path do
-    # Look for bb in parent directory (conductor lives inside the bitterblossom repo)
-    candidates = [
-      Path.expand("../bin/bb"),
-      Path.expand("./bin/bb"),
-      "bb"
-    ]
-
-    Enum.find(candidates, "bb", &File.exists?/1)
-  end
-
   @spec db_path() :: binary()
   def db_path do
     Application.get_env(:conductor, :db_path, ".bb/conductor.db")
@@ -92,7 +76,6 @@ defmodule Conductor.Config do
       {"GITHUB_TOKEN", fn -> System.get_env("GITHUB_TOKEN") end},
       {"SPRITE_TOKEN or FLY_API_TOKEN",
        fn -> System.get_env("SPRITE_TOKEN") || System.get_env("FLY_API_TOKEN") end},
-      {"bb", fn -> find_executable("bb") || File.exists?(bb_path()) end},
       {"gh", fn -> find_executable("gh") end},
       {"sprite", fn -> find_executable("sprite") end}
     ]

--- a/conductor/lib/conductor/harness.ex
+++ b/conductor/lib/conductor/harness.ex
@@ -22,4 +22,16 @@ defmodule Conductor.Harness do
   - `:model` — override the default model identifier
   """
   @callback dispatch_command(opts :: keyword()) :: [binary()]
+
+  @doc """
+  Build the session-resumption command for this harness.
+
+  Used when the agent crashes mid-task: resumes the prior session
+  instead of starting fresh. Returns nil if the harness does not
+  support continuation.
+
+  Accepted opts:
+  - `:model` — override the default model identifier
+  """
+  @callback continue_command(opts :: keyword()) :: [binary()] | nil
 end

--- a/conductor/lib/conductor/sprite.ex
+++ b/conductor/lib/conductor/sprite.ex
@@ -1,17 +1,27 @@
 defmodule Conductor.Sprite do
   @moduledoc """
-  Sprite operations via the `sprite` and `bb` CLIs.
+  Sprite operations via the `sprite` CLI.
 
   Deep module: hides all sprite protocol details — exec, dispatch,
   artifact retrieval, process cleanup.
 
   Implements `Conductor.Worker`.
+
+  ## Dispatch sequence
+
+  `dispatch/4` performs the full sequence via direct `sprite exec` calls:
+
+  1. Kill stale agent processes (`pkill -9 -f claude`)
+  2. Upload prompt to workspace (base64-encoded to avoid shell quoting issues)
+  3. Run agent via `Conductor.Harness` (e.g. `claude -p < PROMPT.md`)
+  4. On non-zero exit, retry once using the harness `continue_command`
   """
 
   @behaviour Conductor.Worker
 
   alias Conductor.{Shell, Config, Workspace}
 
+  @impl Conductor.Worker
   @spec exec(binary(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
   def exec(sprite, command, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 60_000)
@@ -30,24 +40,36 @@ defmodule Conductor.Sprite do
     end
   end
 
+  @impl Conductor.Worker
   @spec dispatch(binary(), binary(), binary(), keyword()) ::
           {:ok, binary()} | {:error, binary(), integer()}
-  def dispatch(sprite, prompt, repo, opts \\ []) do
+  def dispatch(sprite, prompt, _repo, opts \\ []) do
     timeout_minutes = Keyword.get(opts, :timeout, Config.builder_timeout())
-    template = Keyword.get(opts, :template)
-    workspace = Keyword.get(opts, :workspace)
+    workspace = Keyword.fetch!(opts, :workspace)
+    harness = Keyword.get(opts, :harness, Conductor.ClaudeCode)
+    # Injected in tests to capture exec calls without a real sprite
+    exec_fn = Keyword.get(opts, :exec_fn, &exec/3)
 
-    args =
-      ["dispatch", sprite, prompt, "--repo", repo, "--timeout", "#{timeout_minutes}m"]
-      |> maybe_add("--prompt-template", template)
-      |> maybe_add("--workspace", workspace)
+    timeout_ms = timeout_minutes * 60_000
 
-    Shell.cmd(Config.bb_path(), args,
-      timeout: (timeout_minutes + 5) * 60_000,
-      env: Config.dispatch_env()
-    )
+    # 1. Kill stale agent processes from prior dispatches
+    exec_fn.(sprite, "pkill -9 -f claude 2>/dev/null; true", timeout: 15_000)
+
+    # 2. Upload prompt (base64 to avoid shell quoting; base64 alphabet is shell-safe)
+    prompt_path = Path.join(workspace, "PROMPT.md")
+    encoded = Base.encode64(prompt)
+
+    case exec_fn.(sprite, "echo #{encoded} | base64 -d > '#{prompt_path}'", timeout: 30_000) do
+      {:error, msg, code} ->
+        {:error, "prompt upload failed: #{msg}", code}
+
+      {:ok, _} ->
+        # 3. Run agent
+        run_agent(sprite, workspace, prompt_path, harness, exec_fn, timeout_ms)
+    end
   end
 
+  @impl Conductor.Worker
   @spec read_artifact(binary(), binary(), keyword()) :: {:ok, map()} | {:error, term()}
   def read_artifact(sprite, path, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 30_000)
@@ -64,6 +86,7 @@ defmodule Conductor.Sprite do
     end
   end
 
+  @impl Conductor.Worker
   @spec cleanup(binary(), binary(), binary()) :: :ok | {:error, term()}
   def cleanup(sprite, repo, run_id) do
     Workspace.cleanup(sprite, repo, run_id)
@@ -71,7 +94,7 @@ defmodule Conductor.Sprite do
 
   @spec kill(binary()) :: :ok | {:error, term()}
   def kill(sprite) do
-    case Shell.cmd(Config.bb_path(), ["kill", sprite], timeout: 30_000) do
+    case exec(sprite, "pkill -9 -f claude 2>/dev/null; true", timeout: 15_000) do
       {:ok, _} -> :ok
       {:error, msg, _} -> {:error, msg}
     end
@@ -79,8 +102,8 @@ defmodule Conductor.Sprite do
 
   @spec status(binary()) :: {:ok, map()} | {:error, term()}
   def status(sprite) do
-    case Shell.cmd(Config.bb_path(), ["status", sprite], timeout: 30_000) do
-      {:ok, output} -> {:ok, %{sprite: sprite, output: output, reachable: true}}
+    case exec(sprite, "echo ok", timeout: 15_000) do
+      {:ok, _} -> {:ok, %{sprite: sprite, reachable: true}}
       {:error, msg, _} -> {:error, msg}
     end
   end
@@ -90,6 +113,30 @@ defmodule Conductor.Sprite do
     match?({:ok, _}, exec(sprite, "echo ok", timeout: 15_000))
   end
 
-  defp maybe_add(args, _flag, nil), do: args
-  defp maybe_add(args, flag, value), do: args ++ [flag, value]
+  # --- Private ---
+
+  defp run_agent(sprite, workspace, prompt_path, harness, exec_fn, timeout_ms) do
+    cmd = agent_command(harness.dispatch_command([]), workspace, prompt_path)
+
+    case exec_fn.(sprite, cmd, timeout: timeout_ms) do
+      {:ok, output} ->
+        {:ok, output}
+
+      {:error, _output, _code} ->
+        # Retry with session resumption if the harness supports it
+        case harness.continue_command([]) do
+          nil ->
+            {:error, "agent exited non-zero; harness does not support continuation", 1}
+
+          continue_parts ->
+            retry_cmd = agent_command(continue_parts, workspace, prompt_path)
+            exec_fn.(sprite, retry_cmd, timeout: timeout_ms)
+        end
+    end
+  end
+
+  defp agent_command(cmd_parts, workspace, prompt_path) do
+    cmd_str = Enum.join(cmd_parts, " ")
+    "cd '#{workspace}' && LEFTHOOK=0 #{cmd_str} < '#{prompt_path}'"
+  end
 end

--- a/conductor/test/conductor/config_test.exs
+++ b/conductor/test/conductor/config_test.exs
@@ -3,23 +3,6 @@ defmodule Conductor.ConfigTest do
 
   alias Conductor.Config
 
-  describe "bb_path/0" do
-    test "returns BB_PATH env var when set" do
-      System.put_env("BB_PATH", "/custom/path/bb")
-      assert Config.bb_path() == "/custom/path/bb"
-    after
-      System.delete_env("BB_PATH")
-    end
-
-    test "falls back to resolution when BB_PATH unset" do
-      System.delete_env("BB_PATH")
-      path = Config.bb_path()
-
-      # Must return a string; either a resolved candidate or the fallback "bb"
-      assert is_binary(path)
-    end
-  end
-
   describe "db_path/0" do
     test "returns default when no app config" do
       assert Config.db_path() == ".bb/conductor.db"

--- a/conductor/test/conductor/sprite_dispatch_test.exs
+++ b/conductor/test/conductor/sprite_dispatch_test.exs
@@ -1,0 +1,235 @@
+defmodule Conductor.SpriteDispatchTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Verifies the `Conductor.Sprite.dispatch/4` sequence using an injected
+  exec_fn — no real sprite required.
+
+  Sequence under test:
+  1. Kill stale agent processes
+  2. Upload prompt (base64)
+  3. Run agent via harness dispatch_command
+  4. On crash, retry via harness continue_command
+  """
+
+  alias Conductor.Sprite
+
+  # ---------------------------------------------------------------------------
+  # Mock Harness
+  # ---------------------------------------------------------------------------
+
+  defmodule MockHarness do
+    @behaviour Conductor.Harness
+
+    def name, do: "mock"
+    def dispatch_command(_opts), do: ["agent", "-p"]
+    def continue_command(_opts), do: ["agent", "--continue", "-p"]
+  end
+
+  defmodule NoRetryHarness do
+    @behaviour Conductor.Harness
+
+    def name, do: "no_retry"
+    def dispatch_command(_opts), do: ["agent", "-p"]
+    def continue_command(_opts), do: nil
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Returns an exec_fn that records all calls to the test process and returns
+  # `responses` matched by substring. Falls back to `{:ok, ""}` if no match.
+  defp make_exec_fn(responses \\ []) do
+    test_pid = self()
+
+    fn _sprite, command, _opts ->
+      send(test_pid, {:exec_called, command})
+
+      Enum.find_value(responses, {:ok, ""}, fn {pattern, result} ->
+        if String.contains?(command, pattern), do: result
+      end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tests
+  # ---------------------------------------------------------------------------
+
+  describe "dispatch/4 full sequence" do
+    test "kills stale processes before dispatching" do
+      exec_fn = make_exec_fn()
+
+      Sprite.dispatch("s1", "hello prompt", "org/repo",
+        workspace: "/ws",
+        harness: MockHarness,
+        exec_fn: exec_fn,
+        timeout: 1
+      )
+
+      assert_received {:exec_called, kill_cmd}
+      assert String.contains?(kill_cmd, "pkill")
+    end
+
+    test "uploads prompt as base64 to workspace/PROMPT.md" do
+      exec_fn = make_exec_fn()
+
+      Sprite.dispatch("s1", "my test prompt", "org/repo",
+        workspace: "/my/ws",
+        harness: MockHarness,
+        exec_fn: exec_fn,
+        timeout: 1
+      )
+
+      # Drain the kill call
+      assert_received {:exec_called, _kill_cmd}
+
+      # Base64 upload
+      assert_received {:exec_called, upload_cmd}
+      assert String.contains?(upload_cmd, "base64 -d")
+      assert String.contains?(upload_cmd, "/my/ws/PROMPT.md")
+
+      # Verify the prompt content is encoded in the command
+      expected_b64 = Base.encode64("my test prompt")
+      assert String.contains?(upload_cmd, expected_b64)
+    end
+
+    test "runs agent via harness dispatch_command" do
+      exec_fn = make_exec_fn()
+
+      Sprite.dispatch("s1", "prompt", "org/repo",
+        workspace: "/ws",
+        harness: MockHarness,
+        exec_fn: exec_fn,
+        timeout: 1
+      )
+
+      # Drain kill and upload
+      assert_received {:exec_called, _}
+      assert_received {:exec_called, _}
+
+      assert_received {:exec_called, agent_cmd}
+      assert String.contains?(agent_cmd, "agent -p")
+      assert String.contains?(agent_cmd, "/ws")
+      assert String.contains?(agent_cmd, "PROMPT.md")
+    end
+
+    test "includes LEFTHOOK=0 to suppress git hooks" do
+      exec_fn = make_exec_fn()
+
+      Sprite.dispatch("s1", "prompt", "org/repo",
+        workspace: "/ws",
+        harness: MockHarness,
+        exec_fn: exec_fn,
+        timeout: 1
+      )
+
+      assert_received {:exec_called, _}
+      assert_received {:exec_called, _}
+      assert_received {:exec_called, agent_cmd}
+      assert String.contains?(agent_cmd, "LEFTHOOK=0")
+    end
+
+    test "returns :ok tuple on success" do
+      exec_fn = make_exec_fn()
+
+      result =
+        Sprite.dispatch("s1", "prompt", "org/repo",
+          workspace: "/ws",
+          harness: MockHarness,
+          exec_fn: exec_fn,
+          timeout: 1
+        )
+
+      assert {:ok, _} = result
+    end
+  end
+
+  describe "dispatch/4 retry on agent crash" do
+    test "retries with continue_command on non-zero agent exit" do
+      exec_fn =
+        make_exec_fn([
+          # First agent run fails; continue succeeds
+          {"agent -p", {:error, "agent crashed", 1}}
+        ])
+
+      result =
+        Sprite.dispatch("s1", "prompt", "org/repo",
+          workspace: "/ws",
+          harness: MockHarness,
+          exec_fn: exec_fn,
+          timeout: 1
+        )
+
+      assert {:ok, _} = result
+
+      # Drain kill and upload
+      assert_received {:exec_called, _}
+      assert_received {:exec_called, _}
+
+      # First agent call (fails)
+      assert_received {:exec_called, first_cmd}
+      refute String.contains?(first_cmd, "--continue")
+
+      # Retry call (continue)
+      assert_received {:exec_called, retry_cmd}
+      assert String.contains?(retry_cmd, "agent --continue -p")
+    end
+
+    test "returns error when harness has no continue_command" do
+      exec_fn =
+        make_exec_fn([
+          {"agent -p", {:error, "agent crashed", 1}}
+        ])
+
+      result =
+        Sprite.dispatch("s1", "prompt", "org/repo",
+          workspace: "/ws",
+          harness: NoRetryHarness,
+          exec_fn: exec_fn,
+          timeout: 1
+        )
+
+      assert {:error, msg, _code} = result
+      assert String.contains?(msg, "continuation")
+    end
+
+    test "propagates continue_command failure" do
+      exec_fn =
+        make_exec_fn([
+          {"agent -p", {:error, "crashed", 1}},
+          {"agent --continue", {:error, "still crashed", 2}}
+        ])
+
+      result =
+        Sprite.dispatch("s1", "prompt", "org/repo",
+          workspace: "/ws",
+          harness: MockHarness,
+          exec_fn: exec_fn,
+          timeout: 1
+        )
+
+      assert {:error, "still crashed", 2} = result
+    end
+  end
+
+  describe "dispatch/4 upload failure" do
+    test "returns error when prompt upload fails" do
+      exec_fn =
+        make_exec_fn([
+          {"base64 -d", {:error, "no space left", 1}}
+        ])
+
+      result =
+        Sprite.dispatch("s1", "prompt", "org/repo",
+          workspace: "/ws",
+          harness: MockHarness,
+          exec_fn: exec_fn,
+          timeout: 1
+        )
+
+      assert {:error, msg, _code} = result
+      assert String.contains?(msg, "prompt upload failed")
+    end
+  end
+end


### PR DESCRIPTION
Closes #621

## Summary

- `Conductor.Sprite.dispatch/4` now performs the full dispatch sequence via direct `sprite exec` calls — no Go bb binary, no ralph.sh
- `Conductor.Harness` gets `continue_command/1` for session resumption on agent crash
- `Conductor.ClaudeCode` implements both `dispatch_command` and `continue_command` (`claude --continue -p`)
- `Conductor.Config` drops `bb_path/0` and the `bb` check from `check_env!`
- 9 new tests exercise the full sequence with an injected `exec_fn` (no real sprite needed)

## Dispatch sequence (new)

```
Before: Elixir → System.cmd("bb") → Go → sprites-go SDK → sprite → ralph.sh → claude -p
After:  Elixir → System.cmd("sprite") → sprite → claude -p
```

Steps in `Sprite.dispatch/4`:
1. Kill stale agent processes (`pkill -9 -f claude`)
2. Upload prompt as base64 → `base64 -d > PROMPT.md` (shell-safe, any size)
3. Run `claude -p --dangerously-skip-permissions < PROMPT.md` via harness
4. On non-zero exit, retry with `claude --continue -p` (session resumption)

## Test plan

- [x] `mix test` — 134 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix compile` — no warnings
- [x] New `sprite_dispatch_test.exs` covers: kill, upload, agent invocation, continue retry, upload failure, no-retry harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session continuation capability to resume agent execution after crashes.
  * Added reachability check for sprite connectivity.

* **Improvements**
  * Enhanced prompt handling with secure upload workflow.
  * Added stale process cleanup before execution.
  * Improved agent crash recovery with automatic retry logic.

* **Removed Features**
  * Removed bb_path configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->