### PR TITLE
fix(conductor): validate workspace bash scripts

### DIFF
--- a/conductor/lib/conductor/shell.ex
+++ b/conductor/lib/conductor/shell.ex
@@ -45,6 +45,16 @@ defmodule Conductor.Shell do
     end
   end
 
+  @spec validate_bash(binary(), keyword()) :: :ok | {:error, binary()}
+  def validate_bash(command, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 10_000)
+
+    case cmd("bash", ["-n", "-c", command], timeout: timeout) do
+      {:ok, _output} -> :ok
+      {:error, output, _code} -> {:error, String.trim(output)}
+    end
+  end
+
   defp maybe_cd(opts, nil), do: opts
   defp maybe_cd(opts, cd), do: [{:cd, cd} | opts]
 end

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -7,7 +7,7 @@ defmodule Conductor.Workspace do
   """
 
   require Logger
-  alias Conductor.{Config, Sprite}
+  alias Conductor.{Config, Shell, Sprite}
   @mirror_base "/home/sprite/workspace"
   @safe_input ~r/^[a-zA-Z0-9_\-\.\/]+$/
   @persona_roles ~w(weaver thorn fern)
@@ -57,12 +57,15 @@ defmodule Conductor.Workspace do
     echo #{worktree}
     """
 
-    case exec_fn.(sprite, commands, timeout: 120_000) do
-      {:ok, output} ->
-        {:ok, extract_path(output)}
-
+    with :ok <- validate_workspace_command(commands, "workspace preparation"),
+         {:ok, output} <- exec_fn.(sprite, commands, timeout: 120_000) do
+      {:ok, extract_path(output)}
+    else
       {:error, msg, code} ->
         {:error, "workspace preparation failed (#{code}): #{msg}"}
+
+      {:error, msg} ->
+        {:error, msg}
     end
   end
 
@@ -141,12 +144,15 @@ defmodule Conductor.Workspace do
     echo #{worktree}
     """
 
-    case exec_fn.(sprite, commands, timeout: 120_000) do
-      {:ok, output} ->
-        {:ok, extract_path(output)}
-
+    with :ok <- validate_workspace_command(commands, "branch adoption"),
+         {:ok, output} <- exec_fn.(sprite, commands, timeout: 120_000) do
+      {:ok, extract_path(output)}
+    else
       {:error, msg, code} ->
         {:error, "branch adoption failed (#{code}): #{msg}"}
+
+      {:error, msg} ->
+        {:error, msg}
     end
   end
 
@@ -175,12 +181,15 @@ defmodule Conductor.Workspace do
     '
     """
 
-    case exec_fn.(sprite, commands, timeout: 60_000) do
-      {:ok, _} ->
-        verify_cleanup_health(sprite, repo, branch, opts)
-
+    with :ok <- validate_workspace_command(commands, "workspace cleanup"),
+         {:ok, _} <- exec_fn.(sprite, commands, timeout: 60_000) do
+      verify_cleanup_health(sprite, repo, branch, opts)
+    else
       {:error, msg, _} ->
         Logger.warning("[workspace] cleanup command failed for #{run_id} on #{sprite}: #{msg}")
+        {:error, msg}
+
+      {:error, msg} ->
         {:error, msg}
     end
   end
@@ -211,15 +220,18 @@ defmodule Conductor.Workspace do
     #{stale_worktree_list_command(branch)}
     """
 
-    case exec_fn.(sprite, commands, timeout: 30_000) do
-      {:ok, output} ->
-        case parse_stale_worktrees(output) do
-          [] -> {:ok, :clean}
-          paths -> {:error, {:stale_worktrees, paths}}
-        end
-
+    with :ok <- validate_workspace_command(commands, "workspace health check"),
+         {:ok, output} <- exec_fn.(sprite, commands, timeout: 30_000) do
+      case parse_stale_worktrees(output) do
+        [] -> {:ok, :clean}
+        paths -> {:error, {:stale_worktrees, paths}}
+      end
+    else
       {:error, msg, code} ->
         {:error, "workspace health check failed (#{code}): #{msg}"}
+
+      {:error, msg} ->
+        {:error, msg}
     end
   end
 
@@ -269,7 +281,7 @@ defmodule Conductor.Workspace do
 
   defp stale_worktree_cleanup_commands(branch) do
     """
-    #{stale_worktree_list_command(branch)} | while IFS= read -r path; do
+    while IFS= read -r path; do
       [ -n "$path" ] || continue
       if [ "$path" = "$(pwd)" ]; then
         git checkout "$default_branch" --quiet 2>/dev/null || true
@@ -277,7 +289,9 @@ defmodule Conductor.Workspace do
         git worktree remove --force "$path" 2>/dev/null || true
         rm -rf "$path" 2>/dev/null || true
       fi
-    done
+    done < <(
+    #{stale_worktree_list_command(branch)}
+    )
     """
   end
 
@@ -584,5 +598,12 @@ defmodule Conductor.Workspace do
   defp shell_quote(value) do
     escaped = value |> to_string() |> String.replace("'", "'\"'\"'")
     "'#{escaped}'"
+  end
+
+  defp validate_workspace_command(command, context) do
+    case Shell.validate_bash(command) do
+      :ok -> :ok
+      {:error, message} -> {:error, "#{context} command failed bash validation: #{message}"}
+    end
   end
 end

--- a/conductor/test/conductor/shell_test.exs
+++ b/conductor/test/conductor/shell_test.exs
@@ -1,0 +1,21 @@
+defmodule Conductor.ShellTest do
+  use ExUnit.Case, async: true
+
+  alias Conductor.Shell
+
+  describe "validate_bash/2" do
+    test "accepts valid bash" do
+      assert :ok = Shell.validate_bash("set -e\nprintf 'ok\\n'\n")
+    end
+
+    test "returns the parser error for invalid bash" do
+      assert {:error, message} =
+               Shell.validate_bash(
+                 "printf 'ok\\n'\n| while read -r line; do\n  echo \"$line\"\ndone\n"
+               )
+
+      assert message =~ "syntax error"
+      assert message =~ "unexpected token `|'"
+    end
+  end
+end

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -4,6 +4,27 @@ defmodule Conductor.WorkspaceTest do
   alias Conductor.Workspace
 
   describe "prepare/5" do
+    test "emits bash-parseable workspace preparation commands" do
+      parent = self()
+
+      exec_fn = fn _sprite, command, _opts ->
+        send(parent, {:prepare_command, command})
+        {:ok, "/tmp/test-worktree\n"}
+      end
+
+      assert {:ok, "/tmp/test-worktree"} =
+               Workspace.prepare(
+                 "bb-weaver",
+                 "misty-step/bitterblossom",
+                 "run-42-1773867376",
+                 "factory/42-1773867376",
+                 exec_fn: exec_fn
+               )
+
+      assert_received {:prepare_command, command}
+      assert_bash_valid(command)
+    end
+
     test "installs a branch guard hook for the prepared branch" do
       parent = self()
 
@@ -46,6 +67,27 @@ defmodule Conductor.WorkspaceTest do
   end
 
   describe "adopt_branch/5" do
+    test "emits bash-parseable branch adoption commands" do
+      parent = self()
+
+      exec_fn = fn _sprite, command, _opts ->
+        send(parent, {:adopt_command, command})
+        {:ok, "/tmp/test-worktree\n"}
+      end
+
+      assert {:ok, "/tmp/test-worktree"} =
+               Workspace.adopt_branch(
+                 "bb-weaver",
+                 "misty-step/bitterblossom",
+                 "run-42-1773867376",
+                 "factory/42-1773867376",
+                 exec_fn: exec_fn
+               )
+
+      assert_received {:adopt_command, command}
+      assert_bash_valid(command)
+    end
+
     test "installs the same branch guard when adopting an existing branch" do
       parent = self()
 
@@ -276,6 +318,26 @@ defmodule Conductor.WorkspaceTest do
   end
 
   describe "cleanup/4" do
+    test "emits bash-parseable cleanup commands" do
+      parent = self()
+
+      exec_fn = fn _sprite, command, _opts ->
+        send(parent, {:cleanup_command, command})
+        {:ok, ""}
+      end
+
+      assert :ok =
+               Workspace.cleanup(
+                 "bb-weaver",
+                 "misty-step/bitterblossom",
+                 "custom-123",
+                 exec_fn: exec_fn
+               )
+
+      assert_received {:cleanup_command, command}
+      assert_bash_valid(command)
+    end
+
     test "removes all worktrees for the run branch before deleting the branch" do
       parent = self()
 
@@ -449,6 +511,13 @@ defmodule Conductor.WorkspaceTest do
     case System.cmd("bash", ["-lc", command], stderr_to_stdout: true) do
       {output, 0} -> {:ok, output}
       {output, code} -> {:error, output, code}
+    end
+  end
+
+  defp assert_bash_valid(command) do
+    case System.cmd("bash", ["-n", "-c", command], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, code} -> flunk("expected valid bash script, got exit #{code}: #{output}")
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix workspace stale-worktree cleanup to use valid bash process substitution instead of a malformed leading pipe
- validate generated workspace shell snippets with a reusable bash parser check before execution
- add targeted tests for shell validation and workspace prepare/adopt/cleanup command syntax

Closes #794

## Verification
- cd conductor && mix test test/conductor/shell_test.exs test/conductor/workspace_test.exs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bash syntax validation for workspace commands to catch errors early with clear, actionable error messages.

* **Tests**
  * Added comprehensive tests to verify workspace operations generate syntactically valid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->