### PR TITLE
fix: make polisher robust to duplicate issue PRs

### DIFF
--- a/conductor/lib/conductor/polisher.ex
+++ b/conductor/lib/conductor/polisher.ex
@@ -193,7 +193,7 @@ defmodule Conductor.Polisher do
       if(needs_polish?(pr), do: 1, else: 0),
       latest_green_check_timestamp(pr),
       commit_count(pr),
-      parse_timestamp(pr["updatedAt"]),
+      parse_timestamp(pr["updatedAt"]) || 0,
       pr["number"] || 0
     }
   end

--- a/conductor/test/conductor/polisher_test.exs
+++ b/conductor/test/conductor/polisher_test.exs
@@ -438,6 +438,58 @@ defmodule Conductor.PolisherTest do
 
       assert log =~ "[fern] duplicate open PRs for issue #702: [728, 729]; selecting PR #729"
     end
+
+    test "falls back to commit count when duplicate PRs tie on green CI recency" do
+      shared_green_checks = [
+        %{
+          "name" => "Elixir Checks",
+          "conclusion" => "SUCCESS",
+          "status" => "COMPLETED",
+          "completedAt" => "2026-03-19T13:20:40Z"
+        }
+      ]
+
+      MockState.put(
+        :open_prs,
+        {:ok,
+         [
+           %{
+             "number" => 728,
+             "headRefName" => "factory/702-1773867376",
+             "title" => "refactor: remove dead shell scripts",
+             "body" => "Closes #702",
+             "labels" => [],
+             "statusCheckRollup" => shared_green_checks,
+             "updatedAt" => nil,
+             "commits" => [%{"oid" => "a1"}]
+           },
+           %{
+             "number" => 729,
+             "headRefName" => "cx/issue-702-delete-dead-scripts",
+             "title" => "refactor(runtime): remove dead script surface",
+             "body" => "Closes #702",
+             "labels" => [],
+             "statusCheckRollup" => shared_green_checks,
+             "updatedAt" => "2026-03-19T13:30:40Z",
+             "commits" => [%{"oid" => "b1"}, %{"oid" => "b2"}]
+           }
+         ]}
+      )
+
+      capture_log(fn ->
+        {:ok, _pid} =
+          Polisher.start_link(
+            repo: "test/repo",
+            polisher_sprite: "bb-fern",
+            poll_ms: 50
+          )
+
+        assert_receive {:review_comments_requested, 729}, 2_000
+        assert_receive {:dispatched, "bb-fern", prompt}, 2_000
+        assert prompt =~ "PR: #729"
+        refute prompt =~ "PR: #728"
+      end)
+    end
   end
 
   describe "status/0" do


### PR DESCRIPTION
## Summary
- detect when multiple open PRs reference the same issue and log the duplicate set clearly
- collapse duplicate issue groups to one scored candidate so Fern works the strongest PR instead of the first one returned
- cover duplicate selection with a polisher test that prefers the newer green candidate

## Testing
- `cd conductor && mix test test/conductor/polisher_test.exs`
- `cd conductor && mix test test/conductor/polisher_test.exs test/conductor/prompt_test.exs`

Closes #731.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and group duplicate pull requests referencing the same issue and pick the best candidate for processing using CI status, commit count, recency, and deterministic tiebreakers.
  * Emit warning logs listing duplicate PR groups and the selected PR.

* **Tests**
  * Added tests validating duplicate-PR grouping, selection of the stronger PR, and that processing targets the chosen PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->