### PR TITLE
fix: prevent concurrent builder sprite dispatch

### DIFF
--- a/conductor/lib/conductor/orchestrator.ex
+++ b/conductor/lib/conductor/orchestrator.ex
@@ -508,22 +508,28 @@ defmodule Conductor.Orchestrator do
 
   defp pick_worker(state) do
     count = length(state.worker_order)
-    occupied_workers = occupied_workers(state)
 
-    0..(count - 1)
-    |> Enum.reduce_while({:error, :no_available_workers, state}, fn offset,
-                                                                    {_status, _reason, acc} ->
-      candidate_index = rem(acc.worker_index + offset, count)
-      worker_name = Enum.at(acc.worker_order, candidate_index)
+    case occupied_workers(state) do
+      {:ok, occupied_workers} ->
+        0..(count - 1)
+        |> Enum.reduce_while({:error, :no_available_workers, state}, fn offset,
+                                                                        {_status, _reason, acc} ->
+          candidate_index = rem(acc.worker_index + offset, count)
+          worker_name = Enum.at(acc.worker_order, candidate_index)
 
-      case probe_and_reserve_worker(acc, worker_name, candidate_index, occupied_workers) do
-        {:ok, worker, next_state} ->
-          {:halt, {:ok, worker, next_state}}
+          case probe_and_reserve_worker(acc, worker_name, candidate_index, occupied_workers) do
+            {:ok, worker, next_state} ->
+              {:halt, {:ok, worker, next_state}}
 
-        {:error, next_state} ->
-          {:cont, {:error, :no_available_workers, next_state}}
-      end
-    end)
+            {:error, next_state} ->
+              {:cont, {:error, :no_available_workers, next_state}}
+          end
+        end)
+
+      {:error, reason} ->
+        Logger.warning("[dispatch] failed to read active workers: #{inspect(reason)}")
+        {:error, :no_available_workers, state}
+    end
   end
 
   defp probe_and_reserve_worker(state, worker_name, candidate_index, occupied_workers) do
@@ -551,24 +557,28 @@ defmodule Conductor.Orchestrator do
   end
 
   defp occupied_workers(state) do
-    state.active_runs
-    |> Enum.map(fn {_issue_number, run} -> run.worker end)
-    |> MapSet.new()
-    |> MapSet.union(store_active_workers())
+    in_memory_workers =
+      state.active_runs
+      |> Enum.map(fn {_issue_number, run} -> run.worker end)
+      |> MapSet.new()
+
+    case store_active_workers() do
+      {:ok, store_workers} -> {:ok, MapSet.union(in_memory_workers, store_workers)}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp store_active_workers do
-    Store.active_runs()
-    |> Map.keys()
-    |> MapSet.new()
+    {:ok,
+     Store.active_runs()
+     |> Map.keys()
+     |> MapSet.new()}
   rescue
     exception ->
-      Logger.warning("[dispatch] failed to read active workers: #{Exception.message(exception)}")
-      MapSet.new()
+      {:error, {:exception, Exception.message(exception)}}
   catch
     :exit, reason ->
-      Logger.warning("[dispatch] failed to read active workers: #{inspect(reason)}")
-      MapSet.new()
+      {:error, {:exit, reason}}
   end
 
   defp probe_worker(state, worker_name) do

--- a/conductor/lib/conductor/store.ex
+++ b/conductor/lib/conductor/store.ex
@@ -698,6 +698,13 @@ defmodule Conductor.Store do
           ON runs(repo, completed_at, picked_at)
           """,
           """
+          CREATE INDEX IF NOT EXISTS idx_runs_active_by_builder_and_picked
+          ON runs(builder_sprite, picked_at)
+          WHERE completed_at IS NULL
+            AND builder_sprite IS NOT NULL
+            AND builder_sprite != ''
+          """,
+          """
           CREATE INDEX IF NOT EXISTS idx_runs_repo_pr
           ON runs(repo, pr_number)
           """

--- a/conductor/test/conductor/orchestrator_test.exs
+++ b/conductor/test/conductor/orchestrator_test.exs
@@ -534,6 +534,9 @@ defmodule Conductor.OrchestratorTest do
       eventually(fn ->
         assert MockState.get(:started_runs) == [{401, "sprite-2"}]
       end)
+
+      assert_received {:probed, "sprite-2"}
+      refute_received {:probed, "sprite-1"}
     end
 
     test "does not start more runs than max_concurrent_runs allows" do


### PR DESCRIPTION
## Summary
- add `Store.active_runs/0` to group non-terminal runs by builder sprite
- skip occupied workers in the orchestrator before probing/dispatching
- cover store grouping, occupied-worker selection, and same-cycle deferral in orchestrator tests

## Testing
- `cd conductor && mix test test/conductor/orchestrator_test.exs`

Closes #709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worker selection now reliably skips already-occupied workers before probing, reducing incorrect dispatches and improving concurrent task handling.
  * Added defensive handling and logging when reading active runs so store read issues don't cause unhandled failures; dispatch will surface a handled error when no workers are available.

* **New Features**
  * New API to retrieve grouped active runs by builder sprite, excluding stale heartbeats.

* **Tests**
  * Added tests for worker occupancy, concurrent run behavior, and active-run grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->