### PR TITLE
feat: persist retro analysis events

### DIFF
--- a/conductor/lib/conductor/retro.ex
+++ b/conductor/lib/conductor/retro.ex
@@ -23,6 +23,7 @@ defmodule Conductor.Retro do
   @anthropic_url "https://api.anthropic.com/v1/messages"
   @model "claude-sonnet-4-20250514"
   @max_tokens 2048
+  @supported_actions ~w(create_issue comment_issue update_backlog)
 
   # Repo root is three levels up from __DIR__ (conductor/lib/conductor/)
   @repo_root Path.expand("../../..", __DIR__)
@@ -63,6 +64,28 @@ defmodule Conductor.Retro do
     })
   end
 
+  @doc false
+  @spec finalize_analysis(binary(), map(), map(), (list(), map() -> any())) :: :ok
+  def finalize_analysis(
+        run_id,
+        %{"findings" => findings} = analysis,
+        run,
+        execute_fn \\ &execute_actions/2
+      )
+      when is_list(findings) and is_map(run) do
+    try do
+      execute_fn.(findings, run)
+    rescue
+      error ->
+        Logger.error(Exception.format(:error, error, __STACKTRACE__))
+        reraise error, __STACKTRACE__
+    after
+      record_complete_event(run_id, analysis)
+    end
+
+    :ok
+  end
+
   # --- GenServer Callbacks ---
 
   @impl true
@@ -92,8 +115,7 @@ defmodule Conductor.Retro do
          context <- build_context(run, events),
          {:ok, response} <- call_llm(context),
          {:ok, analysis} <- parse_response(response) do
-      execute_actions(analysis["findings"], run)
-      record_complete_event(run_id, analysis)
+      finalize_analysis(run_id, analysis, run)
       Logger.info("[retro] #{run_id} complete: #{action_count(analysis["findings"])} action(s)")
     else
       {:error, reason} ->
@@ -443,5 +465,5 @@ defmodule Conductor.Retro do
     }
   end
 
-  defp actionable?(finding), do: Map.get(finding, "action") not in [nil, "none"]
+  defp actionable?(finding), do: Map.get(finding, "action") in @supported_actions
 end

--- a/conductor/test/conductor/retro_test.exs
+++ b/conductor/test/conductor/retro_test.exs
@@ -59,6 +59,11 @@ defmodule Conductor.RetroTest do
               "title" => "Low-value note",
               "action" => "none",
               "existing_issue" => "#615"
+            },
+            %{
+              "title" => "Unsupported action",
+              "action" => "surprise_me",
+              "existing_issue" => nil
             }
           ]
         })
@@ -68,7 +73,7 @@ defmodule Conductor.RetroTest do
       assert event["event_type"] == "retro_complete"
       assert event["payload"]["summary"] == "builder hit review friction; backlog updated"
       assert event["payload"]["action_count"] == 1
-      assert event["payload"]["skipped_count"] == 1
+      assert event["payload"]["skipped_count"] == 2
 
       assert event["payload"]["actions_taken"] == [
                %{
@@ -107,6 +112,38 @@ defmodule Conductor.RetroTest do
       assert event["event_type"] == "retro_complete"
       assert event["payload"]["summary"] == "clean run"
       assert event["payload"]["action_count"] == 0
+    end
+
+    test "persists retro_complete even when action execution raises" do
+      {:ok, run_id} =
+        Store.create_run(%{
+          repo: "test/repo",
+          issue_number: 648,
+          issue_title: "Persist failed retro",
+          builder_sprite: "sprite-1"
+        })
+
+      {:ok, run} = Store.get_run(run_id)
+
+      analysis = %{
+        "summary" => "retro action failed",
+        "findings" => [
+          %{
+            "title" => "Actionable failure",
+            "action" => "create_issue",
+            "existing_issue" => nil
+          }
+        ]
+      }
+
+      assert_raise RuntimeError, "boom", fn ->
+        Retro.finalize_analysis(run_id, analysis, run, fn _, _ -> raise "boom" end)
+      end
+
+      [event] = Store.list_events(run_id)
+      assert event["event_type"] == "retro_complete"
+      assert event["payload"]["summary"] == "retro action failed"
+      assert event["payload"]["action_count"] == 1
     end
   end
 end


### PR DESCRIPTION
## Summary
- persist retro analysis as a `retro_complete` store event after retro actions run
- include summary, full findings, and derived action metadata in the event payload for CLI/dashboard consumers
- add regression coverage for `Store.list_events/1` and `mix conductor show-events --run-id`

Closes #646

## Verification
- cd conductor && mix test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrospective completion events now capture full analysis including summary, findings, actionable item counts, action metadata, and skipped item counts for improved tracking and reporting.

* **Tests**
  * Expanded end-to-end tests for retrospective event persistence and CLI event display, with isolated test environments and structured output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->