### PR TITLE
fix: inject OPENAI_API_KEY as CODEX_API_KEY for Codex CLI auth

### DIFF
--- a/conductor/lib/conductor/config.ex
+++ b/conductor/lib/conductor/config.ex
@@ -91,6 +91,7 @@ defmodule Conductor.Config do
     []
     |> maybe_env("GITHUB_TOKEN")
     |> maybe_env("OPENAI_API_KEY")
+    |> maybe_env_as("OPENAI_API_KEY", "CODEX_API_KEY")
     |> maybe_env("EXA_API_KEY")
     |> Enum.reverse()
   end
@@ -100,6 +101,16 @@ defmodule Conductor.Config do
       nil -> acc
       "" -> acc
       val -> [{key, val} | acc]
+    end
+  end
+
+  # Inject a local env var under a different name on the sprite.
+  # Used for OPENAI_API_KEY → CODEX_API_KEY (Codex CLI reads CODEX_API_KEY).
+  defp maybe_env_as(acc, source_key, target_key) do
+    case System.get_env(source_key) do
+      nil -> acc
+      "" -> acc
+      val -> [{target_key, val} | acc]
     end
   end
 

--- a/conductor/test/conductor/config_dispatch_env_test.exs
+++ b/conductor/test/conductor/config_dispatch_env_test.exs
@@ -51,6 +51,20 @@ defmodule Conductor.ConfigDispatchEnvTest do
       end
     end
 
+    test "maps OPENAI_API_KEY to CODEX_API_KEY for Codex CLI" do
+      prev = System.get_env("OPENAI_API_KEY")
+      System.put_env("OPENAI_API_KEY", "sk-test-codex")
+
+      try do
+        env = Config.dispatch_env()
+        assert {"CODEX_API_KEY", "sk-test-codex"} in env
+      after
+        if prev,
+          do: System.put_env("OPENAI_API_KEY", prev),
+          else: System.delete_env("OPENAI_API_KEY")
+      end
+    end
+
     test "includes EXA_API_KEY when set" do
       prev = System.get_env("EXA_API_KEY")
       System.put_env("EXA_API_KEY", "exa-test-key")


### PR DESCRIPTION
## Why This Matters

First Codex factory dispatch failed 401 Unauthorized. Codex CLI reads `CODEX_API_KEY`, not `OPENAI_API_KEY`. Discovered during factory audit of #646.

## Changes

- `config.ex`: Add `maybe_env_as/3` — maps `OPENAI_API_KEY` (our source) to `CODEX_API_KEY` (what Codex CLI reads)
- Test: Verify `CODEX_API_KEY` appears in `dispatch_env()` when `OPENAI_API_KEY` is set

## Test Coverage

- `config_dispatch_env_test.exs`: 5 tests (1 new for CODEX_API_KEY mapping)
- Full suite: 213 tests, 0 failures

## Merge Confidence

**High.** One-line behavioral fix. Root cause confirmed by manual sprite test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced environment variable handling to support API key configuration mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->