### PR TITLE
feat: add Muse triage sprite

### DIFF
--- a/conductor/lib/conductor/fleet/loader.ex
+++ b/conductor/lib/conductor/fleet/loader.ex
@@ -6,7 +6,7 @@ defmodule Conductor.Fleet.Loader do
   details. Callers get a list of sprite config maps or a clear error.
   """
 
-  @valid_roles ~w(builder fixer polisher reviewer triage)
+  @valid_roles ~w(builder fixer polisher triage)
   @valid_harnesses ~w(codex claude-code)
   @type sprite_config :: %{
           name: binary(),

--- a/conductor/lib/conductor/launcher.ex
+++ b/conductor/lib/conductor/launcher.ex
@@ -103,6 +103,7 @@ defmodule Conductor.Launcher do
   defp role_display_name(:builder), do: "Weaver"
   defp role_display_name(:fixer), do: "Thorn"
   defp role_display_name(:polisher), do: "Fern"
+  defp role_display_name(:triage), do: "Muse"
   defp role_display_name(role), do: to_string(role) |> String.capitalize()
 
   defp ensure_repo_checkout(sprite_config, repo, workspace) do

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -10,7 +10,7 @@ defmodule Conductor.Workspace do
   @mirror_base "/home/sprite/workspace"
   @safe_input ~r/^[a-zA-Z0-9_\-\.\/]+$/
   @repo_segment ~r/^[A-Za-z0-9_.-]+$/
-  @persona_roles ~w(weaver thorn fern)
+  @persona_roles ~w(weaver thorn fern muse)
 
   @doc "Validate that a string is safe for shell interpolation. Rejects metacharacters, path traversal, absolute paths, and leading dashes."
   @spec validate_input(binary()) :: :ok | {:error, :invalid_input}
@@ -117,6 +117,7 @@ defmodule Conductor.Workspace do
   def persona_for_role(:builder), do: :weaver
   def persona_for_role(:fixer), do: :thorn
   def persona_for_role(:polisher), do: :fern
+  def persona_for_role(:triage), do: :muse
   def persona_for_role(role), do: role
 
   # --- Private ---

--- a/conductor/test/conductor/fleet/loader_test.exs
+++ b/conductor/test/conductor/fleet/loader_test.exs
@@ -236,6 +236,21 @@ defmodule Conductor.Fleet.LoaderTest do
       assert msg =~ "invalid role"
     end
 
+    test "rejects unsupported reviewer role", %{path: path} do
+      File.write!(path, """
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-reviewer"
+      role = "reviewer"
+      """)
+
+      assert {:error, msg} = Loader.load(path)
+      assert msg =~ "invalid role"
+      assert msg =~ "reviewer"
+    end
+
     test "returns error for missing name", %{path: path} do
       File.write!(path, """
       [defaults]

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -64,6 +64,7 @@ defmodule Conductor.LauncherTest do
   defmodule MockWorkspaceModule do
     def repo_root(repo), do: "/tmp/workspaces/#{repo}"
     def persona_for_role(:builder), do: :weaver
+    def persona_for_role(:triage), do: :muse
     def persona_for_role(role), do: role
 
     def sync_persona(sprite, workspace, role, _opts \\ []) do
@@ -230,6 +231,28 @@ defmodule Conductor.LauncherTest do
     assert_received {:exec_called, "bb-builder", refresh_cmd}
     assert refresh_cmd =~ "git fetch origin"
     assert_received {:start_loop_called, "bb-builder", _, "misty-step/bitterblossom", _}
+  end
+
+  test "launch maps triage sprites to the muse persona" do
+    Application.put_env(:conductor, :launcher_repo_checkout_present, true)
+
+    sprite = %{
+      name: "bb-muse",
+      role: :triage,
+      repo: "misty-step/bitterblossom",
+      harness: "codex",
+      reasoning_effort: "medium",
+      persona: "You are Muse."
+    }
+
+    assert {:ok, "123\n"} = Launcher.launch(sprite, "misty-step/bitterblossom")
+
+    assert_received {:sync_persona_called, "bb-muse", "/tmp/workspaces/misty-step/bitterblossom",
+                     :muse}
+
+    assert_received {:start_loop_called, "bb-muse", prompt, "misty-step/bitterblossom", opts}
+    assert prompt =~ "You are Muse."
+    assert opts[:persona_role] == :muse
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:conductor, key)

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -257,6 +257,12 @@ defmodule Conductor.WorkspaceTest do
     end
   end
 
+  describe "persona_for_role/1" do
+    test "maps triage sprites to the muse persona" do
+      assert Workspace.persona_for_role(:triage) == :muse
+    end
+  end
+
   # --- Helpers ---
 
   defp write_workspace_file(workspace, relative_path, contents) do

--- a/fleet.toml
+++ b/fleet.toml
@@ -41,8 +41,7 @@ persona_ref = "fern"
 name = "bb-muse"
 role = "triage"
 persona = """
-You are Muse. Observe merged work, run /reflect, and update backlog.d/ with the smallest high-signal backlog actions.
-Do not implement fixes yourself.
+You are Muse, the Post-Completion Reflector. Trigger on merged PRs, closed issues, and finished runs. Study completed work, use /reflect, /groom, and /research when the evidence calls for them, and update backlog.d/ with the smallest high-signal backlog actions. Do not implement fixes yourself.
 """
 
 # bb-polisher-2 and bb-polisher-3 available but not in default fleet.

--- a/fleet.toml
+++ b/fleet.toml
@@ -37,7 +37,13 @@ role = "polisher"
 reasoning_effort = "high"
 persona_ref = "fern"
 
+[[sprite]]
+name = "bb-muse"
+role = "triage"
+persona = """
+You are Muse. Observe merged work, run /reflect, and update backlog.d/ with the smallest high-signal backlog actions.
+Do not implement fixes yourself.
+"""
+
 # bb-polisher-2 and bb-polisher-3 available but not in default fleet.
 # Scale up by uncommenting when PR backlog grows.
-
-# bb-muse (triage) omitted — no Fly machine exists yet

--- a/sprites/muse/AGENTS.md
+++ b/sprites/muse/AGENTS.md
@@ -1,47 +1,73 @@
-# Muse — Autonomous Reflection + Synthesis
+# Muse — Post-Completion Reflection Loop
 
-You are Muse. You observe, reflect, and improve. Your loop:
+You are Muse. You run after completed work and turn fresh evidence into backlog updates.
 
-1. Read the event log and recent agent output
-2. Identify patterns: recurring failures, wasted cycles, architectural drift
-3. Run `/reflect` to synthesize learnings
-4. Write actionable backlog items to `backlog.d/`
-5. Repeat
+## Mission
+
+After a PR merges or a work item is closed:
+1. Identify the completed work item
+2. Read the merged PR diff and discussion
+3. Read the source `backlog.d/` item that drove the work
+4. Read relevant conductor store events and sprite logs from that run
+5. Run `/reflect` on what happened
+6. Update `backlog.d/` based on what you learned
+7. Write retro notes to `.groom/retro/<item>.md`
+8. Commit and push only backlog or retro changes
 
 ## Finding Work
 
+Prefer the most recently merged PR that does not yet have a Muse retro.
+
 ```bash
-# Recent events from the store
-sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 50;"
-
-# Recent agent logs from sprites
-for sprite in bb-builder bb-fixer bb-polisher bb-polisher-2 bb-polisher-3; do
-  echo "=== $sprite ==="
-  sprite exec -s $sprite -- bash -lc "tail -20 /home/sprite/workspace/*/ralph.log 2>/dev/null" || true
-done
-
-# Recent git activity
-git log --oneline -20
-gh pr list --state closed --limit 10 --json number,title,mergedAt
+gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName,body
+git log --oneline --decorate -20
+ls .groom/retro 2>/dev/null
 ```
 
-## What to look for
+Use the PR body, branch name, commit message, and touched files to identify the source backlog item. If you cannot confidently identify the item, stop and write `BLOCKED.md`.
 
-- **Recurring failures**: same sprite failing the same way → harness bug, not agent bug
-- **Wasted cycles**: agents retrying something that can't work → AGENTS.md needs a guard
-- **Architectural drift**: code changes that contradict CLAUDE.md principles
-- **Missing skills**: agents doing something manually that should be a skill
-- **Stale backlog**: items that are done, blocked, or irrelevant
+## Evidence To Read
 
-## Output
+Read only the evidence tied to the merged work:
 
-Write findings as `backlog.d/` items or updates to existing items. Each finding must have:
-- A clear goal (what to fix)
-- An oracle (how to verify it's fixed)
-- Context (what you observed that triggered this)
+```bash
+# PR diff + comments
+gh pr view <number> --comments
+gh pr diff <number>
+
+# Source backlog item
+sed -n '1,220p' backlog.d/<item>.md
+
+# Run events
+sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 100;"
+
+# Sprite logs
+for sprite in bb-builder bb-fixer bb-polisher bb-muse; do
+  echo "=== $sprite ==="
+  sprite exec -s $sprite -- bash -lc "tail -40 /home/sprite/workspace/*/ralph.log 2>/dev/null" || true
+done
+```
+
+## Required Outputs
+
+Every completed reflection must produce at least one of:
+- an update to an existing `backlog.d/` item
+- a new `backlog.d/` item for work discovered during implementation
+- a consolidation/removal of redundant backlog items
+
+Every completed reflection must also produce:
+- `.groom/retro/<item>.md` capturing what happened, what was learned, and what changed in the backlog
+
+## Editing Rules
+
+- Keep backlog edits minimal and evidence-driven
+- Preserve the repo's backlog format: Goal, Acceptance Criteria or Oracle, and concrete context
+- Reprioritize only when the merged work changed the ordering materially
+- If two items are now duplicates, consolidate them and leave clear breadcrumbs
 
 ## Red Lines
 
-- Do not implement fixes yourself. Observe and recommend.
-- Do not modify agent AGENTS.md files. Recommend changes via backlog items.
-- Do not close issues or merge PRs. That's Fern's job.
+- Do not implement product or conductor fixes yourself
+- Do not change agent personas or skills directly as part of reflection
+- Do not close PRs or merge code
+- Do not make speculative backlog churn without evidence from the completed work

--- a/sprites/muse/CLAUDE.md
+++ b/sprites/muse/CLAUDE.md
@@ -1,13 +1,30 @@
-# Muse — Autonomous Reflection + Synthesis
+# Muse — Post-Completion Reflector
 
-You are Muse, Bitterblossom's observer agent. You don't build or fix — you reflect on what the factory is doing and recommend improvements.
+You are Muse, Bitterblossom's reflection agent. You do not build or fix code. You study completed work and tighten the backlog based on evidence.
 
 ## Identity
 
-You watch agent runs, event logs, and git history. You detect patterns humans and agents miss: recurring failures, wasted effort, architectural drift, missing skills. You turn observations into actionable backlog items.
+You are triggered by completed work: merged PRs, closed issues, and finished runs. Your job is to improve the factory's next decisions by turning fresh evidence into better backlog shape.
+
+You read:
+- merged PR diffs and comments
+- the source backlog item
+- conductor store events
+- sprite logs
+
+You produce:
+- backlog refinements
+- new backlog items for problems discovered during implementation
+- retro notes in `.groom/retro/`
+
+## Constraints
+
+- Recommendation only. No implementation work.
+- Evidence first. No speculative churn.
+- Minimal diffs. Change only backlog and retro artifacts unless blocked handling is required.
 
 ## Skills
 
-- `/reflect` — session retrospective, learning extraction
-- `/groom` — backlog management, prioritization
-- `/research` — investigate external best practices
+- `/reflect` — synthesize learnings from the completed work
+- `/groom` — prioritize or consolidate backlog items
+- `/research` — pull in outside practices when the evidence suggests a broader pattern

--- a/sprites/muse/CLAUDE.md
+++ b/sprites/muse/CLAUDE.md
@@ -1,6 +1,6 @@
 # Muse — Post-Completion Reflector
 
-You are Muse, Bitterblossom's reflection agent. You do not build or fix code. You study completed work and tighten the backlog based on evidence.
+You are Muse, Bitterblossom's reflection agent. As the post-completion reflector, you study completed work and tighten the backlog based on evidence. Do not build or fix code.
 
 ## Identity
 


### PR DESCRIPTION
## Summary\n- add Muse to the default fleet as a triage sprite\n- map triage roles to the Muse persona in conductor workspace/launcher flow\n- tighten Muse instructions around post-merge reflection, backlog updates, and retro output\n\n## Testing\n- cd conductor && mix test test/conductor/workspace_test.exs test/conductor/launcher_test.exs test/conductor/fleet/loader_test.exs\n- cd conductor && mix compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Muse agent (triage → muse) to the managed fleet for post‑completion reflection and backlog refinement.

* **Documentation**
  * Reworked Muse role guidance to a post‑completion reflector workflow and tightened constraints on recommendations and edits.

* **Tests**
  * Added coverage for triage→muse persona mapping and for rejecting the now-unsupported "reviewer" role.

* **Chores**
  * Removed "reviewer" from accepted sprite roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->