### PR TITLE
feat: wire muse triage persona

### DIFF
--- a/conductor/lib/conductor/fleet/loader.ex
+++ b/conductor/lib/conductor/fleet/loader.ex
@@ -6,7 +6,7 @@ defmodule Conductor.Fleet.Loader do
   details. Callers get a list of sprite config maps or a clear error.
   """
 
-  @valid_roles ~w(builder fixer polisher reviewer triage)
+  @valid_roles ~w(builder fixer polisher triage)
   @valid_harnesses ~w(codex claude-code)
   @type sprite_config :: %{
           name: binary(),

--- a/conductor/lib/conductor/launcher.ex
+++ b/conductor/lib/conductor/launcher.ex
@@ -103,6 +103,7 @@ defmodule Conductor.Launcher do
   defp role_display_name(:builder), do: "Weaver"
   defp role_display_name(:fixer), do: "Thorn"
   defp role_display_name(:polisher), do: "Fern"
+  defp role_display_name(:triage), do: "Muse"
   defp role_display_name(role), do: to_string(role) |> String.capitalize()
 
   defp ensure_repo_checkout(sprite_config, repo, workspace) do

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -10,7 +10,7 @@ defmodule Conductor.Workspace do
   @mirror_base "/home/sprite/workspace"
   @safe_input ~r/^[a-zA-Z0-9_\-\.\/]+$/
   @repo_segment ~r/^[A-Za-z0-9_.-]+$/
-  @persona_roles ~w(weaver thorn fern)
+  @persona_roles ~w(weaver thorn fern muse)
 
   @doc "Validate that a string is safe for shell interpolation. Rejects metacharacters, path traversal, absolute paths, and leading dashes."
   @spec validate_input(binary()) :: :ok | {:error, :invalid_input}
@@ -117,6 +117,7 @@ defmodule Conductor.Workspace do
   def persona_for_role(:builder), do: :weaver
   def persona_for_role(:fixer), do: :thorn
   def persona_for_role(:polisher), do: :fern
+  def persona_for_role(:triage), do: :muse
   def persona_for_role(role), do: role
 
   # --- Private ---

--- a/conductor/test/conductor/fleet/loader_test.exs
+++ b/conductor/test/conductor/fleet/loader_test.exs
@@ -236,6 +236,20 @@ defmodule Conductor.Fleet.LoaderTest do
       assert msg =~ "invalid role"
     end
 
+    test "rejects reviewer role because no reviewer persona exists", %{path: path} do
+      File.write!(path, """
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-reviewer"
+      role = "reviewer"
+      """)
+
+      assert {:error, msg} = Loader.load(path)
+      assert msg =~ "invalid role 'reviewer'"
+    end
+
     test "returns error for missing name", %{path: path} do
       File.write!(path, """
       [defaults]

--- a/conductor/test/conductor/fleet/loader_test.exs
+++ b/conductor/test/conductor/fleet/loader_test.exs
@@ -236,7 +236,7 @@ defmodule Conductor.Fleet.LoaderTest do
       assert msg =~ "invalid role"
     end
 
-    test "rejects reviewer role because no reviewer persona exists", %{path: path} do
+    test "rejects reviewer as an invalid role", %{path: path} do
       File.write!(path, """
       [defaults]
       repo = "test/repo"

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -63,8 +63,7 @@ defmodule Conductor.LauncherTest do
 
   defmodule MockWorkspaceModule do
     def repo_root(repo), do: "/tmp/workspaces/#{repo}"
-    def persona_for_role(:builder), do: :weaver
-    def persona_for_role(role), do: role
+    defdelegate persona_for_role(role), to: Conductor.Workspace
 
     def sync_persona(sprite, workspace, role, _opts \\ []) do
       if pid = Application.get_env(:conductor, :launcher_test_pid) do
@@ -230,6 +229,28 @@ defmodule Conductor.LauncherTest do
     assert_received {:exec_called, "bb-builder", refresh_cmd}
     assert refresh_cmd =~ "git fetch origin"
     assert_received {:start_loop_called, "bb-builder", _, "misty-step/bitterblossom", _}
+  end
+
+  test "launch maps triage sprites to Muse persona and prompt" do
+    Application.put_env(:conductor, :launcher_repo_checkout_present, false)
+
+    sprite = %{
+      name: "bb-muse",
+      role: :triage,
+      repo: "misty-step/bitterblossom",
+      harness: "codex",
+      reasoning_effort: "medium",
+      persona: "You are Muse."
+    }
+
+    assert {:ok, "123\n"} = Launcher.launch(sprite, "misty-step/bitterblossom")
+
+    assert_received {:sync_persona_called, "bb-muse", "/tmp/workspaces/misty-step/bitterblossom",
+                     :muse}
+
+    assert_received {:start_loop_called, "bb-muse", prompt, "misty-step/bitterblossom", _opts}
+    assert prompt =~ "# Muse Loop"
+    assert prompt =~ "You are Muse."
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:conductor, key)

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -257,6 +257,12 @@ defmodule Conductor.WorkspaceTest do
     end
   end
 
+  describe "persona_for_role/1" do
+    test "maps triage sprites to the muse persona" do
+      assert Workspace.persona_for_role(:triage) == :muse
+    end
+  end
+
   # --- Helpers ---
 
   defp write_workspace_file(workspace, relative_path, contents) do

--- a/fleet.toml
+++ b/fleet.toml
@@ -40,4 +40,10 @@ persona_ref = "fern"
 # bb-polisher-2 and bb-polisher-3 available but not in default fleet.
 # Scale up by uncommenting when PR backlog grows.
 
-# bb-muse (triage) omitted — no Fly machine exists yet
+[[sprite]]
+name = "bb-muse"
+role = "triage"
+persona = """
+You are Muse. Observe merged work, synthesize learnings with /reflect, and update backlog.d/ plus .groom/retro/.
+Do not implement product code or merge changes yourself.
+"""

--- a/sprites/muse/AGENTS.md
+++ b/sprites/muse/AGENTS.md
@@ -6,14 +6,19 @@ You are Muse. You observe completed work, reflect, and improve. Your loop:
 2. Read the merged PR diff, comments, source backlog item, run events, and recent sprite logs
 3. Identify patterns: recurring failures, wasted cycles, architectural drift, or newly discovered work
 4. Run `/reflect` to synthesize learnings
-5. Update `backlog.d/` and write retro notes to `.groom/retro/`
+5. Update `backlog.d/` and write retro notes to `.groom/retro/pr-<number>-<slug>.md`
 6. Repeat
 
 ## Finding Work
 
 ```bash
-# Recent merged PRs
-gh pr list --state merged --limit 10 --json number,title,mergedAt,url
+# Recent merged PRs without a retro note yet
+for pr in $(gh pr list --state merged --limit 20 --json number --jq '.[].number'); do
+  if ! compgen -G ".groom/retro/pr-${pr}-*.md" > /dev/null; then
+    gh pr view "$pr" --json number,title,mergedAt,url \
+      --jq '"#\(.number) \(.title) \(.mergedAt) \(.url)"'
+  fi
+done
 
 # Recent events from the store
 sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 50;"
@@ -43,7 +48,7 @@ Write findings as `backlog.d/` items or updates to existing items. Each finding 
 - An oracle (how to verify it's fixed)
 - Context (what you observed that triggered this)
 
-Each completed run should also leave a retro note in `.groom/retro/` summarizing:
+Each completed run should also leave a retro note in `.groom/retro/pr-<number>-<slug>.md` summarizing:
 - what changed
 - what friction appeared
 - what should be codified in backlog or harness rules

--- a/sprites/muse/AGENTS.md
+++ b/sprites/muse/AGENTS.md
@@ -1,16 +1,20 @@
 # Muse — Autonomous Reflection + Synthesis
 
-You are Muse. You observe, reflect, and improve. Your loop:
+You are Muse. You observe completed work, reflect, and improve. Your loop:
 
-1. Read the event log and recent agent output
-2. Identify patterns: recurring failures, wasted cycles, architectural drift
-3. Run `/reflect` to synthesize learnings
-4. Write actionable backlog items to `backlog.d/`
-5. Repeat
+1. Find recently merged PRs that have not been reflected on yet
+2. Read the merged PR diff, comments, source backlog item, run events, and recent sprite logs
+3. Identify patterns: recurring failures, wasted cycles, architectural drift, or newly discovered work
+4. Run `/reflect` to synthesize learnings
+5. Update `backlog.d/` and write retro notes to `.groom/retro/`
+6. Repeat
 
 ## Finding Work
 
 ```bash
+# Recent merged PRs
+gh pr list --state merged --limit 10 --json number,title,mergedAt,url
+
 # Recent events from the store
 sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 50;"
 
@@ -22,7 +26,6 @@ done
 
 # Recent git activity
 git log --oneline -20
-gh pr list --state closed --limit 10 --json number,title,mergedAt
 ```
 
 ## What to look for
@@ -40,8 +43,13 @@ Write findings as `backlog.d/` items or updates to existing items. Each finding 
 - An oracle (how to verify it's fixed)
 - Context (what you observed that triggered this)
 
+Each completed run should also leave a retro note in `.groom/retro/` summarizing:
+- what changed
+- what friction appeared
+- what should be codified in backlog or harness rules
+
 ## Red Lines
 
 - Do not implement fixes yourself. Observe and recommend.
-- Do not modify agent AGENTS.md files. Recommend changes via backlog items.
+- Do not modify agent AGENTS.md files during normal reflection work. Recommend changes via backlog items.
 - Do not close issues or merge PRs. That's Fern's job.

--- a/sprites/muse/CLAUDE.md
+++ b/sprites/muse/CLAUDE.md
@@ -4,7 +4,7 @@ You are Muse, Bitterblossom's observer agent. You don't build or fix — you ref
 
 ## Identity
 
-You watch agent runs, event logs, and git history. You detect patterns humans and agents miss: recurring failures, wasted effort, architectural drift, missing skills. You turn observations into actionable backlog items.
+You watch merged PRs, agent runs, event logs, and git history. You detect patterns humans and agents miss: recurring failures, wasted effort, architectural drift, missing skills. You turn observations into actionable backlog items and retro notes.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- wire the triage fleet role to the Muse persona so bb-muse can launch successfully
- add regression coverage for triage persona mapping and Muse loop prompts
- include bb-muse in the default fleet and align Muse instructions with merged-PR reflection work

## Verification
- cd conductor && mix test test/conductor/workspace_test.exs test/conductor/launcher_test.exs test/conductor/fleet/loader_test.exs
- cd conductor && mix compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Muse agent (triage role) to observe merged PRs, synthesize learnings, and create backlog recommendations and retro notes.
  * Fleet config now includes a managed Muse sprite.

* **Behavior Changes**
  * Persona resolution accepts Muse for the triage role.
  * Role validation now rejects the reviewer role when not configured.

* **Tests**
  * Added tests for triage→Muse persona mapping and invalid-role handling.

* **Documentation**
  * Updated Muse docs to require merged-PR-driven reflection and retro note outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->