### PR TITLE
fix(conductor): heredoc trailing newline broke sprite provisioning

### DIFF
--- a/conductor/lib/conductor/sprite.ex
+++ b/conductor/lib/conductor/sprite.ex
@@ -670,18 +670,26 @@ defmodule Conductor.Sprite do
   defp validate_repo(repo), do: {:error, "invalid repo format: #{inspect(repo)}"}
 
   defp repo_setup_script(repo_dir, repo, true) do
-    "rm -rf #{shell_quote(repo_dir)}" <>
-      " && cd #{shell_quote(@sprite_workspace_root)}" <>
-      " && git clone #{shell_quote(repo_clone_url(repo))}"
+    """
+    rm -rf #{shell_quote(repo_dir)} &&
+      cd #{shell_quote(@sprite_workspace_root)} &&
+      git clone #{shell_quote(repo_clone_url(repo))}
+    """
+    |> String.trim()
   end
 
   defp repo_setup_script(repo_dir, repo, false) do
-    "if [ -d #{shell_quote(repo_dir)} ]; then" <>
-      " cd #{shell_quote(repo_dir)}" <>
-      " && (git checkout master 2>/dev/null || git checkout main 2>/dev/null)" <>
-      " && git pull --ff-only;" <>
-      " else cd #{shell_quote(@sprite_workspace_root)}" <>
-      " && git clone #{shell_quote(repo_clone_url(repo))}; fi"
+    """
+    if [ -d #{shell_quote(repo_dir)} ]; then
+      cd #{shell_quote(repo_dir)} &&
+        (git checkout master 2>/dev/null || git checkout main 2>/dev/null) &&
+        git pull --ff-only
+    else
+      cd #{shell_quote(@sprite_workspace_root)} &&
+        git clone #{shell_quote(repo_clone_url(repo))}
+    fi
+    """
+    |> String.trim()
   end
 
   defp repo_clone_url(repo), do: "https://github.com/#{repo}.git"


### PR DESCRIPTION
## Why This Matters

Fresh sprites cannot provision. The `repo_setup_script/3` function used Elixir heredocs which append a trailing newline. When concatenated with `" && mkdir -p ..."`, this produced a bash syntax error:

```
git clone 'https://github.com/misty-step/bitterblossom.git'
 && mkdir -p '/home/sprite/workspace/bitterblossom/.claude/skills' ...
```

Bash rejects `&&` at the start of a new line after an empty continuation.

**Discovery:** All three sprites were destroyed and recreated (bb-builder had disk full from 107 accumulated checkpoints, bb-fixer/bb-polisher were cold/never-started). The reconciler's `provision` step failed on all three with the heredoc syntax error.

**Fix:** Keep the readable heredocs in both `repo_setup_script/3` branches and pipe each rendered script through `String.trim/1` before the later `" && mkdir -p ..."` concatenation. That preserves readability while removing the trailing newline that broke provisioning.

**Trade-offs:** None. This stays a pure bug fix with the same shell command structure, just without the trailing newline. The heredoc version only appeared to work earlier because existing sprites already had the repo cloned and the guarded path short-circuited first.

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 512 tests, 0 failures
- [x] Live verification: conductor booted with all 3 sprites healthy after destroy/recreate
