### PR TITLE
fix: sync builder persona during workspace prep

### DIFF
--- a/conductor/lib/conductor/run_server.ex
+++ b/conductor/lib/conductor/run_server.ex
@@ -162,6 +162,9 @@ defmodule Conductor.RunServer do
 
         {:noreply, state, {:continue, :dispatch_builder}}
 
+      {:error, {:persona_sync_failed, path, reason}} ->
+        fail(%{state | worktree_path: path}, "workspace_preparation_failed", reason)
+
       {:error, reason} ->
         fail(state, "workspace_preparation_failed", reason)
     end

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -211,7 +211,7 @@ defmodule Conductor.Workspace do
 
         case sync_persona(sprite, worktree, role, sync_opts) do
           :ok -> {:ok, worktree}
-          {:error, reason} -> {:error, reason}
+          {:error, reason} -> {:error, {:persona_sync_failed, worktree, reason}}
         end
     end
   end

--- a/conductor/test/conductor/run_server_test.exs
+++ b/conductor/test/conductor/run_server_test.exs
@@ -164,7 +164,7 @@ defmodule Conductor.RunServerTest do
         _role ->
           case MockState.get(:sync_persona_result, :ok) do
             :ok -> MockState.get(:workspace_result, {:ok, "/tmp/test-worktree"})
-            {:error, reason} -> {:error, reason}
+            {:error, reason} -> {:error, {:persona_sync_failed, "/tmp/test-worktree", reason}}
           end
       end
     end
@@ -537,6 +537,7 @@ defmodule Conductor.RunServerTest do
       run = find_run(42)
       assert run["phase"] == "failed"
       assert "workspace_preparation_failed" in event_types(run["run_id"])
+      assert "workspace_cleaned" in event_types(run["run_id"])
       assert log =~ "workspace_preparation_failed: persona sync failed"
     end
   end

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -127,6 +127,42 @@ defmodule Conductor.WorkspaceTest do
       assert File.read!(Path.join(Workspace.persona_launch_dir(workspace, :weaver), "CLAUDE.md")) ==
                "shared claude\nweaver claude\n"
     end
+
+    test "preserves the prepared worktree path when persona sync fails" do
+      workspace =
+        Path.join(System.tmp_dir!(), "workspace-test-#{System.unique_integer([:positive])}")
+
+      source_root = minimal_persona_source_root(:weaver)
+      File.mkdir_p!(workspace)
+
+      on_exit(fn ->
+        File.rm_rf(workspace)
+        File.rm_rf(source_root)
+      end)
+
+      assert {:error,
+              {:persona_sync_failed, ^workspace, "persona sync failed (75): upload failed"}} =
+               Workspace.prepare(
+                 "bb-weaver",
+                 "misty-step/bitterblossom",
+                 "run-42-1773867376",
+                 "factory/42-1773867376",
+                 source_root: source_root,
+                 persona_role: :weaver,
+                 exec_fn: fn _sprite, command, opts ->
+                   cond do
+                     String.contains?(command, "git worktree add -b factory/42-1773867376") ->
+                       {:ok, workspace <> "\n"}
+
+                     command == "true" and Keyword.has_key?(opts, :files) ->
+                       {:error, "upload failed", 75}
+
+                     true ->
+                       {:ok, ""}
+                   end
+                 end
+               )
+    end
   end
 
   describe "sync_persona/4" do


### PR DESCRIPTION
## Summary
- move Weaver persona sync into workspace preparation and branch adoption
- pass the builder persona role through RunServer workspace prep instead of dispatch-time sync
- add coverage for persona materialization during prepare/adopt and the revised RunServer failure path

## Testing
- cd conductor && mix test test/conductor/workspace_test.exs test/conductor/prompt_test.exs test/conductor/sprite_dispatch_test.exs test/conductor/fixer_test.exs test/conductor/polisher_test.exs test/conductor/run_server_test.exs
- cd conductor && mix test

Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces can be prepared/adopted with a specified persona role so persona-specific content is integrated automatically.

* **Bug Fixes**
  * Persona sync failures are now reported distinctly and ensure workspace path is preserved and cleaned when runs fail.

* **Tests**
  * Added tests validating persona sync behavior, role-specific launch artifacts, and error handling for persona synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->