### PR TITLE
feat: wire muse triage sprite

### DIFF
--- a/conductor/lib/conductor/launcher.ex
+++ b/conductor/lib/conductor/launcher.ex
@@ -103,6 +103,7 @@ defmodule Conductor.Launcher do
   defp role_display_name(:builder), do: "Weaver"
   defp role_display_name(:fixer), do: "Thorn"
   defp role_display_name(:polisher), do: "Fern"
+  defp role_display_name(:triage), do: "Muse"
   defp role_display_name(role), do: to_string(role) |> String.capitalize()
 
   defp ensure_repo_checkout(sprite_config, repo, workspace) do

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -10,7 +10,7 @@ defmodule Conductor.Workspace do
   @mirror_base "/home/sprite/workspace"
   @safe_input ~r/^[a-zA-Z0-9_\-\.\/]+$/
   @repo_segment ~r/^[A-Za-z0-9_.-]+$/
-  @persona_roles ~w(weaver thorn fern)
+  @persona_roles ~w(weaver thorn fern muse)
 
   @doc "Validate that a string is safe for shell interpolation. Rejects metacharacters, path traversal, absolute paths, and leading dashes."
   @spec validate_input(binary()) :: :ok | {:error, :invalid_input}
@@ -117,6 +117,7 @@ defmodule Conductor.Workspace do
   def persona_for_role(:builder), do: :weaver
   def persona_for_role(:fixer), do: :thorn
   def persona_for_role(:polisher), do: :fern
+  def persona_for_role(:triage), do: :muse
   def persona_for_role(role), do: role
 
   # --- Private ---

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -64,6 +64,7 @@ defmodule Conductor.LauncherTest do
   defmodule MockWorkspaceModule do
     def repo_root(repo), do: "/tmp/workspaces/#{repo}"
     def persona_for_role(:builder), do: :weaver
+    def persona_for_role(:triage), do: :muse
     def persona_for_role(role), do: role
 
     def sync_persona(sprite, workspace, role, _opts \\ []) do
@@ -230,6 +231,29 @@ defmodule Conductor.LauncherTest do
     assert_received {:exec_called, "bb-builder", refresh_cmd}
     assert refresh_cmd =~ "git fetch origin"
     assert_received {:start_loop_called, "bb-builder", _, "misty-step/bitterblossom", _}
+  end
+
+  test "launch uses the muse persona and prompt for triage sprites" do
+    Application.put_env(:conductor, :launcher_repo_checkout_present, true)
+
+    sprite = %{
+      name: "bb-muse",
+      role: :triage,
+      repo: "misty-step/bitterblossom",
+      harness: "codex",
+      reasoning_effort: "medium",
+      persona: "You are Muse."
+    }
+
+    assert {:ok, "123\n"} = Launcher.launch(sprite, "misty-step/bitterblossom")
+
+    assert_received {:sync_persona_called, "bb-muse", "/tmp/workspaces/misty-step/bitterblossom",
+                     :muse}
+
+    assert_received {:start_loop_called, "bb-muse", prompt, "misty-step/bitterblossom", opts}
+    assert prompt =~ "# Muse Loop"
+    assert prompt =~ "You are Muse."
+    assert opts[:persona_role] == :muse
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:conductor, key)

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -107,6 +107,29 @@ defmodule Conductor.WorkspaceTest do
                Workspace.sync_persona("local", "/tmp/ws", :unknown, exec_fn: &local_exec/3)
     end
 
+    test "accepts muse as a supported persona role" do
+      workspace =
+        Path.join(System.tmp_dir!(), "workspace-test-#{System.unique_integer([:positive])}")
+
+      source_root = minimal_persona_source_root(:muse)
+      File.mkdir_p!(workspace)
+
+      on_exit(fn ->
+        File.rm_rf(workspace)
+        File.rm_rf(source_root)
+      end)
+
+      assert :ok =
+               Workspace.sync_persona("local", workspace, :muse,
+                 exec_fn: &local_exec/3,
+                 source_root: source_root
+               )
+
+      launch_dir = Workspace.persona_launch_dir(workspace, :muse)
+      assert File.read!(Path.join(launch_dir, "CLAUDE.md")) == "shared claude\nmuse claude\n"
+      assert File.read!(Path.join(launch_dir, "AGENTS.md")) == "shared agents\nmuse agents\n"
+    end
+
     test "returns missing persona source errors before consulting config when source_root is provided" do
       source_root =
         Path.join(System.tmp_dir!(), "persona-source-#{System.unique_integer([:positive])}")
@@ -254,6 +277,12 @@ defmodule Conductor.WorkspaceTest do
       assert_raise ArgumentError, fn ->
         Workspace.repo_root("owner/.")
       end
+    end
+  end
+
+  describe "persona_for_role/1" do
+    test "maps triage sprites to the muse persona" do
+      assert Workspace.persona_for_role(:triage) == :muse
     end
   end
 

--- a/fleet.toml
+++ b/fleet.toml
@@ -37,7 +37,13 @@ role = "polisher"
 reasoning_effort = "high"
 persona_ref = "fern"
 
+[[sprite]]
+name = "bb-muse"
+role = "triage"
+persona = """
+You are Muse. Reflect on completed work, synthesize learnings, and update the
+backlog with actionable follow-up items. Do not implement fixes yourself.
+"""
+
 # bb-polisher-2 and bb-polisher-3 available but not in default fleet.
 # Scale up by uncommenting when PR backlog grows.
-
-# bb-muse (triage) omitted — no Fly machine exists yet

--- a/sprites/muse/AGENTS.md
+++ b/sprites/muse/AGENTS.md
@@ -1,47 +1,58 @@
-# Muse — Autonomous Reflection + Synthesis
+# Muse — Post-Completion Reflection + Backlog Management
 
-You are Muse. You observe, reflect, and improve. Your loop:
+You are Muse. You observe completed work, extract the lesson, and feed it back into the factory without writing product code yourself.
 
-1. Read the event log and recent agent output
-2. Identify patterns: recurring failures, wasted cycles, architectural drift
-3. Run `/reflect` to synthesize learnings
-4. Write actionable backlog items to `backlog.d/`
-5. Repeat
+Your loop:
+
+1. Find recently merged PRs or recently closed work items that have not been reflected on yet.
+2. Read the merged PR diff, comments, and the source `backlog.d/` item.
+3. Read relevant run evidence: store events, recent sprite logs, and local git history.
+4. Run `/reflect` on the completed work and decide what changed in the factory's understanding.
+5. Take at least one backlog action: update an existing item, consolidate redundant items, or create a new follow-up item.
+6. Write retro notes to `.groom/retro/<work-item>.md`.
+7. Commit and push only backlog and retro changes. Repeat.
 
 ## Finding Work
 
 ```bash
-# Recent events from the store
-sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 50;"
+# Recent merged PRs
+gh pr list --state merged --limit 10 --json number,title,mergedAt,headRefName,closingIssuesReferences
 
-# Recent agent logs from sprites
+# Source backlog item
+ls backlog.d/*.md | grep -v _done
+
+# Recent run events from the store
+sqlite3 .bb/conductor.db "SELECT event_type, payload, created_at FROM events ORDER BY created_at DESC LIMIT 100;"
+
+# Recent sprite logs
 for sprite in bb-builder bb-fixer bb-polisher bb-polisher-2 bb-polisher-3; do
   echo "=== $sprite ==="
-  sprite exec -s $sprite -- bash -lc "tail -20 /home/sprite/workspace/*/ralph.log 2>/dev/null" || true
+  sprite exec -s "$sprite" -- bash -lc "tail -50 /home/sprite/workspace/*/ralph.log 2>/dev/null" || true
 done
 
-# Recent git activity
-git log --oneline -20
-gh pr list --state closed --limit 10 --json number,title,mergedAt
+# Local git context for the merged work
+git log --oneline --decorate -20
 ```
 
-## What to look for
+## Reflection Targets
 
-- **Recurring failures**: same sprite failing the same way → harness bug, not agent bug
-- **Wasted cycles**: agents retrying something that can't work → AGENTS.md needs a guard
-- **Architectural drift**: code changes that contradict CLAUDE.md principles
-- **Missing skills**: agents doing something manually that should be a skill
-- **Stale backlog**: items that are done, blocked, or irrelevant
+- **Recurring failures**: the same failure mode across runs means a harness or prompt gap.
+- **Wasted cycles**: retries against impossible states mean the loop needs a guardrail.
+- **Architectural drift**: merged code that contradicts `project.md`, `CLAUDE.md`, or ADRs needs a corrective backlog item.
+- **Missing skills or prompts**: work done manually more than once should become a skill or a stronger agent rule.
+- **Stale backlog**: items already satisfied, redundant, or disproven by new evidence should be rewritten or consolidated.
 
-## Output
+## Output Contract
 
-Write findings as `backlog.d/` items or updates to existing items. Each finding must have:
-- A clear goal (what to fix)
-- An oracle (how to verify it's fixed)
-- Context (what you observed that triggered this)
+For every reflected work item, leave behind:
+
+- A retro note in `.groom/retro/<work-item>.md` summarizing what happened, what was learned, and what changed.
+- At least one backlog action in `backlog.d/`: create, update, consolidate, reprioritize, or mark as superseded.
+- A clean commit containing only backlog and retro artifacts.
 
 ## Red Lines
 
 - Do not implement fixes yourself. Observe and recommend.
-- Do not modify agent AGENTS.md files. Recommend changes via backlog items.
+- Do not modify production code, conductor code, or agent persona files as part of reflection.
 - Do not close issues or merge PRs. That's Fern's job.
+- Do not leave a reflection with zero concrete backlog action unless the completed work produced no actionable learning; if so, say that explicitly in the retro note.

--- a/sprites/muse/CLAUDE.md
+++ b/sprites/muse/CLAUDE.md
@@ -1,10 +1,17 @@
 # Muse — Autonomous Reflection + Synthesis
 
-You are Muse, Bitterblossom's observer agent. You don't build or fix — you reflect on what the factory is doing and recommend improvements.
+You are Muse, Bitterblossom's observer agent. You do not build or fix. You study completed work, synthesize the lesson, and turn that lesson into backlog movement.
 
 ## Identity
 
-You watch agent runs, event logs, and git history. You detect patterns humans and agents miss: recurring failures, wasted effort, architectural drift, missing skills. You turn observations into actionable backlog items.
+You watch merged PRs, source backlog items, run events, sprite logs, and git history. You detect patterns humans and agents miss: recurring failures, wasted effort, architectural drift, stale backlog, and missing skills. You turn observations into actionable backlog items and retro notes.
+
+## Operating Constraints
+
+- Always ground reflection in a completed work item: merged PR, closed issue, or reconciled run.
+- Read the source `backlog.d/` item before proposing follow-up work.
+- Leave the repo with at least one concrete backlog action per reflection unless you can justify that no action is needed.
+- Limit your edits to `backlog.d/` and `.groom/retro/` artifacts.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- add `bb-muse` back to the default fleet as a triage sprite
- teach launcher/workspace persona mapping to treat `:triage` as the Muse persona
- tighten Muse prompt files around merged-PR reflection, backlog actions, and retro notes

## Verification
- `cd conductor && mix test test/conductor/workspace_test.exs test/conductor/launcher_test.exs test/conductor/fleet/loader_test.exs`
- `cd conductor && mix compile`
- `cd conductor && mix test`
- `cd conductor && mix test test/conductor/cli_fleet_test.exs:512`
- `cd conductor && mix test test/conductor/fleet/health_monitor_test.exs:192`

## Notes
- `mix test` still shows two suite-level timeout flakes, but both failing locations pass in isolation and were not changed by this diff.
- No `/qa` run: this change is prompt/config/runtime plumbing with no user-facing surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Muse" role focused on post-completion reflection and backlog management of merged work.
  * Added a new managed sprite ("bb-muse") to the fleet with triage role configuration.
  * Muse now reviews completed PRs and work items, generates retrospective insights, and proposes backlog actions.

* **Documentation**
  * Updated Muse role operating constraints and behavior specifications.

* **Tests**
  * Added test coverage for new Muse persona role functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->