### PR TITLE
fix: check worker health before dispatch (#636)

### DIFF
--- a/conductor/lib/conductor/orchestrator.ex
+++ b/conductor/lib/conductor/orchestrator.ex
@@ -172,6 +172,15 @@ defmodule Conductor.Orchestrator do
   defp start_run(state, issue) do
     worker = pick_worker(state)
 
+    if worker_mod().busy?(worker) do
+      Logger.info("worker #{worker} busy, deferring issue ##{issue.number}")
+      state
+    else
+      dispatch_run(state, issue, worker)
+    end
+  end
+
+  defp dispatch_run(state, issue, worker) do
     opts = [
       repo: state.repo,
       issue: issue,
@@ -255,6 +264,7 @@ defmodule Conductor.Orchestrator do
   end
 
   defp tracker_mod, do: Application.get_env(:conductor, :tracker_module, Conductor.GitHub)
+  defp worker_mod, do: Application.get_env(:conductor, :worker_module, Conductor.Sprite)
 
   defp schedule_poll(delay) do
     Process.send_after(self(), :poll, delay)

--- a/conductor/lib/conductor/sprite.ex
+++ b/conductor/lib/conductor/sprite.ex
@@ -113,6 +113,17 @@ defmodule Conductor.Sprite do
     match?({:ok, _}, exec(sprite, "echo ok", timeout: 15_000))
   end
 
+  @doc "Check if a sprite has active agent processes (busy with a dispatch)."
+  @spec busy?(binary(), keyword()) :: boolean()
+  def busy?(sprite, opts \\ []) do
+    exec_fn = Keyword.get(opts, :exec_fn, &exec/3)
+
+    case exec_fn.(sprite, "pgrep -f 'claude.*-p' 2>/dev/null", timeout: 15_000) do
+      {:ok, output} -> String.trim(output) != ""
+      _ -> false
+    end
+  end
+
   # --- Private ---
 
   defp run_agent(sprite, workspace, prompt_path, harness, exec_fn, timeout_ms) do

--- a/conductor/test/conductor/sprite_health_test.exs
+++ b/conductor/test/conductor/sprite_health_test.exs
@@ -1,0 +1,42 @@
+defmodule Conductor.SpriteHealthTest do
+  use ExUnit.Case, async: true
+
+  alias Conductor.Sprite
+
+  describe "busy?/1" do
+    test "returns true when agent processes are detected" do
+      # Stub exec to simulate pgrep finding claude processes
+      busy =
+        Sprite.busy?("test-sprite",
+          exec_fn: fn _sprite, _cmd, _opts ->
+            {:ok, "12345 claude -p\n12346 claude -p\n"}
+          end
+        )
+
+      assert busy == true
+    end
+
+    test "returns false when no agent processes found" do
+      busy =
+        Sprite.busy?("test-sprite",
+          exec_fn: fn _sprite, _cmd, _opts ->
+            # pgrep returns exit 1 when no matches
+            {:error, "", 1}
+          end
+        )
+
+      assert busy == false
+    end
+
+    test "returns false when sprite is unreachable" do
+      busy =
+        Sprite.busy?("test-sprite",
+          exec_fn: fn _sprite, _cmd, _opts ->
+            {:error, "connection refused", 255}
+          end
+        )
+
+      assert busy == false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Sprite.busy?/1` — probes for active agent processes via `pgrep -f 'claude.*-p'`
- Orchestrator checks `busy?` before `start_run` — defers if worker is occupied
- Add `worker_mod/0` accessor for behaviour-based module resolution
- 3 new tests for busy detection (active, no processes, unreachable)

Eliminates the retry churn where the conductor repeatedly leases → dispatches → fails → releases for the same issue when the sprite is busy.

## Test plan

- [x] 3 new tests in `sprite_health_test.exs`
- [x] 152 total tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added worker availability detection to prevent queuing runs when workers are busy.
  * Worker implementations are now configurable via application settings.

* **Tests**
  * Added tests for worker availability detection, covering active processes, idle states, and connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->