### PR TITLE
fix: persist gh auth on sprites

### DIFF
--- a/cmd/bb/dispatch.go
+++ b/cmd/bb/dispatch.go
@@ -75,22 +75,16 @@ func dispatchWorkspace(repo, override string) string {
 	return spriteRepoWorkspace(repo)
 }
 
-func verifyWorkScriptFor(workspace, ghToken, branch string) string {
+func verifyWorkScriptFor(workspace, branch string) string {
 	return fmt.Sprintf(
-		`export GH_TOKEN=%q WORKSPACE=%q BRANCH=%q; cd "$WORKSPACE" && echo "--- commits ---" && git log --oneline "origin/$BRANCH..HEAD" 2>/dev/null; echo "--- PRs ---" && gh pr list --json url,title 2>/dev/null || echo "(gh not available)"`,
-		ghToken, workspace, branch,
+		`export WORKSPACE=%q BRANCH=%q; cd "$WORKSPACE" && echo "--- commits ---" && git log --oneline "origin/$BRANCH..HEAD" 2>/dev/null; echo "--- PRs ---" && gh pr list --json url,title 2>/dev/null || echo "(gh not available)"`,
+		workspace, branch,
 	)
 }
 
 func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverride, promptTemplate string, maxIter int, timeout time.Duration, noOutputTimeout time.Duration, dryRun bool, prCheckTimeout time.Duration, waitForComplete bool) error {
-	// Validate credentials
-	ghToken, err := requireEnv("GITHUB_TOKEN")
-	if err != nil {
-		return err
-	}
-
-	// LLM auth is handled by settings.json on the sprite (baked in during setup).
-	// Dispatch only validates that GITHUB_TOKEN is set for git operations.
+	// LLM auth is handled by settings.json on the sprite and GitHub auth is
+	// persisted on the sprite during setup.
 	_, _ = fmt.Fprintf(os.Stderr, "probing %s...\n", spriteName)
 	session, err := newSpriteSession(ctx, spriteName, spriteSessionOptions{probeTimeout: 15 * time.Second})
 	if err != nil {
@@ -140,8 +134,8 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 	if workspaceOverride == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "syncing repo %s (branch: %s)...\n", repo, defaultBranch)
 		syncScript := fmt.Sprintf(
-			`git config --global --add safe.directory %q 2>/dev/null; export GH_TOKEN=%q && cd %q && git checkout %q && git pull --ff-only 2>&1`,
-			workspace, ghToken, workspace, defaultBranch,
+			`git config --global --add safe.directory %q 2>/dev/null; cd %q && git checkout %q && git pull --ff-only 2>&1`,
+			workspace, workspace, defaultBranch,
 		)
 		syncCmd := s.CommandContext(ctx, "bash", "-c", syncScript)
 		if out, err := syncCmd.Output(); err != nil {
@@ -195,8 +189,8 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 		heartbeatSec = 30
 	}
 	ralphEnv := fmt.Sprintf(
-		`export MAX_ITERATIONS=%d MAX_TIME_SEC=%d ITER_TIMEOUT_SEC=%d HEARTBEAT_INTERVAL_SEC=%d WORKSPACE=%q GH_TOKEN=%q LEFTHOOK=0 ANTHROPIC_MODEL=%q ANTHROPIC_DEFAULT_SONNET_MODEL=%q CLAUDE_CODE_SUBAGENT_MODEL=%q`,
-		maxIter, totalSec, iterSec, heartbeatSec, workspace, ghToken,
+		`export MAX_ITERATIONS=%d MAX_TIME_SEC=%d ITER_TIMEOUT_SEC=%d HEARTBEAT_INTERVAL_SEC=%d WORKSPACE=%q LEFTHOOK=0 ANTHROPIC_MODEL=%q ANTHROPIC_DEFAULT_SONNET_MODEL=%q CLAUDE_CODE_SUBAGENT_MODEL=%q`,
+		maxIter, totalSec, iterSec, heartbeatSec, workspace,
 		spriteModel,
 		spriteModel,
 		spriteModel,
@@ -253,14 +247,14 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 
 	// 9. Verify work produced
 	_, _ = fmt.Fprintf(os.Stderr, "\n=== work produced ===\n")
-	verifyScript := verifyWorkScriptFor(workspace, ghToken, defaultBranch)
+	verifyScript := verifyWorkScriptFor(workspace, defaultBranch)
 	verifyCmd := s.CommandContext(ctx, "bash", "-c", verifyScript)
 	verifyCmd.Stdout = os.Stderr
 	verifyCmd.Stderr = os.Stderr
 	_ = verifyCmd.Run()
 
 	// 10. Snapshot PR CI status (informational; gating is controlled by --pr-check-timeout).
-	prs := snapshotPRChecksWithRunner(ctx, spriteBashRunner(s), workspace, ghToken)
+	prs := snapshotPRChecksWithRunner(ctx, spriteBashRunner(s), workspace)
 	_, _ = fmt.Fprintf(os.Stderr, "dispatch pr-checks: status=%s checks_exit=%d\n", prs.status, prs.checksExit)
 
 	// 11. Return appropriate exit code
@@ -319,7 +313,7 @@ func runDispatch(ctx context.Context, spriteName, prompt, repo, workspaceOverrid
 	if prCheckTimeout > 0 {
 		_, _ = fmt.Fprintf(os.Stderr, "\n=== waiting for PR checks (timeout %s) ===\n", prCheckTimeout)
 		pollInterval := 30 * time.Second
-		if err := waitForPRChecksWithRunner(ctx, spriteBashRunner(s), workspace, ghToken, prCheckTimeout, pollInterval, os.Stderr); err != nil {
+		if err := waitForPRChecksWithRunner(ctx, spriteBashRunner(s), workspace, prCheckTimeout, pollInterval, os.Stderr); err != nil {
 			return fmt.Errorf("PR checks: %w", err)
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "=== PR checks passed ===\n")

--- a/cmd/bb/dispatch_checks.go
+++ b/cmd/bb/dispatch_checks.go
@@ -357,15 +357,15 @@ func hasTaskCompleteSignalWithRunner(ctx context.Context, run spriteScriptRunner
 }
 
 // prChecksScriptFor builds the shell snippet that runs prChecksScript with
-// the given workspace and GitHub token. Shared by snapshot and wait-for-checks.
-func prChecksScriptFor(workspace, ghToken string) string {
-	return fmt.Sprintf("export WORKSPACE=%q GH_TOKEN=%q\n%s", workspace, ghToken, prChecksScript)
+// the given workspace. Shared by snapshot and wait-for-checks.
+func prChecksScriptFor(workspace string) string {
+	return fmt.Sprintf("export WORKSPACE=%q\n%s", workspace, prChecksScript)
 }
 
-func snapshotPRChecksWithRunner(ctx context.Context, run spriteScriptRunner, workspace, ghToken string) prCheckSummary {
+func snapshotPRChecksWithRunner(ctx context.Context, run spriteScriptRunner, workspace string) prCheckSummary {
 	_, exitCode, err := runDispatchCheck(ctx, run, dispatchCheck{
 		timeout: 30 * time.Second,
-		script:  prChecksScriptFor(workspace, ghToken),
+		script:  prChecksScriptFor(workspace),
 	})
 	if err != nil {
 		return prCheckSummary{status: "error", checksExit: -1}
@@ -386,11 +386,11 @@ func snapshotPRChecksWithRunner(ctx context.Context, run spriteScriptRunner, wor
 // line to progress on every poll interval so operators can see activity.
 //
 // prCheckTimeout == 0 is a no-op (returns nil immediately without calling run).
-func waitForPRChecksWithRunner(ctx context.Context, run spriteScriptRunner, workspace, ghToken string, prCheckTimeout, pollInterval time.Duration, progress io.Writer) error {
+func waitForPRChecksWithRunner(ctx context.Context, run spriteScriptRunner, workspace string, prCheckTimeout, pollInterval time.Duration, progress io.Writer) error {
 	return pollDispatchCheck(ctx, run, dispatchPollConfig{
 		check: dispatchCheck{
 			timeout: 30 * time.Second,
-			script:  prChecksScriptFor(workspace, ghToken),
+			script:  prChecksScriptFor(workspace),
 		},
 		waitTimeout:       prCheckTimeout,
 		pollInterval:      pollInterval,

--- a/cmd/bb/dispatch_test.go
+++ b/cmd/bb/dispatch_test.go
@@ -612,7 +612,7 @@ func TestVerifyWorkScriptForQuotesWorkspace(t *testing.T) {
 	t.Parallel()
 
 	workspace := `/tmp/run 123; touch /tmp/pwned`
-	script := verifyWorkScriptFor(workspace, "ghtoken123", "main")
+	script := verifyWorkScriptFor(workspace, "main")
 
 	if !strings.Contains(script, `WORKSPACE="/tmp/run 123; touch /tmp/pwned"`) {
 		t.Fatalf("verifyWorkScriptFor() missing quoted workspace: %q", script)
@@ -625,7 +625,7 @@ func TestVerifyWorkScriptForQuotesWorkspace(t *testing.T) {
 func TestVerifyWorkScriptForUsesDetectedBranch(t *testing.T) {
 	t.Parallel()
 
-	script := verifyWorkScriptFor("/tmp/ws", "ghtoken123", "development")
+	script := verifyWorkScriptFor("/tmp/ws", "development")
 
 	if !strings.Contains(script, `BRANCH="development"`) {
 		t.Fatalf("verifyWorkScriptFor() should set BRANCH to detected branch: %q", script)
@@ -951,7 +951,7 @@ func TestWaitForPRChecksReturnsNilWhenDisabled(t *testing.T) {
 	// without calling the runner.
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token", 0, 30*time.Second, &progress)
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", 0, 30*time.Second, &progress)
 	if err != nil {
 		t.Fatalf("expected nil error when disabled, got %v", err)
 	}
@@ -965,7 +965,7 @@ func TestWaitForPRChecksReturnsNilOnImmediatePass(t *testing.T) {
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("all checks pass\n"), err: nil}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token", time.Minute, time.Second, &progress)
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", time.Minute, time.Second, &progress)
 	if err != nil {
 		t.Fatalf("expected nil error on immediate pass, got %v", err)
 	}
@@ -980,7 +980,7 @@ func TestWaitForPRChecksTimesOut(t *testing.T) {
 	// Script always returns pending (exit 1).
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token", 50*time.Millisecond, 10*time.Millisecond, &progress)
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", 50*time.Millisecond, 10*time.Millisecond, &progress)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
@@ -1003,7 +1003,7 @@ func TestWaitForPRChecksEmitsProgress(t *testing.T) {
 	}
 
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), customRunner, "/tmp/ws", "token", 5*time.Second, 10*time.Millisecond, &progress)
+	err := waitForPRChecksWithRunner(context.Background(), customRunner, "/tmp/ws", 5*time.Second, 10*time.Millisecond, &progress)
 	if err != nil {
 		t.Fatalf("expected nil on second pass, got %v", err)
 	}
@@ -1020,25 +1020,25 @@ func TestWaitForPRChecksContextCancelled(t *testing.T) {
 
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(ctx, r.run, "/tmp/ws", "token", time.Minute, time.Second, &progress)
+	err := waitForPRChecksWithRunner(ctx, r.run, "/tmp/ws", time.Minute, time.Second, &progress)
 	if err == nil {
 		t.Fatal("expected error on cancelled context, got nil")
 	}
 }
 
-func TestWaitForPRChecksUsesWorkspaceAndToken(t *testing.T) {
+func TestWaitForPRChecksUsesWorkspace(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("pass\n"), err: nil}
 	var progress bytes.Buffer
-	if err := waitForPRChecksWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo", "ghtoken123", time.Minute, time.Second, &progress); err != nil {
+	if err := waitForPRChecksWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo", time.Minute, time.Second, &progress); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(r.script, "/home/sprite/workspace/myrepo") {
 		t.Fatalf("script = %q, want to contain workspace path", r.script)
 	}
-	if !strings.Contains(r.script, "ghtoken123") {
-		t.Fatalf("script = %q, want to contain GH token", r.script)
+	if strings.Contains(r.script, "GH_TOKEN") {
+		t.Fatalf("script = %q, should not contain GH token export", r.script)
 	}
 }
 
@@ -1051,7 +1051,7 @@ func TestWaitForPRChecksFatalErrorStopsImmediately(t *testing.T) {
 		return []byte("gh: command not found\n"), 2, nil // fatal error
 	}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws", "token",
+	err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws",
 		time.Minute, 10*time.Millisecond, &progress)
 	if err == nil {
 		t.Fatal("expected error on fatal exit code 2, got nil")
@@ -1073,7 +1073,7 @@ func TestWaitForPRChecksRetriesOnRunnerError(t *testing.T) {
 		return []byte("pass\n"), 0, nil // second call succeeds
 	}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws", "token",
+	err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws",
 		5*time.Second, 10*time.Millisecond, &progress)
 	if err != nil {
 		t.Fatalf("expected nil after retry success, got %v", err)
@@ -1119,7 +1119,7 @@ func TestWaitForPRChecksTreatsExitCode8AsPending(t *testing.T) {
 	}
 
 	var progress bytes.Buffer
-	if err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws", "token", time.Second, 10*time.Millisecond, &progress); err != nil {
+	if err := waitForPRChecksWithRunner(context.Background(), runner, "/tmp/ws", time.Second, 10*time.Millisecond, &progress); err != nil {
 		t.Fatalf("expected nil after pending exit code 8, got %v", err)
 	}
 	if !strings.Contains(progress.String(), "PR checks: pending") {
@@ -1132,7 +1132,7 @@ func TestWaitForPRChecksRejectsNonPositivePollInterval(t *testing.T) {
 
 	r := &fakeSpriteScriptRunner{}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token", time.Second, 0, &progress)
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", time.Second, 0, &progress)
 	if err == nil {
 		t.Fatal("expected error for non-positive poll interval")
 	}
@@ -1148,7 +1148,7 @@ func TestWaitForPRChecksPropagatesProgressWriterFailure(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: nil, err: nil}
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token", time.Second, 10*time.Millisecond, errWriter{err: errors.New("write failed")})
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", time.Second, 10*time.Millisecond, errWriter{err: errors.New("write failed")})
 	if err == nil {
 		t.Fatal("expected progress writer error")
 	}
@@ -1164,7 +1164,7 @@ func TestWaitForPRChecksInitialCheckBeforeTicker(t *testing.T) {
 	// the function would always time out without ever calling the runner.
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("pass\n"), err: nil}
 	var progress bytes.Buffer
-	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token",
+	err := waitForPRChecksWithRunner(context.Background(), r.run, "/tmp/ws",
 		50*time.Millisecond, // prCheckTimeout
 		time.Hour,           // pollInterval (ticker never fires)
 		&progress)
@@ -1297,7 +1297,7 @@ func TestSnapshotPRChecksReturnsPassOnExitCode0(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("pass\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "pass" {
 		t.Fatalf("status = %q, want %q", got.status, "pass")
@@ -1311,7 +1311,7 @@ func TestSnapshotPRChecksReturnsPendingOnExitCode1(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: []byte("check in progress\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "pending" {
 		t.Fatalf("status = %q, want %q", got.status, "pending")
@@ -1325,7 +1325,7 @@ func TestSnapshotPRChecksReturnsPendingOnExitCode8(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 8, out: []byte("checks pending\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "pending" {
 		t.Fatalf("status = %q, want %q", got.status, "pending")
@@ -1339,7 +1339,7 @@ func TestSnapshotPRChecksReturnsErrorOnExitCode2(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 2, out: []byte("no pr found\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "error" {
 		t.Fatalf("status = %q, want %q", got.status, "error")
@@ -1353,7 +1353,7 @@ func TestSnapshotPRChecksReturnsErrorOnRunnerError(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: nil, err: errors.New("network")}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "error" {
 		t.Fatalf("status = %q, want %q", got.status, "error")
@@ -1363,17 +1363,17 @@ func TestSnapshotPRChecksReturnsErrorOnRunnerError(t *testing.T) {
 	}
 }
 
-func TestSnapshotPRChecksUsesWorkspaceAndToken(t *testing.T) {
+func TestSnapshotPRChecksUsesWorkspace(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 0, out: []byte("pass\n"), err: nil}
-	_ = snapshotPRChecksWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo", "ghtoken123")
+	_ = snapshotPRChecksWithRunner(context.Background(), r.run, "/home/sprite/workspace/myrepo")
 
 	if !strings.Contains(r.script, "/home/sprite/workspace/myrepo") {
 		t.Fatalf("script = %q, want to contain workspace path", r.script)
 	}
-	if !strings.Contains(r.script, "ghtoken123") {
-		t.Fatalf("script = %q, want to contain GH token", r.script)
+	if strings.Contains(r.script, "GH_TOKEN") {
+		t.Fatalf("script = %q, should not contain GH token export", r.script)
 	}
 }
 
@@ -1391,7 +1391,7 @@ func TestSnapshotPRChecksHasDeadline(t *testing.T) {
 		return []byte("pass\n"), 0, nil
 	}
 
-	_ = snapshotPRChecksWithRunner(context.Background(), runner, "/tmp/ws", "token")
+	_ = snapshotPRChecksWithRunner(context.Background(), runner, "/tmp/ws")
 
 	if !deadlineSet {
 		t.Fatal("expected context to carry a deadline (30s timeout)")
@@ -1410,7 +1410,7 @@ func TestSnapshotPRChecksTaskCompleteWithPendingChecks(t *testing.T) {
 	t.Parallel()
 
 	r := &fakeSpriteScriptRunner{exitCode: 1, out: []byte("required check failed\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "pending" {
 		t.Fatalf("status = %q, want %q", got.status, "pending")
@@ -1430,7 +1430,7 @@ func TestSnapshotPRChecksReturnsErrorOnCancelledContext(t *testing.T) {
 		return nil, 0, ctx.Err()
 	}
 
-	got := snapshotPRChecksWithRunner(ctx, runner, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(ctx, runner, "/tmp/ws")
 
 	if got.status != "error" {
 		t.Fatalf("status = %q, want %q", got.status, "error")
@@ -1445,7 +1445,7 @@ func TestSnapshotPRChecksReturnsErrorOnUnexpectedExitCode(t *testing.T) {
 
 	// Exit 127 = command not found (gh missing on sprite)
 	r := &fakeSpriteScriptRunner{exitCode: 127, out: []byte("bash: gh: command not found\n"), err: nil}
-	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws", "token")
+	got := snapshotPRChecksWithRunner(context.Background(), r.run, "/tmp/ws")
 
 	if got.status != "error" {
 		t.Fatalf("status = %q, want %q", got.status, "error")
@@ -1458,13 +1458,13 @@ func TestSnapshotPRChecksReturnsErrorOnUnexpectedExitCode(t *testing.T) {
 func TestPRChecksScriptForIncludesWorkspaceAndToken(t *testing.T) {
 	t.Parallel()
 
-	script := prChecksScriptFor("/home/sprite/workspace/myrepo", "ghtoken123")
+	script := prChecksScriptFor("/home/sprite/workspace/myrepo")
 
 	if !strings.Contains(script, "/home/sprite/workspace/myrepo") {
 		t.Fatalf("script = %q, want to contain workspace path", script)
 	}
-	if !strings.Contains(script, "ghtoken123") {
-		t.Fatalf("script = %q, want to contain GH token", script)
+	if strings.Contains(script, "GH_TOKEN") {
+		t.Fatalf("script = %q, should not contain GH_TOKEN export", script)
 	}
 	if !strings.Contains(script, "gh pr checks HEAD") {
 		t.Fatalf("script = %q, want to contain gh pr checks command", script)

--- a/cmd/bb/setup.go
+++ b/cmd/bb/setup.go
@@ -49,6 +49,10 @@ func runSetup(ctx context.Context, spriteName, repo string, force bool, persona 
 	if err != nil {
 		return err
 	}
+	ghToken, err := requireEnv("GITHUB_TOKEN")
+	if err != nil {
+		return err
+	}
 
 	// 1. Probe
 	_, _ = fmt.Fprintf(os.Stderr, "probing %s...\n", spriteName)
@@ -138,12 +142,11 @@ func runSetup(ctx context.Context, spriteName, repo string, force bool, persona 
 
 	// 7. Git auth
 	_, _ = fmt.Fprintf(os.Stderr, "configuring git auth...\n")
-	gitAuthScript := `
-git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
-git config --global user.name "bitterblossom[bot]"
-git config --global user.email "bitterblossom@misty-step.dev"
-git config --global --add safe.directory '*'
-`
+	tokenPath := fmt.Sprintf("/tmp/bb-gh-token-%d", time.Now().UnixNano())
+	if err := s.Filesystem().WriteFileContext(ctx, tokenPath, []byte(ghToken+"\n"), 0600); err != nil {
+		return fmt.Errorf("upload github token: %w", err)
+	}
+	gitAuthScript := persistGitHubAuthScript(tokenPath)
 	if _, err := s.CommandContext(ctx, "bash", "-c", gitAuthScript).Output(); err != nil {
 		return fmt.Errorf("git auth: %w", err)
 	}
@@ -152,27 +155,8 @@ git config --global --add safe.directory '*'
 	if repo != "" {
 		_, _ = fmt.Fprintf(os.Stderr, "setting up repo %s...\n", repo)
 
-		ghToken := os.Getenv("GITHUB_TOKEN")
-		if ghToken == "" {
-			return fmt.Errorf("GITHUB_TOKEN must be set to clone repo")
-		}
-
 		repoDir := spriteRepoWorkspace(repo)
-
-		var cloneScript string
-		if force {
-			cloneScript = fmt.Sprintf(
-				`rm -rf %s && cd %s && git clone https://github.com/%s.git`,
-				repoDir, spriteWorkspaceRoot, repo,
-			)
-		} else {
-			cloneScript = fmt.Sprintf(
-				`if [ -d %s ]; then cd %s && git checkout master 2>/dev/null || git checkout main 2>/dev/null && git pull --ff-only; else cd %s && git clone https://github.com/%s.git; fi`,
-				repoDir, repoDir, spriteWorkspaceRoot, repo,
-			)
-		}
-
-		cloneScript = fmt.Sprintf("export GH_TOKEN=%q && %s", ghToken, cloneScript)
+		cloneScript := repoSetupScript(repoDir, repo, force)
 		cloneCmd := s.CommandContext(ctx, "bash", "-c", cloneScript)
 		cloneCmd.Stdout = os.Stderr
 		cloneCmd.Stderr = os.Stderr
@@ -196,6 +180,33 @@ git config --global --add safe.directory '*'
 
 	_, _ = fmt.Fprintf(os.Stderr, "setup complete: %s\n", spriteName)
 	return nil
+}
+
+func persistGitHubAuthScript(tokenPath string) string {
+	return fmt.Sprintf(`
+set -e
+trap 'rm -f %q' EXIT
+gh auth login --with-token < %q >/dev/null
+gh auth status >/dev/null
+git config --global credential.helper '!gh auth git-credential'
+git config --global user.name "bitterblossom[bot]"
+git config --global user.email "bitterblossom@misty-step.dev"
+git config --global --add safe.directory '*'
+`, tokenPath, tokenPath)
+}
+
+func repoSetupScript(repoDir, repo string, force bool) string {
+	if force {
+		return fmt.Sprintf(
+			`rm -rf %q && cd %q && git clone https://github.com/%s.git`,
+			repoDir, spriteWorkspaceRoot, repo,
+		)
+	}
+
+	return fmt.Sprintf(
+		`if [ -d %q ]; then cd %q && git checkout master 2>/dev/null || git checkout main 2>/dev/null && git pull --ff-only; else cd %q && git clone https://github.com/%s.git; fi`,
+		repoDir, repoDir, spriteWorkspaceRoot, repo,
+	)
 }
 
 func buildBaseConfigMap(root string) (map[string]string, error) {

--- a/cmd/bb/setup_test.go
+++ b/cmd/bb/setup_test.go
@@ -164,3 +164,35 @@ func TestBuildBaseConfigMapIncludesImportedSkillFilesRecursively(t *testing.T) {
 	assertRemote("base/skills/shape/SKILL.md", "/home/sprite/.claude/skills/shape/SKILL.md")
 	assertRemote("base/skills/shape/references/breadboarding.md", "/home/sprite/.claude/skills/shape/references/breadboarding.md")
 }
+
+func TestPersistGitHubAuthScriptUsesGhCredentialHelper(t *testing.T) {
+	t.Parallel()
+
+	script := persistGitHubAuthScript("/tmp/bb-gh-token")
+
+	if !strings.Contains(script, "gh auth login --with-token") {
+		t.Fatalf("script = %q, want gh auth login", script)
+	}
+	if !strings.Contains(script, "credential.helper '!gh auth git-credential'") {
+		t.Fatalf("script = %q, want gh auth git-credential helper", script)
+	}
+	if strings.Contains(script, "password=$GH_TOKEN") {
+		t.Fatalf("script = %q, should not use env-backed git credential helper", script)
+	}
+	if !strings.Contains(script, "trap 'rm -f") {
+		t.Fatalf("script = %q, want cleanup trap for token file", script)
+	}
+}
+
+func TestRepoSetupScriptDoesNotExportGHToken(t *testing.T) {
+	t.Parallel()
+
+	script := repoSetupScript("/home/sprite/workspace/repo", "misty-step/bitterblossom", false)
+
+	if strings.Contains(script, "GH_TOKEN") {
+		t.Fatalf("script = %q, should not export GH_TOKEN during repo setup", script)
+	}
+	if !strings.Contains(script, "git clone https://github.com/misty-step/bitterblossom.git") {
+		t.Fatalf("script = %q, want clone command", script)
+	}
+}

--- a/cmd/bb/status.go
+++ b/cmd/bb/status.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const ghAuthCheckScript = "gh auth status >/dev/null 2>&1"
+
 // parsePorcelainStatus parses `git status --porcelain=v1` output and returns
 // a slice of human-readable file-status lines (e.g. " M cmd/bb/status.go",
 // "?? newfile.go"). An empty input returns nil. This mirrors git status --short
@@ -66,6 +68,7 @@ func fleetStatus(ctx context.Context) error {
 		name   string
 		status string
 		reach  string
+		auth   string
 		avail  string
 		note   string
 	}
@@ -80,17 +83,26 @@ func fleetStatus(ctx context.Context) error {
 		go func(idx int, s *sprites.Sprite) {
 			defer func() { <-sem }()
 			defer wg.Done()
-			r := probeResult{name: s.Name(), status: s.Status, reach: "?", avail: "-"}
+			r := probeResult{name: s.Name(), status: s.Status, reach: "?", auth: "?", avail: "-"}
 
 			if err := probeSprite(ctx, s, s.Name(), 3*time.Second); err != nil {
 				r.reach = "no"
 				r.note = "unreachable"
 			} else {
 				r.reach = "ok"
+				auth, authErr := ghAuthStateWithRunner(ctx, spriteBashRunner(s))
+				if authErr != nil {
+					r.auth = "?"
+					r.note = "gh-auth check failed"
+				} else {
+					r.auth = auth
+				}
 				busy, busyErr := isDispatchLoopActive(ctx, s)
 				if busyErr != nil {
 					r.avail = "?"
-					r.note = "busy-check failed"
+					if r.note == "" {
+						r.note = "busy-check failed"
+					}
 				} else if busy {
 					r.avail = "busy"
 				} else {
@@ -104,10 +116,10 @@ func fleetStatus(ctx context.Context) error {
 
 	wg.Wait()
 
-	fmt.Printf("%-15s %-10s %-8s %-6s %s\n", "SPRITE", "STATUS", "REACH", "AVAIL", "NOTE")
-	fmt.Printf("%-15s %-10s %-8s %-6s %s\n", "------", "------", "-----", "-----", "----")
+	fmt.Printf("%-15s %-10s %-8s %-6s %-6s %s\n", "SPRITE", "STATUS", "REACH", "GH", "AVAIL", "NOTE")
+	fmt.Printf("%-15s %-10s %-8s %-6s %-6s %s\n", "------", "------", "-----", "--", "-----", "----")
 	for _, r := range results {
-		fmt.Printf("%-15s %-10s %-8s %-6s %s\n", r.name, r.status, r.reach, r.avail, r.note)
+		fmt.Printf("%-15s %-10s %-8s %-6s %-6s %s\n", r.name, r.status, r.reach, r.auth, r.avail, r.note)
 	}
 
 	return nil
@@ -130,6 +142,14 @@ func spriteStatus(ctx context.Context, spriteName string) error {
 	statusScript := `
 echo "=== signals ==="
 ` + workspaceStatusSignalsScript("WS") + `
+
+echo ""
+echo "=== gh auth ==="
+if ! command -v gh >/dev/null 2>&1; then
+  echo "(gh not installed)"
+elif ! gh auth status; then
+  echo "(gh auth unavailable)"
+fi
 
 echo ""
 echo "=== git ==="
@@ -175,4 +195,23 @@ fi
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func ghAuthStateWithRunner(ctx context.Context, run spriteScriptRunner) (string, error) {
+	output, exitCode, err := runDispatchCheck(ctx, run, dispatchCheck{
+		timeout: 10 * time.Second,
+		script:  ghAuthCheckScript,
+	})
+	if err != nil {
+		return "", fmt.Errorf("check gh auth: %w", err)
+	}
+
+	switch exitCode {
+	case 0:
+		return "ok", nil
+	case 1:
+		return "no", nil
+	default:
+		return "", fmt.Errorf("gh auth check exited %d: %s", exitCode, output)
+	}
 }

--- a/cmd/bb/status_test.go
+++ b/cmd/bb/status_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 )
 
@@ -104,5 +105,41 @@ func TestParsePorcelainStatus_CountMatchesLines(t *testing.T) {
 	lines := parsePorcelainStatus(input)
 	if len(lines) != 3 {
 		t.Errorf("expected 3 lines (matching dirty count), got %d", len(lines))
+	}
+}
+
+func TestGhAuthStateWithRunnerReturnsOK(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 0}
+	state, err := ghAuthStateWithRunner(context.Background(), r.run)
+	if err != nil {
+		t.Fatalf("ghAuthStateWithRunner() error = %v", err)
+	}
+	if state != "ok" {
+		t.Fatalf("state = %q, want %q", state, "ok")
+	}
+}
+
+func TestGhAuthStateWithRunnerReturnsNoOnUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 1}
+	state, err := ghAuthStateWithRunner(context.Background(), r.run)
+	if err != nil {
+		t.Fatalf("ghAuthStateWithRunner() error = %v", err)
+	}
+	if state != "no" {
+		t.Fatalf("state = %q, want %q", state, "no")
+	}
+}
+
+func TestGhAuthStateWithRunnerReturnsErrorOnUnexpectedExit(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeSpriteScriptRunner{exitCode: 127, out: []byte("gh missing")}
+	_, err := ghAuthStateWithRunner(context.Background(), r.run)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }

--- a/conductor/lib/conductor/cli.ex
+++ b/conductor/lib/conductor/cli.ex
@@ -196,11 +196,15 @@ defmodule Conductor.CLI do
 
     if fleet_sprites != [] do
       for s <- fleet_sprites do
-        reachable = Conductor.Sprite.reachable?(s.name)
+        case Conductor.Sprite.status(s.name, harness: s.harness) do
+          {:ok, status} ->
+            auth = if status.gh_authenticated, do: "gh auth ok", else: "gh auth missing"
+            health = if status.healthy, do: "healthy", else: "needs setup"
+            IO.puts("  #{s.name} (#{s.role}, #{s.harness}) — #{health}, #{auth}")
 
-        IO.puts(
-          "  #{s.name} (#{s.role}, #{s.harness}) — #{if reachable, do: "reachable", else: "unreachable"}"
-        )
+          {:error, _reason} ->
+            IO.puts("  #{s.name} (#{s.role}, #{s.harness}) — unreachable")
+        end
       end
     else
       IO.puts("  (no fleet loaded — run 'conductor start' first)")

--- a/conductor/lib/conductor/config.ex
+++ b/conductor/lib/conductor/config.ex
@@ -85,11 +85,9 @@ defmodule Conductor.Config do
 
   @spec dispatch_env() :: [{binary(), binary()}]
   def dispatch_env do
-    # Pass auth tokens to sprites. Use get_env (not fetch_env!) so command
-    # building never crashes — missing tokens surface at runtime on the sprite,
-    # which is the right failure boundary.
+    # Pass only the runtime API keys the harness still needs. GitHub auth is
+    # persisted on the sprite during setup and should not rely on env injection.
     []
-    |> maybe_env("GITHUB_TOKEN")
     |> maybe_env("OPENAI_API_KEY")
     |> maybe_env_as("OPENAI_API_KEY", "CODEX_API_KEY")
     |> maybe_env("EXA_API_KEY")

--- a/conductor/lib/conductor/fleet/reconciler.ex
+++ b/conductor/lib/conductor/fleet/reconciler.ex
@@ -83,22 +83,15 @@ defmodule Conductor.Fleet.Reconciler do
   end
 
   defp check_health(sprite) do
-    case Sprite.reachable?(sprite.name) do
-      false ->
+    case Sprite.status(sprite.name, harness: sprite.harness) do
+      {:error, _reason} ->
         :unreachable
 
-      true ->
-        harness_cmd =
-          case sprite.harness do
-            "codex" -> "command -v codex"
-            "claude-code" -> "command -v claude"
-            _ -> "echo ok"
-          end
+      {:ok, %{healthy: true}} ->
+        :healthy
 
-        case Sprite.exec(sprite.name, harness_cmd, timeout: 15_000) do
-          {:ok, _} -> :healthy
-          {:error, _, _} -> :needs_setup
-        end
+      {:ok, _status} ->
+        :needs_setup
     end
   end
 

--- a/conductor/lib/conductor/sprite.ex
+++ b/conductor/lib/conductor/sprite.ex
@@ -101,11 +101,27 @@ defmodule Conductor.Sprite do
     end
   end
 
-  @spec status(binary()) :: {:ok, map()} | {:error, term()}
-  def status(sprite) do
-    case exec(sprite, "echo ok", timeout: 15_000) do
-      {:ok, _} -> {:ok, %{sprite: sprite, reachable: true}}
-      {:error, msg, _} -> {:error, msg}
+  @spec status(binary(), keyword()) :: {:ok, map()} | {:error, term()}
+  def status(sprite, opts \\ []) do
+    exec_fn = Keyword.get(opts, :exec_fn, &exec/3)
+    harness = Keyword.get(opts, :harness)
+
+    case exec_fn.(sprite, "echo ok", timeout: 15_000) do
+      {:ok, _} ->
+        harness_ready = harness_ready?(sprite, harness, exec_fn)
+        gh_authenticated = gh_authenticated?(sprite, exec_fn)
+
+        {:ok,
+         %{
+           sprite: sprite,
+           reachable: true,
+           harness_ready: harness_ready,
+           gh_authenticated: gh_authenticated,
+           healthy: harness_ready and gh_authenticated
+         }}
+
+      {:error, msg, _} ->
+        {:error, msg}
     end
   end
 
@@ -141,6 +157,24 @@ defmodule Conductor.Sprite do
     @agent_process_names
     |> Enum.map_join(" || ", &"pgrep -x #{&1} 2>/dev/null")
     |> Kernel.<>(" || pgrep -f 'ralph\\.sh' 2>/dev/null")
+  end
+
+  defp harness_ready?(_sprite, nil, _exec_fn), do: true
+  defp harness_ready?(_sprite, "", _exec_fn), do: true
+
+  defp harness_ready?(sprite, harness, exec_fn) do
+    harness_cmd =
+      case harness do
+        "codex" -> "command -v codex"
+        "claude-code" -> "command -v claude"
+        _ -> "echo ok"
+      end
+
+    match?({:ok, _}, exec_fn.(sprite, harness_cmd, timeout: 15_000))
+  end
+
+  defp gh_authenticated?(sprite, exec_fn) do
+    match?({:ok, _}, exec_fn.(sprite, "gh auth status >/dev/null 2>&1", timeout: 15_000))
   end
 
   defp run_agent(sprite, workspace, prompt_path, harness, harness_opts, exec_fn, timeout_ms) do

--- a/conductor/test/conductor/config_dispatch_env_test.exs
+++ b/conductor/test/conductor/config_dispatch_env_test.exs
@@ -30,7 +30,7 @@ defmodule Conductor.ConfigDispatchEnvTest do
       end
     end
 
-    test "includes both GITHUB_TOKEN and OPENAI_API_KEY when both set" do
+    test "does not inject GITHUB_TOKEN even when OPENAI_API_KEY is set" do
       prev_gh = System.get_env("GITHUB_TOKEN")
       prev_oai = System.get_env("OPENAI_API_KEY")
       System.put_env("GITHUB_TOKEN", "ghp_test")
@@ -38,7 +38,7 @@ defmodule Conductor.ConfigDispatchEnvTest do
 
       try do
         env = Config.dispatch_env()
-        assert {"GITHUB_TOKEN", "ghp_test"} in env
+        refute {"GITHUB_TOKEN", "ghp_test"} in env
         assert {"OPENAI_API_KEY", "sk-test"} in env
       after
         if prev_gh,

--- a/conductor/test/conductor/sprite_dispatch_test.exs
+++ b/conductor/test/conductor/sprite_dispatch_test.exs
@@ -130,7 +130,7 @@ defmodule Conductor.SpriteDispatchTest do
       assert String.contains?(agent_cmd, "LEFTHOOK=0")
     end
 
-    test "injects GITHUB_TOKEN from env, shell-quoted" do
+    test "does not inject GITHUB_TOKEN from env" do
       prev = System.get_env("GITHUB_TOKEN")
       System.put_env("GITHUB_TOKEN", "ghp_test123")
 
@@ -147,13 +147,13 @@ defmodule Conductor.SpriteDispatchTest do
         assert_received {:exec_called, _}
         assert_received {:exec_called, _}
         assert_received {:exec_called, agent_cmd}
-        assert String.contains?(agent_cmd, "GITHUB_TOKEN='ghp_test123'")
+        refute String.contains?(agent_cmd, "GITHUB_TOKEN")
       after
         if prev, do: System.put_env("GITHUB_TOKEN", prev), else: System.delete_env("GITHUB_TOKEN")
       end
     end
 
-    test "omits env exports when GITHUB_TOKEN is unset" do
+    test "still omits GITHUB_TOKEN when unset" do
       prev = System.get_env("GITHUB_TOKEN")
       System.delete_env("GITHUB_TOKEN")
 

--- a/conductor/test/conductor/sprite_test.exs
+++ b/conductor/test/conductor/sprite_test.exs
@@ -1,0 +1,63 @@
+defmodule Conductor.SpriteTest do
+  use ExUnit.Case, async: true
+
+  alias Conductor.Sprite
+
+  defp exec_fn(responses) do
+    fn _sprite, command, _opts ->
+      Enum.find_value(responses, {:ok, ""}, fn {pattern, result} ->
+        if String.contains?(command, pattern), do: result
+      end)
+    end
+  end
+
+  test "status reports gh auth and harness readiness" do
+    status =
+      Sprite.status("bb-builder",
+        harness: "codex",
+        exec_fn:
+          exec_fn([
+            {"echo ok", {:ok, "ok\n"}},
+            {"command -v codex", {:ok, "/usr/bin/codex\n"}},
+            {"gh auth status", {:ok, "github.com\n"}}
+          ])
+      )
+
+    assert {:ok,
+            %{
+              reachable: true,
+              harness_ready: true,
+              gh_authenticated: true,
+              healthy: true
+            }} = status
+  end
+
+  test "status marks missing gh auth as unhealthy" do
+    status =
+      Sprite.status("bb-builder",
+        harness: "codex",
+        exec_fn:
+          exec_fn([
+            {"echo ok", {:ok, "ok\n"}},
+            {"command -v codex", {:ok, "/usr/bin/codex\n"}},
+            {"gh auth status", {:error, "not logged in", 1}}
+          ])
+      )
+
+    assert {:ok,
+            %{
+              reachable: true,
+              harness_ready: true,
+              gh_authenticated: false,
+              healthy: false
+            }} = status
+  end
+
+  test "status returns error when sprite is unreachable" do
+    assert {:error, "timeout"} =
+             Sprite.status("bb-builder",
+               harness: "codex",
+               exec_fn: fn _sprite, _command, _opts -> {:error, "timeout", 255} end
+             )
+  end
+end


### PR DESCRIPTION
## Summary
- persist GitHub CLI auth during `bb setup` and switch git credentials to `gh auth git-credential`
- remove GH token passthrough from sprite dispatch paths and verify auth in `bb status` plus conductor fleet health
- add Go and Elixir tests for persisted auth setup, health checks, and dispatch env behavior

## Testing
- go test ./...
- cd conductor && mix test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub authentication status now displayed in status output, showing whether authentication is configured and available

* **Improvements**
  * Enhanced status reporting with explicit authentication readiness checks
  * Improved setup flow with consolidated authentication handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->