### PR TITLE
fix: add issues:write permission to Cerberus workflow

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -1,31 +1,5 @@
 # Cerberus AI Code Review
 # https://github.com/misty-step/cerberus
-#
-# Drop this file into .github/workflows/cerberus.yml in your repository.
-# Set OPENROUTER_API_KEY in your repository secrets and you're done.
-#
-# Optional inputs:
-#   timeout:     Max seconds per reviewer (default: 600)
-#   model:       Override LLM model for all reviewers
-#   context:     Project context to calibrate reviewer severity (no secrets)
-#   reviewers:   Force specific reviewers, bypassing routing (e.g. trace,guard)
-#   fail-on-verdict: Fail when verdict is FAIL (default: true)
-#   fail-on-skip:    Fail when verdict is SKIP (default: false)
-#                    Recommended: set to "true" so timeout/API failures don't
-#                    silently appear as green checks.
-#
-# Example with options:
-#   jobs:
-#     review:
-#       uses: misty-step/cerberus/.github/workflows/cerberus.yml@master
-#       with:
-#         context: "Single-user personal finance app. Data bounded to ~500 tx/year."
-#         timeout: 900
-#       secrets:
-#         api-key: ${{ secrets.CERBERUS_OPENROUTER_API_KEY }}
-#
-# Power-user option (decomposed pipeline with full control):
-#   See templates/consumer-workflow-minimal.yml
 name: Cerberus
 
 on:
@@ -41,6 +15,7 @@ jobs:
     uses: misty-step/cerberus/.github/workflows/cerberus.yml@master
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     secrets:
       api-key: ${{ secrets.CERBERUS_OPENROUTER_API_KEY }}


### PR DESCRIPTION
Cerberus reusable workflow now requires `issues: write` permission. Without it, every PR review fails with `startup_failure`. Updated to match the current recommended consumer template from `misty-step/cerberus`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable additional automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->