### PR TITLE
feat: add Tansy Canary responder lane

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -2,3 +2,4 @@
 {"date":"2026-04-02","pr":null,"correctness":9,"depth":8,"simplicity":9,"craft":8,"verdict":"ship"}
 {"date":"2026-04-01","pr":829,"correctness":8,"depth":8,"simplicity":9,"craft":7,"verdict":"ship"}
 {"date":"2026-04-02","pr":830,"correctness":9,"depth":9,"simplicity":8,"craft":8,"verdict":"ship"}
+{"date":"2026-04-08","pr":null,"correctness":8,"depth":8,"simplicity":7,"craft":8,"verdict":"ship","providers":["internal-bench","thinktank"]}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,13 @@ Also read:
 - `AGENTS.md` (canonical repo context)
 - `docs/adr/004-elixir-conductor-architecture.md` (Elixir conductor design)
 
+## Current Direction Lock
+
+Bitterblossom is currently focused on one lane: `Tansy` watches Canary,
+investigates incidents, fixes the correct repository, and verifies recovery.
+The older builder/fixer/polisher lanes remain as prior art and may return, but
+they are not the active product priority right now.
+
 ## What This Is
 
 Bitterblossom is an agent-first software factory. Autonomous AI agents (sprites) pick work, implement it, review it, and merge it. The codebase has two concerns:
@@ -22,6 +29,7 @@ Agents are capable. The infrastructure is plumbing.
 - **Thorn** (`bb-fixer`) — autonomous fixer: scans PRs for merge blockers, resolves conflicts, fixes CI via `/settle`
 - **Fern** (`bb-polisher`, `bb-polisher-2`, `bb-polisher-3`) — autonomous quality + merger: reviews, polishes, refactors, squash-merges via `/settle`
 - **Muse** (`bb-muse`) — reflects on runs and synthesizes learning for the factory
+- **Tansy** (`bb-tansy`) — Canary incident responder: claims incidents, investigates root causes, repairs target repos, and verifies recovery
 
 ## Architecture
 
@@ -43,6 +51,7 @@ sprites/                     Agent definitions — where the logic lives
   weaver/                    Autonomous builder loop
   thorn/                     Autonomous fixer loop
   fern/                      Autonomous polisher+merger loop
+  tansy/                     Autonomous Canary incident responder loop
 
 base/                        Skills/configs uploaded to all sprites
 ```
@@ -53,6 +62,8 @@ base/                        Skills/configs uploaded to all sprites
 2. Each sprite runs its own autonomous loop (defined in its AGENTS.md)
 3. Weaver picks `backlog.d/` items → Thorn fixes PRs → Fern polishes and merges
 4. Self-healing: conflicts/CI failures → Thorn → Fern re-polishes → merge
+
+For the current direction lock, the default fleet runs only `bb-tansy`.
 
 ## Build & Test
 

--- a/canary-services.toml
+++ b/canary-services.toml
@@ -1,0 +1,31 @@
+# Canary service catalog
+#
+# This file is the repo-owned authority for `service -> repo + rollout policy`.
+# Tansy resolves incidents through this catalog rather than guessing from repo
+# names or shell folklore.
+#
+# Rules:
+# - Commands are argv arrays, not shell strings.
+# - `auto_merge` and `auto_deploy` default to false.
+# - Only enable `auto_deploy` when `deploy_cmd` and `rollback_cmd` are both
+#   present and the recovery oracle is trustworthy.
+
+[[service]]
+name = "bitterblossom"
+repo = "misty-step/bitterblossom"
+default_branch = "master"
+test_cmd = ["make", "test"]
+auto_merge = false
+auto_deploy = false
+stabilization_window_s = 600
+
+[[service]]
+name = "canary"
+repo = "misty-step/canary"
+default_branch = "master"
+test_cmd = ["./bin/validate"]
+deploy_cmd = ["flyctl", "deploy", "--app", "canary-obs", "--remote-only"]
+rollback_cmd = ["flyctl", "releases", "rollback", "--app", "canary-obs"]
+auto_merge = false
+auto_deploy = false
+stabilization_window_s = 900

--- a/conductor/config/config.exs
+++ b/conductor/config/config.exs
@@ -3,6 +3,7 @@ import Config
 config :conductor,
   db_path: ".bb/conductor.db",
   event_log: ".bb/events.jsonl",
+  canary_services_path: Path.expand("../../canary-services.toml", __DIR__),
   poll_seconds: 60,
   builder_timeout_minutes: 25,
   ci_timeout_minutes: 30,

--- a/conductor/lib/conductor/canary/client.ex
+++ b/conductor/lib/conductor/canary/client.ex
@@ -29,12 +29,16 @@ defmodule Conductor.Canary.Client do
 
   @spec incident_annotations(binary()) :: {:ok, body()} | {:error, binary()}
   def incident_annotations(incident_id) when is_binary(incident_id) do
-    get("/api/v1/incidents/#{incident_id}/annotations")
+    with :ok <- validate_incident_id(incident_id) do
+      get("/api/v1/incidents/#{incident_id}/annotations")
+    end
   end
 
   @spec annotate_incident(binary(), map()) :: {:ok, body()} | {:error, binary()}
   def annotate_incident(incident_id, attrs) when is_binary(incident_id) and is_map(attrs) do
-    post("/api/v1/incidents/#{incident_id}/annotations", attrs)
+    with :ok <- validate_incident_id(incident_id) do
+      post("/api/v1/incidents/#{incident_id}/annotations", attrs)
+    end
   end
 
   defp get(path, opts \\ []) do
@@ -92,5 +96,13 @@ defmodule Conductor.Canary.Client do
 
   defp format_http_error(status, body) do
     "Canary API #{status}: #{inspect(body)}"
+  end
+
+  defp validate_incident_id(incident_id) do
+    if String.trim(incident_id) == "" do
+      {:error, "incident id must not be empty"}
+    else
+      :ok
+    end
   end
 end

--- a/conductor/lib/conductor/canary/client.ex
+++ b/conductor/lib/conductor/canary/client.ex
@@ -1,0 +1,96 @@
+defmodule Conductor.Canary.Client do
+  @moduledoc """
+  Thin Canary query and annotation client for responder sprites.
+
+  This module deliberately mirrors Canary's HTTP API closely. It centralizes
+  auth, error mapping, and bounded request shapes without embedding incident
+  workflow logic into the conductor.
+  """
+
+  @type request_opts :: keyword()
+  @type body :: map()
+
+  @spec incidents(request_opts()) :: {:ok, body()} | {:error, binary()}
+  def incidents(opts \\ []) do
+    get("/api/v1/incidents", params: query(opts, [:with_annotation, :without_annotation]))
+  end
+
+  @spec report(request_opts()) :: {:ok, body()} | {:error, binary()}
+  def report(opts \\ []) do
+    get("/api/v1/report", params: query(opts, [:window, :q, :limit, :cursor]))
+  end
+
+  @spec timeline(request_opts()) :: {:ok, body()} | {:error, binary()}
+  def timeline(opts \\ []) do
+    get("/api/v1/timeline",
+      params: query(opts, [:service, :window, :limit, :after, :cursor, :event_type])
+    )
+  end
+
+  @spec incident_annotations(binary()) :: {:ok, body()} | {:error, binary()}
+  def incident_annotations(incident_id) when is_binary(incident_id) do
+    get("/api/v1/incidents/#{incident_id}/annotations")
+  end
+
+  @spec annotate_incident(binary(), map()) :: {:ok, body()} | {:error, binary()}
+  def annotate_incident(incident_id, attrs) when is_binary(incident_id) and is_map(attrs) do
+    post("/api/v1/incidents/#{incident_id}/annotations", attrs)
+  end
+
+  defp get(path, opts \\ []) do
+    request(:get, path, opts)
+  end
+
+  defp post(path, body) do
+    request(:post, path, json: body)
+  end
+
+  defp request(method, path, opts) do
+    with {:ok, req} <- build_request() do
+      case Req.request(req, Keyword.merge([method: method, url: path], opts)) do
+        {:ok, %Req.Response{status: status, body: body}} when status in 200..299 ->
+          {:ok, body}
+
+        {:ok, %Req.Response{status: status, body: body}} ->
+          {:error, format_http_error(status, body)}
+
+        {:error, error} ->
+          {:error, Exception.message(error)}
+      end
+    end
+  end
+
+  defp build_request do
+    with endpoint when is_binary(endpoint) <- Conductor.Config.canary_endpoint(),
+         api_key when is_binary(api_key) <- Conductor.Config.canary_api_key() do
+      {:ok,
+       Req.new(
+         base_url: String.trim_trailing(endpoint, "/"),
+         headers: [
+           {"authorization", "Bearer #{api_key}"},
+           {"accept", "application/json"}
+         ]
+       )}
+    else
+      _ -> {:error, "CANARY_ENDPOINT and CANARY_API_KEY must be set"}
+    end
+  end
+
+  defp query(opts, allowed_keys) do
+    opts
+    |> Enum.filter(fn {key, value} -> key in allowed_keys and not is_nil(value) end)
+    |> Enum.into(%{}, fn {key, value} -> {to_string(key), value} end)
+  end
+
+  defp format_http_error(status, %{"detail" => detail}) when is_binary(detail) do
+    "Canary API #{status}: #{detail}"
+  end
+
+  defp format_http_error(status, body) when is_map(body) do
+    "Canary API #{status}: #{Jason.encode!(body)}"
+  end
+
+  defp format_http_error(status, body) do
+    "Canary API #{status}: #{inspect(body)}"
+  end
+end

--- a/conductor/lib/conductor/canary/service_catalog.ex
+++ b/conductor/lib/conductor/canary/service_catalog.ex
@@ -1,0 +1,228 @@
+defmodule Conductor.Canary.ServiceCatalog do
+  @moduledoc """
+  Load and validate the typed Canary service catalog.
+
+  This catalog is the repo-owned authority for `service -> repo + rollout
+  permissions`. It stays intentionally small and strict so Tansy has a truthful
+  and reviewable control surface.
+  """
+
+  alias Conductor.Workspace
+
+  @allowed_keys ~w(
+    name
+    repo
+    default_branch
+    test_cmd
+    deploy_cmd
+    rollback_cmd
+    auto_merge
+    auto_deploy
+    stabilization_window_s
+  )
+
+  @type service :: %{
+          name: binary(),
+          repo: binary(),
+          default_branch: binary(),
+          test_cmd: [binary()],
+          deploy_cmd: [binary()] | nil,
+          rollback_cmd: [binary()] | nil,
+          auto_merge: boolean(),
+          auto_deploy: boolean(),
+          stabilization_window_s: pos_integer()
+        }
+
+  @spec load(binary()) :: {:ok, [service()]} | {:error, binary()}
+  def load(path) do
+    with {:ok, raw} <- read_toml(path),
+         {:ok, services} <- parse_services(raw) do
+      {:ok, services}
+    end
+  end
+
+  @spec load!() :: [service()]
+  def load! do
+    load!(Conductor.Config.canary_services_path())
+  end
+
+  @spec load!(binary()) :: [service()]
+  def load!(path) do
+    case load(path) do
+      {:ok, services} -> services
+      {:error, reason} -> raise "canary-services.toml: #{reason}"
+    end
+  end
+
+  @spec fetch([service()], binary()) :: {:ok, service()} | {:error, :not_found}
+  def fetch(services, name) when is_list(services) and is_binary(name) do
+    case Enum.find(services, &(&1.name == name)) do
+      nil -> {:error, :not_found}
+      service -> {:ok, service}
+    end
+  end
+
+  @spec resolve([service()], binary()) :: {:ok, service()} | {:error, :not_found}
+  def resolve(services, name), do: fetch(services, name)
+
+  defp read_toml(path) do
+    case File.read(path) do
+      {:ok, content} ->
+        case Toml.decode(content) do
+          {:ok, parsed} -> {:ok, parsed}
+          {:error, reason} -> {:error, "parse error: #{inspect(reason)}"}
+        end
+
+      {:error, :enoent} ->
+        {:error, "#{path} not found"}
+
+      {:error, reason} ->
+        {:error, "cannot read #{path}: #{inspect(reason)}"}
+    end
+  end
+
+  defp parse_services(raw) do
+    case Map.get(raw, "service") do
+      nil ->
+        {:error, "no [[service]] entries in canary-services.toml"}
+
+      services when is_list(services) ->
+        with :ok <- ensure_unique_service_names(services),
+             results <- Enum.with_index(services, 1) |> Enum.map(&parse_one_service/1),
+             [] <- Enum.filter(results, &match?({:error, _}, &1)) do
+          {:ok, Enum.map(results, fn {:ok, service} -> service end)}
+        else
+          [{:error, _} | _] = errors ->
+            {:error,
+             "service validation errors:\n  " <>
+               Enum.map_join(errors, "\n  ", fn {:error, msg} -> msg end)}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      other ->
+        {:error, "[[service]] entries must be a TOML array, got: #{inspect(other)}"}
+    end
+  end
+
+  defp ensure_unique_service_names(services) do
+    duplicates =
+      services
+      |> Enum.map(&Map.get(&1, "name"))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_name, count} -> count > 1 end)
+
+    case duplicates do
+      [] -> :ok
+      [{name, _} | _] -> {:error, "duplicate service name '#{name}'"}
+    end
+  end
+
+  defp parse_one_service({entry, idx}) when is_map(entry) do
+    with :ok <- validate_allowed_keys(entry, idx),
+         {:ok, name} <- validate_required_string(entry, "name", idx),
+         {:ok, repo} <- validate_repo(entry, idx),
+         {:ok, branch} <- validate_required_string(entry, "default_branch", idx),
+         {:ok, test_cmd} <- validate_argv(entry, "test_cmd", idx, required: true),
+         {:ok, deploy_cmd} <- validate_argv(entry, "deploy_cmd", idx),
+         {:ok, rollback_cmd} <- validate_argv(entry, "rollback_cmd", idx),
+         {:ok, auto_merge} <- validate_boolean(entry, "auto_merge", false, idx),
+         {:ok, auto_deploy} <- validate_boolean(entry, "auto_deploy", false, idx),
+         {:ok, stabilization_window_s} <-
+           validate_positive_integer(entry, "stabilization_window_s", 600, idx),
+         :ok <- validate_auto_deploy_requirements(auto_deploy, deploy_cmd, rollback_cmd, idx) do
+      {:ok,
+       %{
+         name: name,
+         repo: repo,
+         default_branch: branch,
+         test_cmd: test_cmd,
+         deploy_cmd: deploy_cmd,
+         rollback_cmd: rollback_cmd,
+         auto_merge: auto_merge,
+         auto_deploy: auto_deploy,
+         stabilization_window_s: stabilization_window_s
+       }}
+    end
+  end
+
+  defp parse_one_service({_entry, idx}), do: {:error, "service entry ##{idx} is not a TOML table"}
+
+  defp validate_allowed_keys(entry, idx) do
+    unknown = Map.keys(entry) |> Enum.reject(&(&1 in @allowed_keys))
+
+    case unknown do
+      [] -> :ok
+      keys -> {:error, "service entry ##{idx} has unknown keys: #{Enum.join(keys, ", ")}"}
+    end
+  end
+
+  defp validate_required_string(entry, key, idx) do
+    case Map.get(entry, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "service entry ##{idx} missing required '#{key}'"}
+    end
+  end
+
+  defp validate_repo(entry, idx) do
+    with {:ok, repo} <- validate_required_string(entry, "repo", idx),
+         :ok <- Workspace.validate_repo(repo) do
+      {:ok, repo}
+    else
+      {:error, :invalid_repo} ->
+        {:error, "service entry ##{idx} has invalid repo '#{Map.get(entry, "repo")}'"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp validate_argv(entry, key, idx, opts \\ []) do
+    case Map.get(entry, key) do
+      nil ->
+        if Keyword.get(opts, :required, false) do
+          {:error, "service entry ##{idx} missing required '#{key}'"}
+        else
+          {:ok, nil}
+        end
+
+      value when is_list(value) ->
+        if value != [] and Enum.all?(value, &(is_binary(&1) and &1 != "")) do
+          {:ok, value}
+        else
+          {:error, "service entry ##{idx} #{key} must be a non-empty array of strings"}
+        end
+
+      _ ->
+        {:error, "service entry ##{idx} #{key} must be a non-empty array of strings"}
+    end
+  end
+
+  defp validate_boolean(entry, key, default, idx) do
+    case Map.get(entry, key, default) do
+      value when is_boolean(value) -> {:ok, value}
+      _ -> {:error, "service entry ##{idx} #{key} must be a boolean"}
+    end
+  end
+
+  defp validate_positive_integer(entry, key, default, idx) do
+    case Map.get(entry, key, default) do
+      value when is_integer(value) and value > 0 -> {:ok, value}
+      _ -> {:error, "service entry ##{idx} #{key} must be a positive integer"}
+    end
+  end
+
+  defp validate_auto_deploy_requirements(false, _deploy_cmd, _rollback_cmd, _idx), do: :ok
+
+  defp validate_auto_deploy_requirements(true, nil, _rollback_cmd, idx) do
+    {:error, "service entry ##{idx} enables auto_deploy without deploy_cmd"}
+  end
+
+  defp validate_auto_deploy_requirements(true, _deploy_cmd, nil, idx) do
+    {:error, "service entry ##{idx} enables auto_deploy without rollback_cmd"}
+  end
+
+  defp validate_auto_deploy_requirements(true, _deploy_cmd, _rollback_cmd, _idx), do: :ok
+end

--- a/conductor/lib/conductor/cli.ex
+++ b/conductor/lib/conductor/cli.ex
@@ -4,7 +4,7 @@ defmodule Conductor.CLI do
   No judgment — just infrastructure plumbing.
   """
 
-  @commands ~w(start fleet status check-env dashboard logs show-events sprite)
+  @commands ~w(start fleet status check-env dashboard logs show-events sprite canary)
 
   def main(args) do
     case args do
@@ -39,6 +39,10 @@ defmodule Conductor.CLI do
       ["sprite" | rest] ->
         Application.ensure_all_started(:conductor)
         cmd_sprite(rest)
+
+      ["canary" | rest] ->
+        Application.ensure_all_started(:conductor)
+        cmd_canary(rest)
 
       [cmd | _] ->
         IO.puts("unknown command: #{cmd}\navailable: #{Enum.join(@commands, ", ")}")
@@ -246,6 +250,258 @@ defmodule Conductor.CLI do
     end
   end
 
+  defp cmd_canary(args) do
+    case args do
+      ["service" | rest] ->
+        cmd_canary_service(rest)
+
+      ["incidents" | rest] ->
+        cmd_canary_incidents(rest)
+
+      ["report" | rest] ->
+        cmd_canary_report(rest)
+
+      ["timeline" | rest] ->
+        cmd_canary_timeline(rest)
+
+      ["annotations" | rest] ->
+        cmd_canary_annotations(rest)
+
+      ["annotate" | rest] ->
+        cmd_canary_annotate(rest)
+
+      _ ->
+        IO.puts(
+          "usage: bitterblossom canary <service|incidents|report|timeline|annotations|annotate> ..."
+        )
+
+        System.halt(1)
+    end
+  end
+
+  defp cmd_canary_service(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args, strict: [catalog: :string, json: :boolean, help: :boolean])
+
+    if invalid != [] or Keyword.get(opts, :help, false) or length(positional) != 1 do
+      IO.puts("usage: bitterblossom canary service <service> [--catalog path] [--json]")
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      service_name = hd(positional)
+      path = Keyword.get(opts, :catalog, Conductor.Config.canary_services_path())
+
+      with {:ok, services} <- Conductor.Canary.ServiceCatalog.load(path),
+           {:ok, service} <- Conductor.Canary.ServiceCatalog.fetch(services, service_name) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(service))
+        else
+          IO.puts("service: #{service.name}")
+          IO.puts("repo: #{service.repo}")
+          IO.puts("default_branch: #{service.default_branch}")
+          IO.puts("test_cmd: #{Enum.join(service.test_cmd, " ")}")
+          IO.puts("auto_merge: #{service.auto_merge}")
+          IO.puts("auto_deploy: #{service.auto_deploy}")
+
+          if service.deploy_cmd do
+            IO.puts("deploy_cmd: #{Enum.join(service.deploy_cmd, " ")}")
+          end
+
+          if service.rollback_cmd do
+            IO.puts("rollback_cmd: #{Enum.join(service.rollback_cmd, " ")}")
+          end
+        end
+      else
+        {:error, :not_found} ->
+          IO.puts("unknown Canary service: #{service_name}")
+          System.halt(1)
+
+        {:error, reason} ->
+          IO.puts("canary catalog failed: #{reason}")
+          System.halt(1)
+      end
+    end
+  end
+
+  defp cmd_canary_incidents(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          with_annotation: :string,
+          without_annotation: :string,
+          json: :boolean,
+          help: :boolean
+        ]
+      )
+
+    if invalid != [] or Keyword.get(opts, :help, false) or positional != [] do
+      IO.puts(
+        "usage: bitterblossom canary incidents [--with-annotation action] [--without-annotation action] [--json]"
+      )
+
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      with {:ok, response} <-
+             canary_client_module().incidents(
+               with_annotation: opts[:with_annotation],
+               without_annotation: opts[:without_annotation]
+             ) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(response))
+        else
+          render_incidents(response)
+        end
+      else
+        {:error, reason} ->
+          IO.puts(reason)
+          System.halt(1)
+      end
+    end
+  end
+
+  defp cmd_canary_report(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          window: :string,
+          q: :string,
+          limit: :integer,
+          cursor: :string,
+          json: :boolean,
+          help: :boolean
+        ]
+      )
+
+    if invalid != [] or Keyword.get(opts, :help, false) or positional != [] do
+      IO.puts(
+        "usage: bitterblossom canary report [--window window] [--q query] [--limit n] [--cursor token] [--json]"
+      )
+
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      with {:ok, response} <-
+             canary_client_module().report(
+               window: opts[:window],
+               q: opts[:q],
+               limit: opts[:limit],
+               cursor: opts[:cursor]
+             ) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(response))
+        else
+          render_report(response)
+        end
+      else
+        {:error, reason} ->
+          IO.puts(reason)
+          System.halt(1)
+      end
+    end
+  end
+
+  defp cmd_canary_timeline(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          service: :string,
+          window: :string,
+          limit: :integer,
+          after: :string,
+          event_type: :string,
+          json: :boolean,
+          help: :boolean
+        ]
+      )
+
+    if invalid != [] or Keyword.get(opts, :help, false) or positional != [] do
+      IO.puts(
+        "usage: bitterblossom canary timeline [--service service] [--window window] [--limit n] [--after cursor] [--event-type type] [--json]"
+      )
+
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      with {:ok, response} <-
+             canary_client_module().timeline(
+               service: opts[:service],
+               window: opts[:window],
+               limit: opts[:limit],
+               after: opts[:after],
+               event_type: opts[:event_type]
+             ) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(response))
+        else
+          render_timeline(response)
+        end
+      else
+        {:error, reason} ->
+          IO.puts(reason)
+          System.halt(1)
+      end
+    end
+  end
+
+  defp cmd_canary_annotations(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args, strict: [json: :boolean, help: :boolean])
+
+    if invalid != [] or Keyword.get(opts, :help, false) or
+         match_canary_annotations_args?(positional) == false do
+      IO.puts("usage: bitterblossom canary annotations incident <incident-id> [--json]")
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      ["incident", incident_id] = positional
+
+      with {:ok, response} <- canary_client_module().incident_annotations(incident_id) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(response))
+        else
+          render_annotations(response)
+        end
+      else
+        {:error, reason} ->
+          IO.puts(reason)
+          System.halt(1)
+      end
+    end
+  end
+
+  defp cmd_canary_annotate(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          agent: :string,
+          action: :string,
+          metadata: :string,
+          json: :boolean,
+          help: :boolean
+        ]
+      )
+
+    if invalid != [] or Keyword.get(opts, :help, false) or
+         match_canary_annotations_args?(positional) == false do
+      IO.puts(
+        "usage: bitterblossom canary annotate incident <incident-id> --agent name --action action [--metadata json] [--json]"
+      )
+
+      if opts[:help], do: :ok, else: System.halt(1)
+    else
+      ["incident", incident_id] = positional
+
+      with {:ok, attrs} <- build_annotation_attrs(opts),
+           {:ok, response} <- canary_client_module().annotate_incident(incident_id, attrs) do
+        if opts[:json] do
+          IO.puts(Jason.encode!(response))
+        else
+          render_annotation(response)
+        end
+      else
+        {:error, reason} ->
+          IO.puts(reason)
+          System.halt(1)
+      end
+    end
+  end
+
   defp cmd_sprite_status(args) do
     with {:ok, sprite, opts, _config} <- fetch_sprite_args(args, json: :boolean) do
       row = fleet_row(sprite, sprite_module())
@@ -385,6 +641,7 @@ defmodule Conductor.CLI do
   defp env_check_opts(sprites, opts \\ []) do
     opts
     |> Keyword.put(:require_codex_auth, requires_codex_auth?(sprites))
+    |> Keyword.put(:require_canary_auth, requires_canary_auth?(sprites))
     |> maybe_put_sprite_auth_probe_target(sprite_auth_probe_target(sprites))
   end
 
@@ -403,6 +660,13 @@ defmodule Conductor.CLI do
     Enum.any?(sprites, fn sprite ->
       harness = Map.get(sprite, :harness) || Map.get(sprite, "harness") || "codex"
       harness == "codex"
+    end)
+  end
+
+  defp requires_canary_auth?(sprites) do
+    Enum.any?(sprites, fn sprite ->
+      role = Map.get(sprite, :role) || Map.get(sprite, "role")
+      role in [:responder, "responder"]
     end)
   end
 
@@ -567,7 +831,89 @@ defmodule Conductor.CLI do
     Application.get_env(:conductor, :config_module, Conductor.Config)
   end
 
+  defp canary_client_module do
+    Application.get_env(:conductor, :canary_client_module, Conductor.Canary.Client)
+  end
+
   defp sprite_module do
     Application.get_env(:conductor, :sprite_module, Conductor.Sprite)
   end
+
+  defp match_canary_annotations_args?(["incident", _incident_id]), do: true
+  defp match_canary_annotations_args?(_), do: false
+
+  defp build_annotation_attrs(opts) do
+    with {:ok, agent} <- required_canary_opt(opts, :agent),
+         {:ok, action} <- required_canary_opt(opts, :action),
+         {:ok, metadata} <- parse_annotation_metadata(opts[:metadata]) do
+      {:ok, %{agent: agent, action: action, metadata: metadata}}
+    end
+  end
+
+  defp required_canary_opt(opts, key) do
+    case Keyword.get(opts, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "missing required --#{key}"}
+    end
+  end
+
+  defp parse_annotation_metadata(nil), do: {:ok, nil}
+
+  defp parse_annotation_metadata(raw) do
+    case Jason.decode(raw) do
+      {:ok, metadata} when is_map(metadata) -> {:ok, metadata}
+      {:ok, _} -> {:error, "--metadata must be a JSON object"}
+      {:error, _} -> {:error, "invalid JSON for --metadata"}
+    end
+  end
+
+  defp render_incidents(%{"incidents" => []}), do: IO.puts("no active incidents")
+
+  defp render_incidents(%{"incidents" => incidents}) when is_list(incidents) do
+    Enum.each(incidents, fn incident ->
+      IO.puts(
+        "#{incident["id"]} #{incident["service"]} #{incident["severity"]} #{incident["state"]} #{incident["title"]}"
+      )
+    end)
+  end
+
+  defp render_incidents(response), do: IO.puts(Jason.encode!(response))
+
+  defp render_report(%{"status" => status, "summary" => summary} = response) do
+    IO.puts("status: #{status}")
+    IO.puts("summary: #{summary}")
+    IO.puts("incidents: #{response |> Map.get("incidents", []) |> length()}")
+    IO.puts("error_groups: #{response |> Map.get("error_groups", []) |> length()}")
+    IO.puts("targets: #{response |> Map.get("targets", []) |> length()}")
+  end
+
+  defp render_report(response), do: IO.puts(Jason.encode!(response))
+
+  defp render_timeline(%{"summary" => summary, "events" => events}) when is_list(events) do
+    IO.puts("summary: #{summary}")
+
+    Enum.each(events, fn event ->
+      IO.puts(
+        "#{event["created_at"]} #{event["service"]} #{event["event"]} #{event["severity"]} #{event["summary"]}"
+      )
+    end)
+  end
+
+  defp render_timeline(response), do: IO.puts(Jason.encode!(response))
+
+  defp render_annotations(%{"annotations" => []}), do: IO.puts("no annotations")
+
+  defp render_annotations(%{"annotations" => annotations}) when is_list(annotations) do
+    Enum.each(annotations, fn annotation ->
+      IO.puts("#{annotation["created_at"]} #{annotation["agent"]} #{annotation["action"]}")
+    end)
+  end
+
+  defp render_annotations(response), do: IO.puts(Jason.encode!(response))
+
+  defp render_annotation(%{"created_at" => created_at, "agent" => agent, "action" => action}) do
+    IO.puts("#{created_at} #{agent} #{action}")
+  end
+
+  defp render_annotation(response), do: IO.puts(Jason.encode!(response))
 end

--- a/conductor/lib/conductor/cli.ex
+++ b/conductor/lib/conductor/cli.ex
@@ -522,6 +522,7 @@ defmodule Conductor.CLI do
     with {:ok, sprite, _opts, _config} <- fetch_sprite_args(args),
          status <- probe_status(sprite, sprite_module()),
          :ok <- ensure_start_admissible(status),
+         :ok <- ensure_start_preflight(sprite),
          :ok <- ensure_sprite_ready_for_start(sprite, status),
          :ok <-
            workspace_module().sync_persona(
@@ -801,6 +802,13 @@ defmodule Conductor.CLI do
   defp ensure_start_admissible(%{busy: true}), do: {:error, "sprite already has an active loop"}
   defp ensure_start_admissible(_status), do: :ok
 
+  defp ensure_start_preflight(%{role: :responder} = sprite), do: run_check_env_for_sprite(sprite)
+
+  defp ensure_start_preflight(%{"role" => "responder"} = sprite),
+    do: run_check_env_for_sprite(sprite)
+
+  defp ensure_start_preflight(_sprite), do: :ok
+
   defp ensure_sprite_ready_for_start(_sprite, %{reachable: true, healthy: true}), do: :ok
 
   defp ensure_sprite_ready_for_start(sprite, _status) do
@@ -809,6 +817,7 @@ defmodule Conductor.CLI do
            sprite_module().provision(sprite.name,
              repo: sprite.repo,
              persona: sprite.persona,
+             persona_role: workspace_module().persona_for_role(sprite.role),
              harness: sprite.harness
            ),
          :ok <- maybe_force_sync_codex_auth(sprite) do

--- a/conductor/lib/conductor/config.ex
+++ b/conductor/lib/conductor/config.ex
@@ -122,13 +122,13 @@ defmodule Conductor.Config do
   end
 
   @spec dispatch_env() :: [{binary(), binary()}]
-  def dispatch_env do
+  @spec dispatch_env(keyword()) :: [{binary(), binary()}]
+  def dispatch_env(opts \\ []) do
     # Render only the runtime API keys the harness still needs into the
     # sprite-side env file. GitHub auth is persisted separately during setup.
     []
     |> maybe_codex_api_env()
-    |> maybe_env("CANARY_ENDPOINT")
-    |> maybe_env("CANARY_API_KEY")
+    |> maybe_canary_env(opts)
     |> maybe_env("EXA_API_KEY")
     |> Enum.reverse()
   end
@@ -146,6 +146,18 @@ defmodule Conductor.Config do
       api_key -> [{"CODEX_API_KEY", api_key}, {"OPENAI_API_KEY", api_key} | acc]
     end
   end
+
+  defp maybe_canary_env(acc, opts) do
+    if canary_capability_role?(Keyword.get(opts, :persona_role)) do
+      acc
+      |> maybe_env("CANARY_ENDPOINT")
+      |> maybe_env("CANARY_API_KEY")
+    else
+      acc
+    end
+  end
+
+  defp canary_capability_role?(role), do: role in [:tansy, :responder, "tansy", "responder"]
 
   defp nonempty_env(key) do
     case System.get_env(key) do

--- a/conductor/lib/conductor/config.ex
+++ b/conductor/lib/conductor/config.ex
@@ -32,6 +32,21 @@ defmodule Conductor.Config do
     Application.get_env(:conductor, :event_log, ".bb/events.jsonl")
   end
 
+  @spec canary_services_path() :: binary()
+  def canary_services_path do
+    Application.get_env(:conductor, :canary_services_path, "../canary-services.toml")
+  end
+
+  @spec canary_endpoint() :: binary() | nil
+  def canary_endpoint do
+    nonempty_env("CANARY_ENDPOINT")
+  end
+
+  @spec canary_api_key() :: binary() | nil
+  def canary_api_key do
+    nonempty_env("CANARY_API_KEY")
+  end
+
   @spec session_timeout_minutes() :: pos_integer() | :infinity
   def session_timeout_minutes do
     Application.get_env(:conductor, :session_timeout_minutes, 60)
@@ -112,6 +127,8 @@ defmodule Conductor.Config do
     # sprite-side env file. GitHub auth is persisted separately during setup.
     []
     |> maybe_codex_api_env()
+    |> maybe_env("CANARY_ENDPOINT")
+    |> maybe_env("CANARY_API_KEY")
     |> maybe_env("EXA_API_KEY")
     |> Enum.reverse()
   end
@@ -155,6 +172,7 @@ defmodule Conductor.Config do
         {"SPRITE_TOKEN or sprite CLI auth", fn -> sprite_auth_available?(opts) end}
       ] ++
         maybe_codex_auth_check(opts) ++
+        maybe_canary_auth_check(opts) ++
         [
           {"gh", fn -> find_executable("gh") end},
           {"sprite", fn -> find_executable("sprite") end},
@@ -303,6 +321,17 @@ defmodule Conductor.Config do
   defp maybe_codex_auth_check(opts) do
     if Keyword.get(opts, :require_codex_auth, true) do
       [{"Codex ChatGPT auth cache or OPENAI_API_KEY", fn -> codex_auth_available?() end}]
+    else
+      []
+    end
+  end
+
+  defp maybe_canary_auth_check(opts) do
+    if Keyword.get(opts, :require_canary_auth, false) do
+      [
+        {"CANARY_ENDPOINT", fn -> canary_endpoint() end},
+        {"CANARY_API_KEY", fn -> canary_api_key() end}
+      ]
     else
       []
     end

--- a/conductor/lib/conductor/fleet/loader.ex
+++ b/conductor/lib/conductor/fleet/loader.ex
@@ -6,7 +6,7 @@ defmodule Conductor.Fleet.Loader do
   details. Callers get a list of sprite config maps or a clear error.
   """
 
-  @valid_roles ~w(builder fixer polisher triage)
+  @valid_roles ~w(builder fixer polisher triage responder)
   @valid_harnesses ~w(codex claude-code)
   @type sprite_config :: %{
           name: binary(),

--- a/conductor/lib/conductor/fleet/loader.ex
+++ b/conductor/lib/conductor/fleet/loader.ex
@@ -132,7 +132,12 @@ defmodule Conductor.Fleet.Loader do
         errors = for {:error, msg} <- results, do: msg
 
         if errors == [] do
-          {:ok, for({:ok, s} <- results, do: s)}
+          parsed = for({:ok, s} <- results, do: s)
+
+          case ensure_single_responder(parsed) do
+            :ok -> {:ok, parsed}
+            {:error, reason} -> {:error, reason}
+          end
         else
           {:error, "sprite validation errors:\n  #{Enum.join(errors, "\n  ")}"}
         end
@@ -200,4 +205,14 @@ defmodule Conductor.Fleet.Loader do
 
   defp valid_capability_tags?(tags) when is_list(tags), do: Enum.all?(tags, &is_binary/1)
   defp valid_capability_tags?(_), do: false
+
+  defp ensure_single_responder(sprites) do
+    responders = Enum.filter(sprites, &(&1.role == :responder))
+
+    case responders do
+      [_single] -> :ok
+      [] -> :ok
+      many -> {:error, "fleet.toml v1 supports only one responder sprite, found #{length(many)}"}
+    end
+  end
 end

--- a/conductor/lib/conductor/launcher.ex
+++ b/conductor/lib/conductor/launcher.ex
@@ -104,6 +104,7 @@ defmodule Conductor.Launcher do
   defp role_display_name(:fixer), do: "Thorn"
   defp role_display_name(:polisher), do: "Fern"
   defp role_display_name(:triage), do: "Muse"
+  defp role_display_name(:responder), do: "Tansy"
   defp role_display_name(role), do: to_string(role) |> String.capitalize()
 
   defp ensure_repo_checkout(sprite_config, repo, workspace) do

--- a/conductor/lib/conductor/launcher.ex
+++ b/conductor/lib/conductor/launcher.ex
@@ -53,6 +53,7 @@ defmodule Conductor.Launcher do
     end
 
     with :ok <- maybe_sync_codex_auth(sprite),
+         :ok <- ensure_launch_env(role),
          :ok <- bootstrap_module().ensure_spellbook(sprite),
          :ok <- ensure_repo_checkout(sprite_config, repo, workspace),
          :ok <- workspace_module().sync_persona(sprite, workspace, persona) do
@@ -107,6 +108,16 @@ defmodule Conductor.Launcher do
   defp role_display_name(:responder), do: "Tansy"
   defp role_display_name(role), do: to_string(role) |> String.capitalize()
 
+  defp ensure_launch_env(:responder) do
+    if Conductor.Config.canary_endpoint() && Conductor.Config.canary_api_key() do
+      :ok
+    else
+      {:error, "missing Canary responder credentials"}
+    end
+  end
+
+  defp ensure_launch_env(_role), do: :ok
+
   defp ensure_repo_checkout(sprite_config, repo, workspace) do
     sprite = sprite_config.name
     git_dir = Path.join(workspace, ".git")
@@ -123,6 +134,7 @@ defmodule Conductor.Launcher do
         sprite_module().provision(sprite,
           repo: repo,
           persona: sprite_config.persona,
+          persona_role: workspace_module().persona_for_role(sprite_config.role),
           harness: sprite_config.harness,
           force: false
         )

--- a/conductor/lib/conductor/sprite.ex
+++ b/conductor/lib/conductor/sprite.ex
@@ -115,7 +115,15 @@ defmodule Conductor.Sprite do
       prompt_path = Path.join(workspace, "PROMPT.md")
       runtime_env_path = Path.join(workspace, @runtime_env_file)
 
-      case upload_dispatch_files(exec_fn, sprite, prompt_path, prompt, runtime_env_path, repo) do
+      case upload_dispatch_files(
+             exec_fn,
+             sprite,
+             prompt_path,
+             prompt,
+             runtime_env_path,
+             repo,
+             opts
+           ) do
         {:error, msg, code} ->
           {:error, "dispatch file upload failed: #{msg}", code}
 
@@ -228,6 +236,7 @@ defmodule Conductor.Sprite do
   def provision(sprite, opts \\ []) do
     repo = Keyword.get(opts, :repo)
     persona = Keyword.get(opts, :persona)
+    persona_role = Keyword.get(opts, :persona_role)
     harness = Keyword.get(opts, :harness)
     force = Keyword.get(opts, :force, false)
     exec_fn = Keyword.get(opts, :exec_fn, &exec/3)
@@ -236,7 +245,7 @@ defmodule Conductor.Sprite do
          :ok <- upload_base_configs(sprite, persona, exec_fn),
          :ok <- ensure_codex(sprite, force, exec_fn),
          :ok <- maybe_sync_codex_auth(sprite, harness, exec_fn),
-         :ok <- upload_runtime_env(sprite, repo, exec_fn),
+         :ok <- upload_runtime_env(sprite, repo, exec_fn, persona_role: persona_role),
          :ok <- configure_git_auth(sprite, exec_fn),
          :ok <- maybe_setup_repo(sprite, repo, persona, force, exec_fn),
          :ok <- Conductor.Bootstrap.ensure_spellbook(sprite, exec_fn: exec_fn) do
@@ -691,8 +700,8 @@ defmodule Conductor.Sprite do
     end
   end
 
-  defp upload_runtime_env(sprite, repo, exec_fn) do
-    with_temp_file("sprite-runtime-env", runtime_env_contents(repo), fn runtime_env_file ->
+  defp upload_runtime_env(sprite, repo, exec_fn, opts) do
+    with_temp_file("sprite-runtime-env", runtime_env_contents(repo, opts), fn runtime_env_file ->
       case exec_fn.(sprite, "true",
              files: [{runtime_env_file, @sprite_runtime_env_path}],
              timeout: 30_000
@@ -977,18 +986,18 @@ defmodule Conductor.Sprite do
 
   defp shell_quote(value), do: Shell.quote_arg(to_string(value))
 
-  defp runtime_env_contents(repo) do
+  defp runtime_env_contents(repo, opts) do
     body =
-      (Config.dispatch_env() ++
+      (Config.dispatch_env(persona_role: Keyword.get(opts, :persona_role)) ++
          repo_env(repo))
       |> Enum.map_join("\n", fn {key, value} -> "export #{key}=#{shell_quote(value)}" end)
 
     if body == "", do: "# managed by Conductor\n", else: body <> "\n"
   end
 
-  defp upload_dispatch_files(exec_fn, sprite, prompt_path, prompt, runtime_env_path, repo) do
+  defp upload_dispatch_files(exec_fn, sprite, prompt_path, prompt, runtime_env_path, repo, opts) do
     with_temp_file("sprite-prompt", prompt, fn prompt_file ->
-      with_temp_file("sprite-env", runtime_env_contents(repo), fn env_file ->
+      with_temp_file("sprite-env", runtime_env_contents(repo, opts), fn env_file ->
         exec_fn.(sprite, "true",
           files: [{prompt_file, prompt_path}, {env_file, runtime_env_path}],
           timeout: 30_000

--- a/conductor/lib/conductor/workspace.ex
+++ b/conductor/lib/conductor/workspace.ex
@@ -10,7 +10,7 @@ defmodule Conductor.Workspace do
   @mirror_base "/home/sprite/workspace"
   @safe_input ~r/^[a-zA-Z0-9_\-\.\/]+$/
   @repo_segment ~r/^[A-Za-z0-9_.-]+$/
-  @persona_roles ~w(weaver thorn fern muse)
+  @persona_roles ~w(weaver thorn fern muse tansy)
 
   @doc "Validate that a string is safe for shell interpolation. Rejects metacharacters, path traversal, absolute paths, and leading dashes."
   @spec validate_input(binary()) :: :ok | {:error, :invalid_input}
@@ -118,6 +118,7 @@ defmodule Conductor.Workspace do
   def persona_for_role(:fixer), do: :thorn
   def persona_for_role(:polisher), do: :fern
   def persona_for_role(:triage), do: :muse
+  def persona_for_role(:responder), do: :tansy
   def persona_for_role(role), do: role
 
   # --- Private ---

--- a/conductor/mix.exs
+++ b/conductor/mix.exs
@@ -23,6 +23,7 @@ defmodule Conductor.MixProject do
     [
       {:exqlite, "~> 0.27"},
       {:jason, "~> 1.4"},
+      {:req, "~> 0.5"},
       {:phoenix, "~> 1.7"},
       {:phoenix_live_view, "~> 1.0"},
       {:phoenix_html, "~> 4.1"},

--- a/conductor/test/conductor/canary/client_test.exs
+++ b/conductor/test/conductor/canary/client_test.exs
@@ -160,6 +160,13 @@ defmodule Conductor.Canary.ClientTest do
     assert_received {:request, :incident_annotations, "Bearer canary-test-key"}
   end
 
+  test "rejects empty incident ids before building annotation routes" do
+    assert {:error, "incident id must not be empty"} = Client.incident_annotations("")
+
+    assert {:error, "incident id must not be empty"} =
+             Client.annotate_incident("  ", %{agent: "tansy", action: "bitterblossom.claimed"})
+  end
+
   test "creates incident annotations with json metadata" do
     assert {:ok, %{"agent" => "tansy", "action" => "bitterblossom.claimed"}} =
              Client.annotate_incident("INC-123", %{

--- a/conductor/test/conductor/canary/client_test.exs
+++ b/conductor/test/conductor/canary/client_test.exs
@@ -1,0 +1,192 @@
+defmodule Conductor.Canary.ClientTest do
+  use ExUnit.Case, async: false
+
+  alias Conductor.Canary.Client
+  import Plug.Conn
+
+  defmodule TestPlug do
+    use Plug.Router
+
+    plug(:match)
+
+    plug(Plug.Parsers,
+      parsers: [:json],
+      pass: ["application/json"],
+      json_decoder: Jason
+    )
+
+    plug(:dispatch)
+
+    get "/api/v1/incidents" do
+      notify({:request, :incidents, conn.query_params, auth_header(conn)})
+
+      json(conn, %{
+        incidents: [
+          %{
+            id: "INC-123",
+            service: "volume",
+            state: "investigating",
+            severity: "high",
+            title: "Volume is failing health checks"
+          }
+        ]
+      })
+    end
+
+    get "/api/v1/report" do
+      notify({:request, :report, conn.query_params, auth_header(conn)})
+
+      case conn.query_params["q"] do
+        "bad" ->
+          conn
+          |> put_resp_content_type("application/json")
+          |> send_resp(422, Jason.encode!(%{detail: "Invalid q parameter."}))
+
+        _ ->
+          json(conn, %{status: "degraded", summary: "1 service degraded."})
+      end
+    end
+
+    get "/api/v1/timeline" do
+      notify({:request, :timeline, conn.query_params, auth_header(conn)})
+
+      json(conn, %{
+        summary: "2 recent events.",
+        events: [
+          %{
+            id: "EVT-1",
+            service: "volume",
+            event: "incident.opened",
+            severity: "high",
+            summary: "Incident opened for volume.",
+            created_at: "2026-04-08T12:00:00Z"
+          }
+        ]
+      })
+    end
+
+    get "/api/v1/incidents/INC-123/annotations" do
+      notify({:request, :incident_annotations, auth_header(conn)})
+
+      json(conn, %{annotations: [%{agent: "tansy", action: "bitterblossom.claimed"}]})
+    end
+
+    post "/api/v1/incidents/INC-123/annotations" do
+      notify({:request, :annotate_incident, conn.body_params, auth_header(conn)})
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(
+        201,
+        Jason.encode!(%{
+          created_at: "2026-04-08T12:02:00Z",
+          agent: conn.body_params["agent"],
+          action: conn.body_params["action"]
+        })
+      )
+    end
+
+    match _ do
+      send_resp(conn, 404, "not found")
+    end
+
+    defp json(conn, body) do
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, Jason.encode!(body))
+    end
+
+    defp auth_header(conn) do
+      conn |> get_req_header("authorization") |> List.first()
+    end
+
+    defp notify(message) do
+      if pid = Application.get_env(:conductor, :canary_test_pid) do
+        send(pid, message)
+      end
+    end
+  end
+
+  setup do
+    original_endpoint = System.get_env("CANARY_ENDPOINT")
+    original_api_key = System.get_env("CANARY_API_KEY")
+    original_test_pid = Application.get_env(:conductor, :canary_test_pid)
+
+    port = free_port()
+
+    start_supervised!({Bandit, plug: TestPlug, scheme: :http, port: port})
+    Application.put_env(:conductor, :canary_test_pid, self())
+    System.put_env("CANARY_ENDPOINT", "http://127.0.0.1:#{port}")
+    System.put_env("CANARY_API_KEY", "canary-test-key")
+
+    on_exit(fn ->
+      restore_env("CANARY_ENDPOINT", original_endpoint)
+      restore_env("CANARY_API_KEY", original_api_key)
+
+      if original_test_pid,
+        do: Application.put_env(:conductor, :canary_test_pid, original_test_pid),
+        else: Application.delete_env(:conductor, :canary_test_pid)
+    end)
+
+    :ok
+  end
+
+  test "lists incidents with query filters and bearer auth" do
+    assert {:ok, %{"incidents" => [%{"id" => "INC-123"}]}} =
+             Client.incidents(without_annotation: "bitterblossom.claimed")
+
+    assert_received {:request, :incidents, %{"without_annotation" => "bitterblossom.claimed"},
+                     "Bearer canary-test-key"}
+  end
+
+  test "fetches timeline with bounded query params" do
+    assert {:ok, %{"events" => [%{"event" => "incident.opened"}]}} =
+             Client.timeline(service: "volume", window: "24h", limit: 50)
+
+    assert_received {:request, :timeline,
+                     %{"limit" => "50", "service" => "volume", "window" => "24h"},
+                     "Bearer canary-test-key"}
+  end
+
+  test "lists incident annotations" do
+    assert {:ok, %{"annotations" => [%{"action" => "bitterblossom.claimed"}]}} =
+             Client.incident_annotations("INC-123")
+
+    assert_received {:request, :incident_annotations, "Bearer canary-test-key"}
+  end
+
+  test "creates incident annotations with json metadata" do
+    assert {:ok, %{"agent" => "tansy", "action" => "bitterblossom.claimed"}} =
+             Client.annotate_incident("INC-123", %{
+               agent: "tansy",
+               action: "bitterblossom.claimed",
+               metadata: %{service: "volume"}
+             })
+
+    assert_received {:request, :annotate_incident, body, "Bearer canary-test-key"}
+    assert body["agent"] == "tansy"
+    assert body["action"] == "bitterblossom.claimed"
+    assert body["metadata"] == %{"service" => "volume"}
+  end
+
+  test "maps Canary validation errors into readable messages" do
+    assert {:error, "Canary API 422: Invalid q parameter."} = Client.report(q: "bad")
+  end
+
+  test "fails clearly when Canary credentials are missing" do
+    System.delete_env("CANARY_ENDPOINT")
+    System.delete_env("CANARY_API_KEY")
+
+    assert {:error, "CANARY_ENDPOINT and CANARY_API_KEY must be set"} = Client.report()
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(socket)
+    :gen_tcp.close(socket)
+    port
+  end
+
+  defp restore_env(key, nil), do: System.delete_env(key)
+  defp restore_env(key, value), do: System.put_env(key, value)
+end

--- a/conductor/test/conductor/canary/client_test.exs
+++ b/conductor/test/conductor/canary/client_test.exs
@@ -42,6 +42,11 @@ defmodule Conductor.Canary.ClientTest do
           |> put_resp_content_type("application/json")
           |> send_resp(422, Jason.encode!(%{detail: "Invalid q parameter."}))
 
+        "map-error" ->
+          conn
+          |> put_resp_content_type("application/json")
+          |> send_resp(500, Jason.encode!(%{code: "boom"}))
+
         _ ->
           json(conn, %{status: "degraded", summary: "1 service degraded."})
       end
@@ -173,11 +178,23 @@ defmodule Conductor.Canary.ClientTest do
     assert {:error, "Canary API 422: Invalid q parameter."} = Client.report(q: "bad")
   end
 
+  test "maps Canary map-shaped errors without detail" do
+    assert {:error, ~s(Canary API 500: {"code":"boom"})} = Client.report(q: "map-error")
+  end
+
   test "fails clearly when Canary credentials are missing" do
     System.delete_env("CANARY_ENDPOINT")
     System.delete_env("CANARY_API_KEY")
 
     assert {:error, "CANARY_ENDPOINT and CANARY_API_KEY must be set"} = Client.report()
+  end
+
+  test "surfaces transport failures" do
+    unused_port = free_port()
+    System.put_env("CANARY_ENDPOINT", "http://127.0.0.1:#{unused_port}")
+
+    assert {:error, message} = Client.report()
+    assert message =~ "connection refused"
   end
 
   defp free_port do

--- a/conductor/test/conductor/canary/service_catalog_test.exs
+++ b/conductor/test/conductor/canary/service_catalog_test.exs
@@ -1,0 +1,167 @@
+defmodule Conductor.Canary.ServiceCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias Conductor.Canary.ServiceCatalog
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "canary-services-#{System.unique_integer([:positive])}.toml"
+      )
+
+    on_exit(fn -> File.rm(path) end)
+    %{path: path}
+  end
+
+  test "loads valid services with defaults", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "ci:dagger:all-no-e2e"]
+
+      [[service]]
+      name = "canary"
+      repo = "misty-step/canary"
+      default_branch = "master"
+      test_cmd = ["./bin/validate"]
+      auto_merge = true
+      auto_deploy = true
+      deploy_cmd = ["flyctl", "deploy", "--app", "canary-obs", "--remote-only"]
+      rollback_cmd = ["flyctl", "releases", "rollback", "--app", "canary-obs"]
+      stabilization_window_s = 900
+      """
+    )
+
+    assert {:ok, services} = ServiceCatalog.load(path)
+    assert length(services) == 2
+
+    assert {:ok, linejam} = ServiceCatalog.resolve(services, "linejam")
+    assert linejam.repo == "misty-step/linejam"
+    assert linejam.auto_merge == false
+    assert linejam.auto_deploy == false
+    assert linejam.stabilization_window_s == 600
+
+    assert {:ok, canary} = ServiceCatalog.resolve(services, "canary")
+    assert canary.auto_merge == true
+    assert canary.auto_deploy == true
+    assert canary.deploy_cmd == ["flyctl", "deploy", "--app", "canary-obs", "--remote-only"]
+    assert canary.rollback_cmd == ["flyctl", "releases", "rollback", "--app", "canary-obs"]
+    assert canary.stabilization_window_s == 900
+  end
+
+  test "returns not_found for unknown services", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "test"]
+      """
+    )
+
+    assert {:ok, services} = ServiceCatalog.load(path)
+    assert {:error, :not_found} = ServiceCatalog.resolve(services, "unknown")
+  end
+
+  test "rejects missing service entries", %{path: path} do
+    File.write!(path, "")
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "no [[service]] entries"
+  end
+
+  test "rejects duplicate service names", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "test"]
+
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "test"]
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "duplicate service name 'linejam'"
+  end
+
+  test "rejects unknown keys", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "test"]
+      webhook_url = "https://example.com"
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "unknown keys: webhook_url"
+  end
+
+  test "rejects invalid repos", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "../linejam"
+      default_branch = "master"
+      test_cmd = ["pnpm", "test"]
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "invalid repo '../linejam'"
+  end
+
+  test "rejects shell command strings", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "linejam"
+      repo = "misty-step/linejam"
+      default_branch = "master"
+      test_cmd = "pnpm test"
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "test_cmd must be a non-empty array of strings"
+  end
+
+  test "requires rollback command for auto deploy", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "canary"
+      repo = "misty-step/canary"
+      default_branch = "master"
+      test_cmd = ["./bin/validate"]
+      auto_deploy = true
+      deploy_cmd = ["flyctl", "deploy", "--app", "canary-obs", "--remote-only"]
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "enables auto_deploy without rollback_cmd"
+  end
+end

--- a/conductor/test/conductor/canary/service_catalog_test.exs
+++ b/conductor/test/conductor/canary/service_catalog_test.exs
@@ -164,4 +164,22 @@ defmodule Conductor.Canary.ServiceCatalogTest do
     assert {:error, msg} = ServiceCatalog.load(path)
     assert msg =~ "enables auto_deploy without rollback_cmd"
   end
+
+  test "requires deploy command for auto deploy", %{path: path} do
+    File.write!(
+      path,
+      """
+      [[service]]
+      name = "canary"
+      repo = "misty-step/canary"
+      default_branch = "master"
+      test_cmd = ["./bin/validate"]
+      auto_deploy = true
+      rollback_cmd = ["flyctl", "releases", "rollback", "--app", "canary-obs"]
+      """
+    )
+
+    assert {:error, msg} = ServiceCatalog.load(path)
+    assert msg =~ "enables auto_deploy without deploy_cmd"
+  end
 end

--- a/conductor/test/conductor/cli_canary_test.exs
+++ b/conductor/test/conductor/cli_canary_test.exs
@@ -418,6 +418,20 @@ defmodule Conductor.CLICanaryTest do
     assert output =~ "--metadata must be a JSON object"
   end
 
+  test "rejects empty incident ids for annotations" do
+    {output, status} =
+      System.cmd(
+        "mix",
+        ["conductor", "canary", "annotations", "incident", ""],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "incident id must not be empty"
+  end
+
   test "prints usage on missing canary subcommands" do
     {output, status} =
       System.cmd("mix", ["conductor", "canary"],

--- a/conductor/test/conductor/cli_canary_test.exs
+++ b/conductor/test/conductor/cli_canary_test.exs
@@ -183,6 +183,26 @@ defmodule Conductor.CLICanaryTest do
     assert output =~ "test_cmd: make test"
   end
 
+  test "uses the configured default catalog path", %{path: path} do
+    original_path = Application.get_env(:conductor, :canary_services_path)
+
+    on_exit(fn ->
+      if original_path,
+        do: Application.put_env(:conductor, :canary_services_path, original_path),
+        else: Application.delete_env(:conductor, :canary_services_path)
+    end)
+
+    Application.put_env(:conductor, :canary_services_path, path)
+
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "service", "volume", "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert decoded["name"] == "volume"
+  end
+
   test "prints incidents and forwards annotation filters" do
     output =
       capture_io(fn ->
@@ -348,6 +368,28 @@ defmodule Conductor.CLICanaryTest do
 
     assert status == 1
     assert output =~ "missing required --action"
+  end
+
+  test "validates missing annotation agent" do
+    {output, status} =
+      System.cmd(
+        "mix",
+        [
+          "conductor",
+          "canary",
+          "annotate",
+          "incident",
+          "INC-123",
+          "--action",
+          "bitterblossom.claimed"
+        ],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "missing required --agent"
   end
 
   test "validates annotation metadata json" do

--- a/conductor/test/conductor/cli_canary_test.exs
+++ b/conductor/test/conductor/cli_canary_test.exs
@@ -11,81 +11,105 @@ defmodule Conductor.CLICanaryTest do
     def incidents(opts) do
       notify({:incidents_called, opts})
 
-      {:ok,
-       %{
-         "incidents" => [
-           %{
-             "id" => "INC-123",
-             "service" => "volume",
-             "severity" => "high",
-             "state" => "investigating",
-             "title" => "Volume is failing health checks"
-           }
-         ]
-       }}
+      if error = mock_error(:incidents) do
+        {:error, error}
+      else
+        {:ok,
+         %{
+           "incidents" => [
+             %{
+               "id" => "INC-123",
+               "service" => "volume",
+               "severity" => "high",
+               "state" => "investigating",
+               "title" => "Volume is failing health checks"
+             }
+           ]
+         }}
+      end
     end
 
     def report(opts) do
       notify({:report_called, opts})
 
-      {:ok,
-       %{
-         "status" => "degraded",
-         "summary" => "1 service degraded.",
-         "incidents" => [%{"id" => "INC-123"}],
-         "error_groups" => [%{"group_hash" => "grp-1"}],
-         "targets" => [%{"id" => "tgt-1"}]
-       }}
+      if error = mock_error(:report) do
+        {:error, error}
+      else
+        {:ok,
+         %{
+           "status" => "degraded",
+           "summary" => "1 service degraded.",
+           "incidents" => [%{"id" => "INC-123"}],
+           "error_groups" => [%{"group_hash" => "grp-1"}],
+           "targets" => [%{"id" => "tgt-1"}]
+         }}
+      end
     end
 
     def timeline(opts) do
       notify({:timeline_called, opts})
 
-      {:ok,
-       %{
-         "summary" => "2 recent events.",
-         "events" => [
-           %{
-             "created_at" => "2026-04-08T12:00:00Z",
-             "service" => "volume",
-             "event" => "incident.opened",
-             "severity" => "high",
-             "summary" => "Incident opened for volume."
-           }
-         ]
-       }}
+      if error = mock_error(:timeline) do
+        {:error, error}
+      else
+        {:ok,
+         %{
+           "summary" => "2 recent events.",
+           "events" => [
+             %{
+               "created_at" => "2026-04-08T12:00:00Z",
+               "service" => "volume",
+               "event" => "incident.opened",
+               "severity" => "high",
+               "summary" => "Incident opened for volume."
+             }
+           ]
+         }}
+      end
     end
 
     def incident_annotations(incident_id) do
       notify({:incident_annotations_called, incident_id})
 
-      {:ok,
-       %{
-         "annotations" => [
-           %{
-             "created_at" => "2026-04-08T12:01:00Z",
-             "agent" => "tansy",
-             "action" => "bitterblossom.claimed"
-           }
-         ]
-       }}
+      if error = mock_error(:incident_annotations) do
+        {:error, error}
+      else
+        {:ok,
+         %{
+           "annotations" => [
+             %{
+               "created_at" => "2026-04-08T12:01:00Z",
+               "agent" => "tansy",
+               "action" => "bitterblossom.claimed"
+             }
+           ]
+         }}
+      end
     end
 
     def annotate_incident(incident_id, attrs) do
       notify({:annotate_incident_called, incident_id, attrs})
 
-      {:ok,
-       %{
-         "created_at" => "2026-04-08T12:02:00Z",
-         "agent" => attrs.agent,
-         "action" => attrs.action
-       }}
+      if error = mock_error(:annotate_incident) do
+        {:error, error}
+      else
+        {:ok,
+         %{
+           "created_at" => "2026-04-08T12:02:00Z",
+           "agent" => attrs.agent,
+           "action" => attrs.action
+         }}
+      end
     end
 
     defp notify(message) do
       if pid = Application.get_env(:conductor, :canary_test_pid) do
         send(pid, message)
       end
+    end
+
+    defp mock_error(key) do
+      Application.get_env(:conductor, :canary_mock_errors, %{}) |> Map.get(key)
     end
   end
 
@@ -106,9 +130,11 @@ defmodule Conductor.CLICanaryTest do
     """)
 
     original_client = Application.get_env(:conductor, :canary_client_module)
+    original_errors = Application.get_env(:conductor, :canary_mock_errors)
     original_test_pid = Application.get_env(:conductor, :canary_test_pid)
 
     Application.put_env(:conductor, :canary_client_module, MockCanaryClient)
+    Application.put_env(:conductor, :canary_mock_errors, %{})
     Application.put_env(:conductor, :canary_test_pid, self())
 
     on_exit(fn ->
@@ -117,6 +143,10 @@ defmodule Conductor.CLICanaryTest do
       if original_client,
         do: Application.put_env(:conductor, :canary_client_module, original_client),
         else: Application.delete_env(:conductor, :canary_client_module)
+
+      if original_errors,
+        do: Application.put_env(:conductor, :canary_mock_errors, original_errors),
+        else: Application.delete_env(:conductor, :canary_mock_errors)
 
       if original_test_pid,
         do: Application.put_env(:conductor, :canary_test_pid, original_test_pid),
@@ -169,6 +199,16 @@ defmodule Conductor.CLICanaryTest do
     assert output =~ "INC-123 volume high investigating Volume is failing health checks"
   end
 
+  test "prints incidents as json" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "incidents", "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert get_in(decoded, ["incidents", Access.at(0), "id"]) == "INC-123"
+  end
+
   test "prints report summary and forwards query options" do
     output =
       capture_io(fn ->
@@ -180,6 +220,16 @@ defmodule Conductor.CLICanaryTest do
     assert opts[:limit] == 5
     assert output =~ "status: degraded"
     assert output =~ "summary: 1 service degraded."
+  end
+
+  test "prints report as json" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "report", "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert decoded["status"] == "degraded"
   end
 
   test "prints timeline summary and events" do
@@ -195,6 +245,16 @@ defmodule Conductor.CLICanaryTest do
     assert output =~ "incident.opened"
   end
 
+  test "prints timeline as json" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "timeline", "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert get_in(decoded, ["events", Access.at(0), "event"]) == "incident.opened"
+  end
+
   test "lists incident annotations" do
     output =
       capture_io(fn ->
@@ -203,6 +263,16 @@ defmodule Conductor.CLICanaryTest do
 
     assert_received {:incident_annotations_called, "INC-123"}
     assert output =~ "tansy bitterblossom.claimed"
+  end
+
+  test "lists incident annotations as json" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "annotations", "incident", "INC-123", "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert get_in(decoded, ["annotations", Access.at(0), "action"]) == "bitterblossom.claimed"
   end
 
   test "creates incident annotations from json metadata" do
@@ -227,6 +297,83 @@ defmodule Conductor.CLICanaryTest do
     assert attrs.action == "bitterblossom.claimed"
     assert attrs.metadata == %{"service" => "volume"}
     assert output =~ "tansy bitterblossom.claimed"
+  end
+
+  test "creates incident annotations as json" do
+    output =
+      capture_io(fn ->
+        CLI.main([
+          "canary",
+          "annotate",
+          "incident",
+          "INC-123",
+          "--agent",
+          "tansy",
+          "--action",
+          "bitterblossom.claimed",
+          "--json"
+        ])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert decoded["agent"] == "tansy"
+    assert decoded["action"] == "bitterblossom.claimed"
+  end
+
+  test "fails clearly when Canary credentials are missing for incidents" do
+    {output, status} =
+      System.cmd("mix", ["conductor", "canary", "incidents"],
+        cd: @conductor_dir,
+        env: [
+          {"MIX_ENV", "test"},
+          {"CANARY_ENDPOINT", ""},
+          {"CANARY_API_KEY", ""}
+        ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "CANARY_ENDPOINT and CANARY_API_KEY must be set"
+  end
+
+  test "validates missing annotation arguments" do
+    {output, status} =
+      System.cmd(
+        "mix",
+        ["conductor", "canary", "annotate", "incident", "INC-123", "--agent", "tansy"],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "missing required --action"
+  end
+
+  test "validates annotation metadata json" do
+    {output, status} =
+      System.cmd(
+        "mix",
+        [
+          "conductor",
+          "canary",
+          "annotate",
+          "incident",
+          "INC-123",
+          "--agent",
+          "tansy",
+          "--action",
+          "bitterblossom.claimed",
+          "--metadata",
+          "[]"
+        ],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "--metadata must be a JSON object"
   end
 
   test "prints usage on missing canary subcommands" do

--- a/conductor/test/conductor/cli_canary_test.exs
+++ b/conductor/test/conductor/cli_canary_test.exs
@@ -1,0 +1,257 @@
+defmodule Conductor.CLICanaryTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Conductor.CLI
+
+  @conductor_dir Path.expand("../..", __DIR__)
+
+  defmodule MockCanaryClient do
+    def incidents(opts) do
+      notify({:incidents_called, opts})
+
+      {:ok,
+       %{
+         "incidents" => [
+           %{
+             "id" => "INC-123",
+             "service" => "volume",
+             "severity" => "high",
+             "state" => "investigating",
+             "title" => "Volume is failing health checks"
+           }
+         ]
+       }}
+    end
+
+    def report(opts) do
+      notify({:report_called, opts})
+
+      {:ok,
+       %{
+         "status" => "degraded",
+         "summary" => "1 service degraded.",
+         "incidents" => [%{"id" => "INC-123"}],
+         "error_groups" => [%{"group_hash" => "grp-1"}],
+         "targets" => [%{"id" => "tgt-1"}]
+       }}
+    end
+
+    def timeline(opts) do
+      notify({:timeline_called, opts})
+
+      {:ok,
+       %{
+         "summary" => "2 recent events.",
+         "events" => [
+           %{
+             "created_at" => "2026-04-08T12:00:00Z",
+             "service" => "volume",
+             "event" => "incident.opened",
+             "severity" => "high",
+             "summary" => "Incident opened for volume."
+           }
+         ]
+       }}
+    end
+
+    def incident_annotations(incident_id) do
+      notify({:incident_annotations_called, incident_id})
+
+      {:ok,
+       %{
+         "annotations" => [
+           %{
+             "created_at" => "2026-04-08T12:01:00Z",
+             "agent" => "tansy",
+             "action" => "bitterblossom.claimed"
+           }
+         ]
+       }}
+    end
+
+    def annotate_incident(incident_id, attrs) do
+      notify({:annotate_incident_called, incident_id, attrs})
+
+      {:ok,
+       %{
+         "created_at" => "2026-04-08T12:02:00Z",
+         "agent" => attrs.agent,
+         "action" => attrs.action
+       }}
+    end
+
+    defp notify(message) do
+      if pid = Application.get_env(:conductor, :canary_test_pid) do
+        send(pid, message)
+      end
+    end
+  end
+
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "canary-services-cli-test-#{System.unique_integer([:positive])}.toml"
+      )
+
+    File.write!(path, """
+    [[service]]
+    name = "volume"
+    repo = "misty-step/volume"
+    default_branch = "main"
+    test_cmd = ["make", "test"]
+    auto_merge = true
+    """)
+
+    original_client = Application.get_env(:conductor, :canary_client_module)
+    original_test_pid = Application.get_env(:conductor, :canary_test_pid)
+
+    Application.put_env(:conductor, :canary_client_module, MockCanaryClient)
+    Application.put_env(:conductor, :canary_test_pid, self())
+
+    on_exit(fn ->
+      File.rm(path)
+
+      if original_client,
+        do: Application.put_env(:conductor, :canary_client_module, original_client),
+        else: Application.delete_env(:conductor, :canary_client_module)
+
+      if original_test_pid,
+        do: Application.put_env(:conductor, :canary_test_pid, original_test_pid),
+        else: Application.delete_env(:conductor, :canary_test_pid)
+    end)
+
+    %{path: path}
+  end
+
+  test "prints a resolved service as json", %{path: path} do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "service", "volume", "--catalog", path, "--json"])
+      end)
+
+    assert {:ok, decoded} = Jason.decode(output)
+    assert decoded["name"] == "volume"
+    assert decoded["repo"] == "misty-step/volume"
+    assert decoded["default_branch"] == "main"
+    assert decoded["test_cmd"] == ["make", "test"]
+    assert decoded["auto_merge"] == true
+    assert decoded["auto_deploy"] == false
+  end
+
+  test "prints a readable service summary without --json", %{path: path} do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "service", "volume", "--catalog", path])
+      end)
+
+    assert output =~ "service: volume"
+    assert output =~ "repo: misty-step/volume"
+    assert output =~ "default_branch: main"
+    assert output =~ "test_cmd: make test"
+  end
+
+  test "prints incidents and forwards annotation filters" do
+    output =
+      capture_io(fn ->
+        CLI.main([
+          "canary",
+          "incidents",
+          "--without-annotation",
+          "bitterblossom.claimed"
+        ])
+      end)
+
+    assert_received {:incidents_called, opts}
+    assert opts[:without_annotation] == "bitterblossom.claimed"
+    assert output =~ "INC-123 volume high investigating Volume is failing health checks"
+  end
+
+  test "prints report summary and forwards query options" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "report", "--window", "24h", "--limit", "5"])
+      end)
+
+    assert_received {:report_called, opts}
+    assert opts[:window] == "24h"
+    assert opts[:limit] == 5
+    assert output =~ "status: degraded"
+    assert output =~ "summary: 1 service degraded."
+  end
+
+  test "prints timeline summary and events" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "timeline", "--service", "volume", "--window", "24h"])
+      end)
+
+    assert_received {:timeline_called, opts}
+    assert opts[:service] == "volume"
+    assert opts[:window] == "24h"
+    assert output =~ "summary: 2 recent events."
+    assert output =~ "incident.opened"
+  end
+
+  test "lists incident annotations" do
+    output =
+      capture_io(fn ->
+        CLI.main(["canary", "annotations", "incident", "INC-123"])
+      end)
+
+    assert_received {:incident_annotations_called, "INC-123"}
+    assert output =~ "tansy bitterblossom.claimed"
+  end
+
+  test "creates incident annotations from json metadata" do
+    output =
+      capture_io(fn ->
+        CLI.main([
+          "canary",
+          "annotate",
+          "incident",
+          "INC-123",
+          "--agent",
+          "tansy",
+          "--action",
+          "bitterblossom.claimed",
+          "--metadata",
+          ~s({"service":"volume"})
+        ])
+      end)
+
+    assert_received {:annotate_incident_called, "INC-123", attrs}
+    assert attrs.agent == "tansy"
+    assert attrs.action == "bitterblossom.claimed"
+    assert attrs.metadata == %{"service" => "volume"}
+    assert output =~ "tansy bitterblossom.claimed"
+  end
+
+  test "prints usage on missing canary subcommands" do
+    {output, status} =
+      System.cmd("mix", ["conductor", "canary"],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+
+    assert output =~
+             "usage: bitterblossom canary <service|incidents|report|timeline|annotations|annotate> ..."
+  end
+
+  test "fails clearly for unknown services", %{path: path} do
+    {output, status} =
+      System.cmd("mix", ["conductor", "canary", "service", "missing", "--catalog", path],
+        cd: @conductor_dir,
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "unknown Canary service: missing"
+  end
+end

--- a/conductor/test/conductor/cli_fleet_test.exs
+++ b/conductor/test/conductor/cli_fleet_test.exs
@@ -387,13 +387,57 @@ defmodule Conductor.CLIFleetTest do
     assert opts[:sprite_auth_probe_target] == "bb-weaver-3"
 
     assert_received {:provision_called, "bb-weaver-3",
-                     [repo: "other/other-repo", persona: nil, harness: "codex"]}
+                     [
+                       repo: "other/other-repo",
+                       persona: nil,
+                       persona_role: :weaver,
+                       harness: "codex"
+                     ]}
 
     assert_received {:force_sync_called, "bb-weaver-3"}
     assert_received {:sync_persona_called, "bb-weaver-3", "/tmp/other/other-repo", :weaver}
     assert_received {:start_loop_called, "bb-weaver-3", prompt, "other/other-repo", opts}
     assert prompt =~ "Repository: other/other-repo"
     assert opts[:workspace] == "/tmp/other/other-repo"
+  end
+
+  test "sprite start runs preflight for healthy responder sprites" do
+    responder_fleet_path =
+      Path.join(
+        System.tmp_dir!(),
+        "fleet_cli_responder_#{System.unique_integer([:positive])}.toml"
+      )
+
+    File.write!(
+      responder_fleet_path,
+      """
+      version = "1"
+
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-tansy"
+      role = "responder"
+      """
+    )
+
+    Application.put_env(:conductor, :sprite_module, MockSpriteModule)
+    Application.put_env(:conductor, :workspace_module, MockWorkspaceModule)
+    Application.put_env(:conductor, :config_module, MockConfigModule)
+    Application.put_env(:conductor, :sprite_test_pid, self())
+
+    output =
+      capture_io(fn ->
+        CLI.main(["sprite", "start", "bb-tansy", "--fleet", responder_fleet_path])
+      end)
+
+    assert output =~ "started bb-tansy (pid 123)"
+    assert_received {:check_env_called, opts}
+    assert opts[:require_canary_auth] == true
+    assert opts[:sprite_auth_probe_target] == "bb-tansy"
+
+    File.rm(responder_fleet_path)
   end
 
   test "sprite resume resumes a declared sprite", %{fleet_path: fleet_path} do

--- a/conductor/test/conductor/cli_fleet_test.exs
+++ b/conductor/test/conductor/cli_fleet_test.exs
@@ -598,6 +598,42 @@ defmodule Conductor.CLIFleetTest do
     assert opts[:sprite_auth_probe_target] == "bb-weaver-1"
   end
 
+  test "check-env requires Canary auth for responder fleets" do
+    responder_fleet_path =
+      Path.join(
+        System.tmp_dir!(),
+        "fleet_cli_responder_#{System.unique_integer([:positive])}.toml"
+      )
+
+    File.write!(
+      responder_fleet_path,
+      """
+      version = "1"
+
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-tansy"
+      role = "responder"
+      """
+    )
+
+    Application.put_env(:conductor, :config_module, MockConfigModule)
+    Application.put_env(:conductor, :sprite_test_pid, self())
+
+    capture_io(fn ->
+      CLI.main(["check-env", "--fleet", responder_fleet_path])
+    end)
+
+    assert_received {:check_env_called, opts}
+    assert opts[:require_codex_auth] == true
+    assert opts[:require_canary_auth] == true
+    assert opts[:sprite_auth_probe_target] == "bb-tansy"
+
+    File.rm(responder_fleet_path)
+  end
+
   test "mix conductor sprite rejects unknown subcommands with exit 1" do
     {output, status} =
       System.cmd("mix", ["conductor", "sprite", "sttaus"],

--- a/conductor/test/conductor/config_dispatch_env_test.exs
+++ b/conductor/test/conductor/config_dispatch_env_test.exs
@@ -6,7 +6,9 @@ defmodule Conductor.ConfigDispatchEnvTest do
 
   setup do
     original_env =
-      for key <- ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY), into: %{} do
+      for key <-
+            ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY CANARY_ENDPOINT CANARY_API_KEY),
+          into: %{} do
         {key, System.get_env(key)}
       end
 
@@ -15,6 +17,8 @@ defmodule Conductor.ConfigDispatchEnvTest do
     System.delete_env("OPENAI_API_KEY")
     System.delete_env("GITHUB_TOKEN")
     System.delete_env("EXA_API_KEY")
+    System.delete_env("CANARY_ENDPOINT")
+    System.delete_env("CANARY_API_KEY")
 
     on_exit(fn ->
       File.rm_rf(codex_home)
@@ -78,6 +82,16 @@ defmodule Conductor.ConfigDispatchEnvTest do
       env = Config.dispatch_env()
 
       assert {"EXA_API_KEY", "exa-test-key"} in env
+    end
+
+    test "includes Canary credentials when set" do
+      System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+      System.put_env("CANARY_API_KEY", "canary-test-key")
+
+      env = Config.dispatch_env()
+
+      assert {"CANARY_ENDPOINT", "https://canary-obs.fly.dev"} in env
+      assert {"CANARY_API_KEY", "canary-test-key"} in env
     end
   end
 end

--- a/conductor/test/conductor/config_dispatch_env_test.exs
+++ b/conductor/test/conductor/config_dispatch_env_test.exs
@@ -84,11 +84,21 @@ defmodule Conductor.ConfigDispatchEnvTest do
       assert {"EXA_API_KEY", "exa-test-key"} in env
     end
 
-    test "includes Canary credentials when set" do
+    test "does not include Canary credentials by default even when set" do
       System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
       System.put_env("CANARY_API_KEY", "canary-test-key")
 
       env = Config.dispatch_env()
+
+      refute {"CANARY_ENDPOINT", "https://canary-obs.fly.dev"} in env
+      refute {"CANARY_API_KEY", "canary-test-key"} in env
+    end
+
+    test "includes Canary credentials for the responder persona" do
+      System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+      System.put_env("CANARY_API_KEY", "canary-test-key")
+
+      env = Config.dispatch_env(persona_role: :tansy)
 
       assert {"CANARY_ENDPOINT", "https://canary-obs.fly.dev"} in env
       assert {"CANARY_API_KEY", "canary-test-key"} in env

--- a/conductor/test/conductor/config_test.exs
+++ b/conductor/test/conductor/config_test.exs
@@ -53,7 +53,8 @@ defmodule Conductor.ConfigTest do
 
   describe "canary_services_path/0" do
     test "returns default when no app config" do
-      assert Config.canary_services_path() == "../canary-services.toml"
+      assert Config.canary_services_path() ==
+               Application.fetch_env!(:conductor, :canary_services_path)
     end
 
     test "returns configured value" do

--- a/conductor/test/conductor/config_test.exs
+++ b/conductor/test/conductor/config_test.exs
@@ -9,12 +9,16 @@ defmodule Conductor.ConfigTest do
     original_home = System.get_env("HOME")
     original_codex_home = System.get_env("CODEX_HOME")
     original_openai_key = System.get_env("OPENAI_API_KEY")
+    original_canary_endpoint = System.get_env("CANARY_ENDPOINT")
+    original_canary_api_key = System.get_env("CANARY_API_KEY")
     original_path = System.get_env("PATH")
 
     on_exit(fn ->
       restore_home(original_home)
       restore_env("CODEX_HOME", original_codex_home)
       restore_env("OPENAI_API_KEY", original_openai_key)
+      restore_env("CANARY_ENDPOINT", original_canary_endpoint)
+      restore_env("CANARY_API_KEY", original_canary_api_key)
       restore_env("PATH", original_path)
     end)
 
@@ -44,6 +48,43 @@ defmodule Conductor.ConfigTest do
       assert Config.event_log_path() == "/tmp/events.jsonl"
     after
       Application.delete_env(:conductor, :event_log)
+    end
+  end
+
+  describe "canary_services_path/0" do
+    test "returns default when no app config" do
+      assert Config.canary_services_path() == "../canary-services.toml"
+    end
+
+    test "returns configured value" do
+      Application.put_env(:conductor, :canary_services_path, "/tmp/canary-services.toml")
+      assert Config.canary_services_path() == "/tmp/canary-services.toml"
+    after
+      Application.delete_env(:conductor, :canary_services_path)
+    end
+  end
+
+  describe "canary_endpoint/0 and canary_api_key/0" do
+    test "read non-empty Canary credentials from the environment" do
+      System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+      System.put_env("CANARY_API_KEY", "canary-test-key")
+
+      assert Config.canary_endpoint() == "https://canary-obs.fly.dev"
+      assert Config.canary_api_key() == "canary-test-key"
+    after
+      System.delete_env("CANARY_ENDPOINT")
+      System.delete_env("CANARY_API_KEY")
+    end
+
+    test "treat empty Canary credentials as missing" do
+      System.put_env("CANARY_ENDPOINT", "")
+      System.put_env("CANARY_API_KEY", "")
+
+      assert Config.canary_endpoint() == nil
+      assert Config.canary_api_key() == nil
+    after
+      System.delete_env("CANARY_ENDPOINT")
+      System.delete_env("CANARY_API_KEY")
     end
   end
 
@@ -388,6 +429,51 @@ defmodule Conductor.ConfigTest do
       System.delete_env("CODEX_HOME")
 
       assert Config.codex_auth_file() == Path.join(System.user_home!(), ".codex/auth.json")
+    end
+  end
+
+  describe "check_env!/1" do
+    test "requires Canary credentials when responder fleets need them" do
+      original_persona_source_root = Application.get_env(:conductor, :persona_source_root)
+
+      on_exit(fn ->
+        if original_persona_source_root,
+          do: Application.put_env(:conductor, :persona_source_root, original_persona_source_root),
+          else: Application.delete_env(:conductor, :persona_source_root)
+      end)
+
+      dir = Path.join(System.tmp_dir!(), "fake_cli_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      for cli <- ~w(gh sprite) do
+        path = Path.join(dir, cli)
+        File.write!(path, "#!/bin/sh\nexit 0\n")
+        File.chmod!(path, 0o755)
+      end
+
+      System.put_env("PATH", dir <> ":" <> System.get_env("PATH", ""))
+      System.put_env("GITHUB_TOKEN", "ghp_test")
+      System.put_env("SPRITE_TOKEN", "sprite_test")
+      System.put_env("OPENAI_API_KEY", "sk-test")
+      System.delete_env("CANARY_ENDPOINT")
+      System.delete_env("CANARY_API_KEY")
+
+      Application.put_env(
+        :conductor,
+        :persona_source_root,
+        Path.expand("../../../sprites", __DIR__)
+      )
+
+      assert_raise RuntimeError, ~r/missing: CANARY_ENDPOINT, CANARY_API_KEY/, fn ->
+        Config.check_env!(require_canary_auth: true)
+      end
+    after
+      System.delete_env("GITHUB_TOKEN")
+      System.delete_env("SPRITE_TOKEN")
+      System.delete_env("OPENAI_API_KEY")
+      System.delete_env("CANARY_ENDPOINT")
+      System.delete_env("CANARY_API_KEY")
     end
   end
 

--- a/conductor/test/conductor/fleet/loader_test.exs
+++ b/conductor/test/conductor/fleet/loader_test.exs
@@ -271,6 +271,24 @@ defmodule Conductor.Fleet.LoaderTest do
       assert [%{name: "bb-tansy", role: :responder}] = config.sprites
     end
 
+    test "rejects fleets with more than one responder", %{path: path} do
+      File.write!(path, """
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-tansy-1"
+      role = "responder"
+
+      [[sprite]]
+      name = "bb-tansy-2"
+      role = "responder"
+      """)
+
+      assert {:error, msg} = Loader.load(path)
+      assert msg =~ "supports only one responder sprite"
+    end
+
     test "returns error for missing name", %{path: path} do
       File.write!(path, """
       [defaults]

--- a/conductor/test/conductor/fleet/loader_test.exs
+++ b/conductor/test/conductor/fleet/loader_test.exs
@@ -35,6 +35,10 @@ defmodule Conductor.Fleet.LoaderTest do
   [[sprite]]
   name = "bb-muse"
   role = "triage"
+
+  [[sprite]]
+  name = "bb-tansy"
+  role = "responder"
   """
 
   setup do
@@ -49,11 +53,11 @@ defmodule Conductor.Fleet.LoaderTest do
       File.write!(path, @valid_toml)
       assert {:ok, config} = Loader.load(path)
 
-      assert length(config.sprites) == 4
+      assert length(config.sprites) == 5
       assert config.defaults.org == "test-org"
       assert config.defaults.repo == "test-org/test-repo"
 
-      [builder, fixer, polisher, muse] = config.sprites
+      [builder, fixer, polisher, muse, tansy] = config.sprites
       assert builder.name == "bb-weaver"
       assert builder.role == :builder
       assert builder.org == "test-org"
@@ -73,6 +77,9 @@ defmodule Conductor.Fleet.LoaderTest do
 
       assert muse.name == "bb-muse"
       assert muse.role == :triage
+
+      assert tansy.name == "bb-tansy"
+      assert tansy.role == :responder
     end
 
     test "sprite inherits defaults when not overridden", %{path: path} do
@@ -250,6 +257,20 @@ defmodule Conductor.Fleet.LoaderTest do
       assert msg =~ "invalid role 'reviewer'"
     end
 
+    test "accepts responder as a valid role", %{path: path} do
+      File.write!(path, """
+      [defaults]
+      repo = "test/repo"
+
+      [[sprite]]
+      name = "bb-tansy"
+      role = "responder"
+      """)
+
+      assert {:ok, config} = Loader.load(path)
+      assert [%{name: "bb-tansy", role: :responder}] = config.sprites
+    end
+
     test "returns error for missing name", %{path: path} do
       File.write!(path, """
       [defaults]
@@ -286,6 +307,10 @@ defmodule Conductor.Fleet.LoaderTest do
       fixers = Loader.by_role(config.sprites, :fixer)
       assert length(fixers) == 1
       assert hd(fixers).name == "bb-thorn"
+
+      responders = Loader.by_role(config.sprites, :responder)
+      assert length(responders) == 1
+      assert hd(responders).name == "bb-tansy"
     end
   end
 end

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -287,9 +287,10 @@ defmodule Conductor.LauncherTest do
     assert_received {:sync_persona_called, "bb-tansy", "/tmp/workspaces/misty-step/bitterblossom",
                      :tansy}
 
-    assert_received {:start_loop_called, "bb-tansy", prompt, "misty-step/bitterblossom", _opts}
+    assert_received {:start_loop_called, "bb-tansy", prompt, "misty-step/bitterblossom", opts}
     assert prompt =~ "# Tansy Loop"
     assert prompt =~ "You are Tansy."
+    assert opts[:persona_role] == :tansy
   end
 
   test "launch fails fast for responder sprites when Canary credentials are missing" do

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -82,7 +82,11 @@ defmodule Conductor.LauncherTest do
     orig_checkout_present = Application.get_env(:conductor, :launcher_repo_checkout_present)
     orig_auth_failure = Application.get_env(:conductor, :launcher_auth_failure_result)
     orig_openai_key = System.get_env("OPENAI_API_KEY")
+    orig_canary_endpoint = System.get_env("CANARY_ENDPOINT")
+    orig_canary_api_key = System.get_env("CANARY_API_KEY")
     System.delete_env("OPENAI_API_KEY")
+    System.delete_env("CANARY_ENDPOINT")
+    System.delete_env("CANARY_API_KEY")
 
     Application.put_env(:conductor, :sprite_module, MockSpriteModule)
     Application.put_env(:conductor, :bootstrap_module, MockBootstrapModule)
@@ -100,6 +104,16 @@ defmodule Conductor.LauncherTest do
       case orig_openai_key do
         nil -> System.delete_env("OPENAI_API_KEY")
         val -> System.put_env("OPENAI_API_KEY", val)
+      end
+
+      case orig_canary_endpoint do
+        nil -> System.delete_env("CANARY_ENDPOINT")
+        val -> System.put_env("CANARY_ENDPOINT", val)
+      end
+
+      case orig_canary_api_key do
+        nil -> System.delete_env("CANARY_API_KEY")
+        val -> System.put_env("CANARY_API_KEY", val)
       end
     end)
 
@@ -131,6 +145,7 @@ defmodule Conductor.LauncherTest do
                      [
                        repo: "misty-step/bitterblossom",
                        persona: "You are Weaver.",
+                       persona_role: :weaver,
                        harness: "codex",
                        force: false
                      ]}
@@ -255,6 +270,8 @@ defmodule Conductor.LauncherTest do
 
   test "launch maps responder sprites to Tansy persona and prompt" do
     Application.put_env(:conductor, :launcher_repo_checkout_present, false)
+    System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+    System.put_env("CANARY_API_KEY", "canary-test-key")
 
     sprite = %{
       name: "bb-tansy",
@@ -273,6 +290,22 @@ defmodule Conductor.LauncherTest do
     assert_received {:start_loop_called, "bb-tansy", prompt, "misty-step/bitterblossom", _opts}
     assert prompt =~ "# Tansy Loop"
     assert prompt =~ "You are Tansy."
+  end
+
+  test "launch fails fast for responder sprites when Canary credentials are missing" do
+    Application.put_env(:conductor, :launcher_repo_checkout_present, false)
+
+    sprite = %{
+      name: "bb-tansy",
+      role: :responder,
+      repo: "misty-step/bitterblossom",
+      harness: "codex",
+      reasoning_effort: "medium",
+      persona: "You are Tansy."
+    }
+
+    assert {:error, "missing Canary responder credentials"} =
+             Launcher.launch(sprite, "misty-step/bitterblossom")
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:conductor, key)

--- a/conductor/test/conductor/launcher_test.exs
+++ b/conductor/test/conductor/launcher_test.exs
@@ -253,6 +253,28 @@ defmodule Conductor.LauncherTest do
     assert prompt =~ "You are Muse."
   end
 
+  test "launch maps responder sprites to Tansy persona and prompt" do
+    Application.put_env(:conductor, :launcher_repo_checkout_present, false)
+
+    sprite = %{
+      name: "bb-tansy",
+      role: :responder,
+      repo: "misty-step/bitterblossom",
+      harness: "codex",
+      reasoning_effort: "medium",
+      persona: "You are Tansy."
+    }
+
+    assert {:ok, "123\n"} = Launcher.launch(sprite, "misty-step/bitterblossom")
+
+    assert_received {:sync_persona_called, "bb-tansy", "/tmp/workspaces/misty-step/bitterblossom",
+                     :tansy}
+
+    assert_received {:start_loop_called, "bb-tansy", prompt, "misty-step/bitterblossom", _opts}
+    assert prompt =~ "# Tansy Loop"
+    assert prompt =~ "You are Tansy."
+  end
+
   defp restore_env(key, nil), do: Application.delete_env(:conductor, key)
   defp restore_env(key, value), do: Application.put_env(:conductor, key, value)
 end

--- a/conductor/test/conductor/sprite_agent_test.exs
+++ b/conductor/test/conductor/sprite_agent_test.exs
@@ -73,8 +73,6 @@ defmodule Conductor.SpriteAgentTest do
   test "start_loop uploads prompt/env and launches a detached loop wrapper" do
     test_pid = self()
     System.put_env("OPENAI_API_KEY", "sk-test-123")
-    System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
-    System.put_env("CANARY_API_KEY", "canary-test-123")
 
     exec_fn = fn _sprite, command, opts ->
       uploaded_files =
@@ -107,19 +105,13 @@ defmodule Conductor.SpriteAgentTest do
 
     assert Enum.any?(uploaded_files, fn
              {"/tmp/worktree/.bb-runtime-env", content} ->
-               canary_endpoint_index =
-                 :binary.match(content, "export CANARY_ENDPOINT='https://canary-obs.fly.dev'")
-
-               canary_api_key_index =
-                 :binary.match(content, "export CANARY_API_KEY='canary-test-123'")
-
                exa_index = :binary.match(content, "export EXA_API_KEY='exa-test-456'")
                repo_index = :binary.match(content, "export REPO='test/repo'")
 
                String.contains?(content, "export OPENAI_API_KEY='sk-test-123'") and
                  String.contains?(content, "export CODEX_API_KEY='sk-test-123'") and
-                 match?({_, _}, canary_endpoint_index) and
-                 match?({_, _}, canary_api_key_index) and
+                 not String.contains?(content, "export CANARY_ENDPOINT=") and
+                 not String.contains?(content, "export CANARY_API_KEY=") and
                  match?({_, _}, exa_index) and match?({_, _}, repo_index) and
                  elem(exa_index, 0) < elem(repo_index, 0)
 
@@ -135,6 +127,46 @@ defmodule Conductor.SpriteAgentTest do
     assert detached_cmd =~ "setsid bash -lc"
     assert detached_cmd =~ "/home/sprite/.bitterblossom/loop.pid"
     assert detached_cmd =~ "codex exec"
+  end
+
+  test "start_loop injects Canary credentials only for the responder persona" do
+    test_pid = self()
+    System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+    System.put_env("CANARY_API_KEY", "canary-test-123")
+
+    exec_fn = fn _sprite, command, opts ->
+      uploaded_files =
+        opts
+        |> Keyword.get(:files, [])
+        |> Enum.map(fn {src, dest} -> {dest, File.read!(src)} end)
+
+      send(test_pid, {:exec_called, command, uploaded_files})
+
+      if String.contains?(command, "setsid bash -lc") do
+        {:ok, "__bb_started__:123\n"}
+      else
+        {:ok, ""}
+      end
+    end
+
+    assert {:ok, "123\n"} =
+             Sprite.start_loop("bb-tansy", "# Loop prompt", "misty-step/bitterblossom",
+               workspace: "/tmp/worktree",
+               persona_role: :tansy,
+               harness: Conductor.Codex,
+               exec_fn: exec_fn
+             )
+
+    assert_received {:exec_called, "true", uploaded_files}
+
+    assert Enum.any?(uploaded_files, fn
+             {"/tmp/worktree/.bb-runtime-env", content} ->
+               String.contains?(content, "export CANARY_ENDPOINT='https://canary-obs.fly.dev'") and
+                 String.contains?(content, "export CANARY_API_KEY='canary-test-123'")
+
+             _ ->
+               false
+           end)
   end
 
   test "start_loop refuses to launch when the sprite is paused" do

--- a/conductor/test/conductor/sprite_agent_test.exs
+++ b/conductor/test/conductor/sprite_agent_test.exs
@@ -6,7 +6,9 @@ defmodule Conductor.SpriteAgentTest do
 
   setup do
     original_env =
-      for key <- ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY), into: %{} do
+      for key <-
+            ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY CANARY_ENDPOINT CANARY_API_KEY),
+          into: %{} do
         {key, System.get_env(key)}
       end
 
@@ -15,6 +17,8 @@ defmodule Conductor.SpriteAgentTest do
     System.delete_env("OPENAI_API_KEY")
     System.delete_env("GITHUB_TOKEN")
     System.put_env("EXA_API_KEY", "exa-test-456")
+    System.delete_env("CANARY_ENDPOINT")
+    System.delete_env("CANARY_API_KEY")
 
     on_exit(fn ->
       File.rm_rf(codex_home)
@@ -69,6 +73,8 @@ defmodule Conductor.SpriteAgentTest do
   test "start_loop uploads prompt/env and launches a detached loop wrapper" do
     test_pid = self()
     System.put_env("OPENAI_API_KEY", "sk-test-123")
+    System.put_env("CANARY_ENDPOINT", "https://canary-obs.fly.dev")
+    System.put_env("CANARY_API_KEY", "canary-test-123")
 
     exec_fn = fn _sprite, command, opts ->
       uploaded_files =
@@ -101,11 +107,19 @@ defmodule Conductor.SpriteAgentTest do
 
     assert Enum.any?(uploaded_files, fn
              {"/tmp/worktree/.bb-runtime-env", content} ->
+               canary_endpoint_index =
+                 :binary.match(content, "export CANARY_ENDPOINT='https://canary-obs.fly.dev'")
+
+               canary_api_key_index =
+                 :binary.match(content, "export CANARY_API_KEY='canary-test-123'")
+
                exa_index = :binary.match(content, "export EXA_API_KEY='exa-test-456'")
                repo_index = :binary.match(content, "export REPO='test/repo'")
 
                String.contains?(content, "export OPENAI_API_KEY='sk-test-123'") and
                  String.contains?(content, "export CODEX_API_KEY='sk-test-123'") and
+                 match?({_, _}, canary_endpoint_index) and
+                 match?({_, _}, canary_api_key_index) and
                  match?({_, _}, exa_index) and match?({_, _}, repo_index) and
                  elem(exa_index, 0) < elem(repo_index, 0)
 
@@ -197,7 +211,9 @@ defmodule Conductor.SpriteRetryLoopTest do
 
   setup do
     original_env =
-      for key <- ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY), into: %{} do
+      for key <-
+            ~w(CODEX_HOME OPENAI_API_KEY GITHUB_TOKEN EXA_API_KEY CANARY_ENDPOINT CANARY_API_KEY),
+          into: %{} do
         {key, System.get_env(key)}
       end
 
@@ -206,6 +222,8 @@ defmodule Conductor.SpriteRetryLoopTest do
     System.put_env("OPENAI_API_KEY", "sk-test-123")
     System.delete_env("GITHUB_TOKEN")
     System.put_env("EXA_API_KEY", "exa-test-456")
+    System.delete_env("CANARY_ENDPOINT")
+    System.delete_env("CANARY_API_KEY")
 
     on_exit(fn ->
       File.rm_rf(codex_home)

--- a/conductor/test/conductor/workspace_test.exs
+++ b/conductor/test/conductor/workspace_test.exs
@@ -261,6 +261,10 @@ defmodule Conductor.WorkspaceTest do
     test "maps triage sprites to the muse persona" do
       assert Workspace.persona_for_role(:triage) == :muse
     end
+
+    test "maps responder sprites to the tansy persona" do
+      assert Workspace.persona_for_role(:responder) == :tansy
+    end
   end
 
   # --- Helpers ---

--- a/docs/plans/2026-04-08-tansy-canary-responder.md
+++ b/docs/plans/2026-04-08-tansy-canary-responder.md
@@ -1,0 +1,395 @@
+# Context Packet: Tansy, Canary Incident Responder
+
+## Why This Exists
+
+Bitterblossom is currently shaped as a single-repo, backlog-driven factory.
+The immediate direction lock is different: one always-on sprite should watch
+Canary across all reporting services, investigate what is actually happening,
+fix the right repository, review the change rigorously, merge, deploy, verify
+recovery, and continue monitoring.
+
+Canary already provides the right observability substrate for this:
+
+- signed webhook hints
+- canonical read APIs
+- incidents
+- timelines
+- annotations
+
+What Bitterblossom lacks is a dedicated responder lane, a truthful mapping from
+Canary `service` to repository and allowed actions, and an incident-response
+skill path that is built for live production problems instead of backlog items.
+
+## Product Exploration
+
+### Approach 1: Reuse `triage` and point Muse at Canary
+
+Keep `role = "triage"` and try to make a fleet persona act like a Canary
+responder.
+
+Why reject it:
+
+- `triage` is hard-wired to `muse` in loader, workspace, and launcher wiring.
+- Muse currently observes and recommends; it does not implement, merge, or
+  deploy.
+- The semantic mismatch would be encoded as prompt folklore instead of a clear
+  system contract.
+
+### Approach 2: Add a first-class responder lane and keep Canary polling as truth
+
+Introduce a dedicated responder identity, `Tansy`, with a responder skill that
+polls Canary read APIs, claims incidents through annotations, resolves the
+target repo through a typed catalog, investigates strategically, runs review,
+and optionally merges and deploys for allowlisted services.
+
+Recommendation: this is the right v1.
+
+Why:
+
+- matches the actual job
+- keeps Canary as observability substrate rather than workflow engine
+- avoids public webhook infrastructure before it is needed
+- makes the safety boundary explicit
+- stays deletable and evolvable
+
+### Approach 3: Build webhook intake into Bitterblossom first
+
+Expose a public Bitterblossom endpoint, subscribe it to Canary webhooks, and
+drive the responder from pushed events.
+
+Why defer it:
+
+- Canary explicitly treats webhooks as wake-up hints, not source of truth.
+- Bitterblossom does not currently need public ingress to solve the real
+  problem.
+- It adds queueing, signature verification, reachability, and replay concerns
+  before the responder behavior itself exists.
+
+## Goal
+
+One always-on Bitterblossom sprite, `Tansy`, autonomously handles active Canary
+incidents for allowlisted services end to end: claim, investigate, fix, review,
+merge, deploy, confirm recovery, annotate, repeat.
+
+## Non-Goals
+
+- Do not build a generic event bus or workflow console into Canary.
+- Do not start with a public webhook receiver in Bitterblossom.
+- Do not horizontally scale responders in v1.
+- Do not treat raw error groups as the primary work queue in v1.
+- Do not encode arbitrary shell workflow logic as an open-ended DSL.
+- Do not grant merge or deploy authority to every service by default.
+
+## Constraints / Invariants
+
+- Canary read APIs are the source of truth. Webhooks are hints only.
+- `Tansy` must be a first-class persona path. Do not overload `triage`/`muse`.
+- Exactly one active `Tansy` loop in v1.
+- v1 work queue is active incidents first. Error groups are evidence, not the
+  primary scheduler.
+- Service-to-repo resolution must live in Bitterblossom, not Canary.
+- The service catalog must be typed and validated at startup.
+- Catalog commands are argv arrays, not shell strings.
+- Auto-merge and auto-deploy are explicit per-service opt-ins and default to
+  `false`.
+- A fix is not done until Canary stays healthy through a stabilization window.
+
+## Authority Order
+
+tests > Canary API contracts > type system > code > docs > lore
+
+## Repo Anchors
+
+- `conductor/lib/conductor/fleet/loader.ex` — valid roles are explicit and must
+  stay truthful.
+- `conductor/lib/conductor/workspace.ex` — persona sync is role-driven; Tansy
+  needs first-class wiring.
+- `conductor/lib/conductor/launcher.ex` — loop prompt, persona display, and
+  workspace lifecycle.
+- `fleet.toml` — fleet declaration and sprite authority surface.
+- `sprites/muse/AGENTS.md` — current `triage` semantics that this plan must not
+  silently overload.
+- `../canary/lib/canary_web/router.ex` — current read and annotation API
+  surface.
+- `../canary/lib/canary_web/controllers/annotation_controller.ex` — current
+  annotation write semantics and race boundary.
+- `../canary/README.md` — webhook and polling contract.
+
+## Prior Art
+
+- `conductor/test/conductor/canary_integration_test.exs` — Bitterblossom
+  already attaches itself to Canary for outbound reporting.
+- `../canary/README.md` — canonical statement that webhooks are wake-up hints.
+- `../canary/test/canary_web/controllers/incident_controller_test.exs` —
+  incident filtering via annotations already exists.
+- `../canary/test/canary/query_annotation_test.exs` — error-group annotation
+  filtering already exists for evidence gathering.
+
+## Product Shape
+
+### Sprite identity
+
+- Sprite name: `bb-tansy`
+- Persona name: `tansy`
+- Role name: `responder`
+
+Do not reuse `triage`. The current code and persona tree do not support that
+cleanly.
+
+### Work queue
+
+`Tansy` handles:
+
+1. `GET /api/v1/incidents`
+2. `GET /api/v1/report`
+3. `GET /api/v1/timeline`
+4. focused reads such as `GET /api/v1/errors/:id` and health check history
+
+Scheduling rule:
+
+- v1 picks from active incidents without a `bitterblossom.claimed` annotation.
+- Error groups may be queried while investigating, but they do not independently
+  trigger repo mutation in v1.
+
+### Coordination protocol
+
+Canary annotations are the operator-visible state trail:
+
+- `bitterblossom.claimed`
+- `bitterblossom.investigating`
+- `bitterblossom.resolved`
+- `bitterblossom.escalated`
+- `bitterblossom.rollback`
+
+Each annotation includes:
+
+- `agent`
+- `action`
+- metadata with `sprite`, `run_id`, `repo`, `branch`, `started_at`, and
+  `expires_at`
+
+Because annotation claims are not atomic, v1 relies on the stronger invariant:
+single active Tansy only. No second responder until claim semantics are
+hardened.
+
+### Service catalog
+
+Add a typed catalog at repo root:
+
+`canary-services.toml`
+
+Minimal v1 schema per service:
+
+```toml
+[[service]]
+name = "volume"
+repo = "misty-step/volume"
+default_branch = "main"
+test_cmd = ["make", "test"]
+deploy_cmd = ["flyctl", "deploy", "--app", "volume-prod", "--remote-only"]
+rollback_cmd = ["flyctl", "releases", "rollback", "--app", "volume-prod"]
+auto_merge = false
+auto_deploy = false
+stabilization_window_s = 600
+```
+
+Rules:
+
+- strict schema validation on load
+- no shell interpolation
+- no optional branching language
+- defaults are deny-by-default
+
+### Incident execution flow
+
+The hot path should be investigation-first, not backlog-first:
+
+1. Poll Canary for eligible incidents.
+2. Claim the incident and annotate `bitterblossom.claimed`.
+3. Gather canonical context from incident, report, timeline, error detail, and
+   target-check APIs.
+4. Resolve the target repo from `canary-services.toml`.
+5. Check out a dedicated worktree for that repo.
+6. Run `/investigate`.
+7. Brainstorm and validate strategic fixes with `/research thinktank` when the
+   design is unclear or the fix is risky.
+8. Implement the chosen fix with tests.
+9. Run `/code-review` so the thinktank review tier is mandatory.
+10. Apply `/settle`-style verification gates.
+11. If `auto_merge=true`, squash merge after all review and verification gates.
+12. If `auto_deploy=true`, run the typed deploy command.
+13. Confirm Canary recovery through the stabilization window.
+14. Annotate `resolved`, `rollback`, or `escalated`.
+
+`/autopilot` is not the default primitive here. It is backlog-oriented. The
+incident lane should be `/investigate` first, then focused fix, then
+`/code-review`, then settlement and rollout gates.
+
+## Technical Exploration
+
+### Option A: Dedicated responder role + catalog + polling/reconciliation
+
+Add explicit responder wiring in the conductor and keep responder behavior in a
+small set of deep modules and persona-specific skills.
+
+Recommendation: choose this.
+
+Why:
+
+- small conductor change, large semantic clarity gain
+- no public ingress required
+- matches Canary’s actual contract
+
+### Option B: Reuse `triage` and patch Muse into Tansy
+
+Why reject it:
+
+- wrong persona wiring
+- wrong operator language
+- hidden coupling between unrelated workflows
+
+### Option C: Public webhook intake + queue before responder behavior
+
+Why reject it for v1:
+
+- infrastructure before product
+- more failure modes than value at this stage
+
+## Recommended Technical Design
+
+### 1. Add a first-class responder role
+
+Extend:
+
+- `Conductor.Fleet.Loader` valid roles
+- `Conductor.Workspace` persona role whitelist and role mapping
+- `Conductor.Launcher` role display name
+- focused conductor tests
+
+Add:
+
+- `sprites/tansy/CLAUDE.md`
+- `sprites/tansy/AGENTS.md`
+
+### 2. Add a dedicated incident-response skill
+
+Add a repo-local skill such as:
+
+- `base/skills/canary-responder/SKILL.md`
+
+This skill owns the responder loop contract:
+
+- poll
+- claim
+- context gather
+- investigate
+- fix
+- review
+- merge gate
+- deploy gate
+- recovery gate
+- annotate
+
+Do not bury this protocol in giant AGENTS prose.
+
+### 3. Keep the runtime thin with four deep modules
+
+- `CanaryInbox`
+  - `next_incident/1`
+  - `incident_context/2`
+- `ServiceCatalog`
+  - `load!/1`
+  - `resolve!/2`
+- `IncidentLease`
+  - `claim/2`
+  - `heartbeat/2`
+  - `close/2`
+- `Remediator`
+  - `execute/2`
+
+If these land as conductor modules, they should stay narrow and truthful. If
+they land as skill-owned scripts first, keep the same interface boundaries.
+
+### 4. Explicit incident lifecycle
+
+Per work item:
+
+`new -> claimed -> investigating -> fixing -> review -> verified -> deployed -> recovered`
+
+Terminal states:
+
+- `escalated`
+- `rollback`
+
+### 5. Merge and deploy authority
+
+This plan assumes:
+
+- `Tansy` may merge and deploy, but only for services explicitly allowlisted in
+  the catalog.
+- services without `auto_merge` and `auto_deploy` stay investigation-only or
+  merge-ready with escalation.
+
+That keeps the user’s desired end-to-end automation while preserving a hard
+safety boundary.
+
+## Oracle (Definition of Done)
+
+- [ ] `cd conductor && mix test test/conductor/fleet/loader_test.exs test/conductor/workspace_test.exs test/conductor/launcher_test.exs`
+- [ ] `cd conductor && mix test test/conductor/canary_integration_test.exs test/conductor/tansy_catalog_test.exs test/conductor/tansy_lease_test.exs test/conductor/tansy_responder_test.exs`
+- [ ] `cd conductor && mix test test/conductor/tansy_e2e_test.exs`
+- [ ] `make test`
+- [ ] In the fixture e2e test, one seeded Canary incident is claimed exactly
+  once, mapped to the right repo, annotated through `claimed -> investigating ->
+  resolved|escalated`, and never double-processed.
+- [ ] For an allowlisted fixture service, merge only happens after `/code-review`
+  returns a ship verdict and the repo verification command exits `0`.
+- [ ] For an auto-deploy fixture service, Canary stays healthy for the full
+  stabilization window before the incident is marked resolved.
+
+## Implementation Sequence
+
+1. Lock the product pivot in docs.
+   Update `project.md`, `CLAUDE.md`, and any workflow text that still frames
+   Bitterblossom as single-repo only.
+2. Introduce `responder` + `tansy` persona wiring and tests.
+3. Add `canary-services.toml` plus strict loader/validator tests.
+4. Add the `canary-responder` skill and Tansy persona loop.
+5. Implement polling, annotation, and repo-resolution flow for incidents only.
+6. Add focused integration tests against mocked Canary APIs and a fixture target
+   repo.
+7. Enable `bb-tansy` in `fleet.toml`; disable or retire `bb-muse` if the pivot
+   is total.
+8. Roll out on one allowlisted service with `auto_merge=false` and
+   `auto_deploy=false`.
+9. After real runs are trustworthy, selectively enable autonomous merge and
+   deploy per service.
+
+## Risk + Rollout
+
+- Blast radius:
+  auto-merge and auto-deploy are dangerous across many repos. Default deny, then
+  opt in per service.
+- Claim races:
+  acceptable in v1 only because there is one active Tansy. Do not scale out
+  until lease semantics are stronger.
+- Rate limits:
+  poll incidents and narrow report/timeline reads; do not sweep every service on
+  every loop.
+- False recovery:
+  require a stabilization window before `resolved`.
+- Repeated bad deploys:
+  require `rollback_cmd` for any service allowed to auto-deploy.
+- Product drift:
+  current top-level docs still describe a different product. Update them before
+  implementation starts.
+
+## Open Questions
+
+- Should merge authority live entirely in `Tansy`, or should `Tansy` hand off
+  merge to a slimmer Fern lane after incident repair is ready?
+- Should the idempotency ledger stay annotation-only in v1, or should
+  Bitterblossom persist responder leases in `Conductor.Store` before the first
+  rollout?
+- Does the catalog belong at repo root, or under `docs/context/` once the pivot
+  is fully codified?

--- a/fleet.toml
+++ b/fleet.toml
@@ -9,41 +9,15 @@ org = "misty-step"
 repo = "misty-step/bitterblossom"
 harness = "codex"
 model = "gpt-5.4"
-reasoning_effort = "medium"  # "low" conserves tokens for builder tasks; "high" for polisher review
+reasoning_effort = "medium"
 spellbook = "phrazzld/spellbook"
 
-[personas]
-fern = """
-You are Fern. Review carefully, run /simplify, /pr-polish, and /pr-fix.
-Only add the lgtm label when the PR is genuinely merge-ready.
-"""
-
 [[sprite]]
-name = "bb-builder"
-role = "builder"
+name = "bb-tansy"
+role = "responder"
+capability_tags = ["canary", "incident-response", "cross-repo"]
 persona = """
-You are Weaver. Implement the spec with minimal diffs.
-TDD by default. Fix what you touch. Conserve session budget.
-"""
-
-[[sprite]]
-name = "bb-fixer"
-role = "fixer"
-persona = "You are Thorn. Fix failing CI with the smallest correct change and nothing else."
-
-[[sprite]]
-name = "bb-polisher"
-role = "polisher"
-reasoning_effort = "high"
-persona_ref = "fern"
-
-# bb-polisher-2 and bb-polisher-3 available but not in default fleet.
-# Scale up by uncommenting when PR backlog grows.
-
-[[sprite]]
-name = "bb-muse"
-role = "triage"
-persona = """
-You are Muse. Observe merged work, synthesize learnings with /reflect, and update backlog.d/ plus .groom/retro/.
-Do not implement product code or merge changes yourself.
+You are Tansy. Monitor Canary incidents, investigate root causes, and only
+auto-merge or auto-deploy for services explicitly allowlisted in
+canary-services.toml after review and recovery verification.
 """

--- a/project.md
+++ b/project.md
@@ -1,5 +1,12 @@
 # Project: Bitterblossom
 
+## Direction Lock
+
+**Current direction lock (2026-04-08):** Bitterblossom is temporarily focused
+on one job only: `Tansy` listens to Canary, investigates live incidents,
+repairs the correct repo, and verifies recovery. Backlog-clearing factory lanes
+remain in the codebase, but they are not the active product priority.
+
 ## Vision
 Bitterblossom is the conductor for a single-repo software factory: it routes GitHub work to persistent sprites, drives implementation and review, and merges only when governance says the run is truly done.
 
@@ -35,9 +42,9 @@ Bitterblossom is a **cybernetic governor** for software production. The conducto
 
 ## Active Focus
 
-- **Milestone:** `Now: Current Sprint` for operational quality foundation, with `Next: Up Next` carrying behaviour extraction and Go absorption.
-- **Key Issues:** [#625](https://github.com/misty-step/bitterblossom/issues/625) (Elixir CI), [#626](https://github.com/misty-step/bitterblossom/issues/626) (RunServer tests), [#627](https://github.com/misty-step/bitterblossom/issues/627) (security hardening), [#628](https://github.com/misty-step/bitterblossom/issues/628) (prompt context), [#553](https://github.com/misty-step/bitterblossom/issues/553) (CI/Auth)
-- **Theme:** Make the Elixir conductor trustworthy: CI pipeline, test coverage on critical paths, security hardening, Weaver prompt enrichment. The architecture is validated — now harden the operational foundation.
+- **Milestone:** `Tansy v1` — one always-on Canary responder sprite with an explicit service catalog and recovery verification loop.
+- **Key Issues:** role wiring for `responder`, typed `canary-services.toml`, Tansy persona/skill path, and a safe path to opt-in merge/deploy.
+- **Theme:** Truthful incident response over generic factory throughput. Canary is the work queue; incidents come before backlog.
 
 ## Architecture Artifacts
 

--- a/sprites/tansy.md
+++ b/sprites/tansy.md
@@ -1,0 +1,55 @@
+---
+name: tansy
+description: "Canary incident responder. Watches active incidents, drives root-cause investigation, fixes the right repo, and verifies recovery."
+model: inherit
+memory: local
+permissionMode: bypassPermissions
+skills:
+  - canary-responder
+  - debug
+  - code-review
+  - gather-pr-context
+  - verify-invariants
+  - research
+---
+
+# Tansy — Canary Incident Responder
+
+You are Tansy, a sprite in the fae engineering court. Your specialization is
+live incident response driven by Canary.
+
+## Philosophy
+
+Truth first. Canary says what is happening; the code says why; tests and review
+say whether the fix is real. Do not paper over an incident just to make the red
+go away.
+
+## Working Patterns
+
+- **Read the incident, really read it.** Timeline, correlated signals, error
+  detail, probe history, and annotations are evidence.
+- **Resolve through the catalog.** `canary-services.toml` is the authority for
+  repo mapping and rollout permissions.
+- **Investigate before implementing.** Incidents are not backlog items.
+- **Recovery is part of the fix.** If Canary does not stay healthy, the work is
+  not done.
+- **Safe automation only.** Merge and deploy only where the catalog explicitly
+  allows it.
+
+## Routing Signals
+
+You are dispatched when work involves:
+
+- Canary incidents
+- production error triage
+- cross-repo remediation from observability data
+- recovery verification and rollback judgment
+
+## Memory
+
+Maintain `MEMORY.md` in your working directory. Record:
+
+- recurring incident signatures
+- service-specific rollout gotchas
+- catalog gaps that required escalation
+- recovery windows that were too short or too long

--- a/sprites/tansy/AGENTS.md
+++ b/sprites/tansy/AGENTS.md
@@ -1,0 +1,70 @@
+# Tansy — Autonomous Canary Responder
+
+You are Tansy. Your loop:
+
+1. Poll Canary for active incidents that are not already claimed
+2. Claim one incident with a Canary annotation
+3. Run `/canary-responder`
+4. If the incident is resolved and stable, annotate `bitterblossom.resolved`
+5. If blocked or unsafe to continue, annotate `bitterblossom.escalated`
+6. Repeat
+
+## Finding Work
+
+Canary is the work queue. Use the Bitterblossom Canary CLI as the truthful
+control surface:
+
+- `mix conductor canary incidents --without-annotation bitterblossom.claimed --json`
+- `mix conductor canary report --window 24h --json`
+- `mix conductor canary timeline --window 24h --limit 200 --json`
+- `mix conductor canary annotations incident <incident-id> --json`
+
+Use annotations as the visible state trail:
+
+- `bitterblossom.claimed`
+- `bitterblossom.investigating`
+- `bitterblossom.resolved`
+- `bitterblossom.escalated`
+- `bitterblossom.rollback`
+
+## Execution Discipline
+
+- Incidents only in v1. Do not independently schedule raw error groups.
+- Investigate first. Do not default to `/autopilot` in the hot incident loop.
+- Prefer root-cause fixes over suppression or retries.
+- Use `/research thinktank` before committing to a risky architecture change.
+- Run `/code-review` before merge. Review diversity is mandatory.
+- Use `/settle`-style verification before any merge or deploy action.
+
+## Repo Resolution
+
+Before touching code, resolve the target service through the repo-owned catalog:
+
+```bash
+cd conductor
+mix conductor canary service <service> --json
+```
+
+If the service is missing from `canary-services.toml`, do not improvise. Annotate
+`bitterblossom.escalated` and stop.
+
+Claim and state transitions happen through:
+
+```bash
+cd conductor
+mix conductor canary annotate incident <incident-id> \
+  --agent tansy \
+  --action bitterblossom.claimed \
+  --metadata '{"service":"<service>"}'
+```
+
+## Recovery Gate
+
+An incident is not done when the patch lands. It is done when:
+
+1. tests and review are clean
+2. any allowed merge/deploy step completed cleanly
+3. Canary stays healthy through the catalog's stabilization window
+
+If the deployment makes things worse, annotate `bitterblossom.rollback`, run the
+catalog rollback command, and escalate.

--- a/sprites/tansy/CLAUDE.md
+++ b/sprites/tansy/CLAUDE.md
@@ -6,7 +6,8 @@ repository, and verify recovery before standing down.
 
 ## Identity
 
-You are an incident commander with implementation authority.
+You are an incident commander who keeps incident judgment on the lead model and
+uses delegated execution deliberately.
 
 - Canary is the source of truth.
 - Active incidents are the work queue.

--- a/sprites/tansy/CLAUDE.md
+++ b/sprites/tansy/CLAUDE.md
@@ -1,0 +1,37 @@
+# Tansy — Canary Incident Responder
+
+You are Tansy, Bitterblossom's Canary responder. You do not clear generic
+backlog. You watch Canary, investigate active incidents, repair the correct
+repository, and verify recovery before standing down.
+
+## Identity
+
+You are an incident commander with implementation authority.
+
+- Canary is the source of truth.
+- Active incidents are the work queue.
+- Error groups are evidence, not the primary scheduler.
+- `canary-services.toml` is the authority for `service -> repo + rollout policy`.
+- Webhooks are wake-up hints only. Poll and reconcile from read APIs.
+
+## Skills
+
+- `/canary-responder` — poll, claim, investigate, fix, review, verify, annotate
+- `/investigate` — root-cause analysis and reproduction
+- `/research` — thinktank and external validation before risky fixes
+- `/code-review` — multi-agent review before merge
+- `/settle` — verification, polish, and merge-readiness discipline
+
+## Operating Rules
+
+- Never mutate a repo that is not present in `canary-services.toml`.
+- Never guess the target repo from the incident name alone; resolve it through
+  `bitterblossom canary service <service> --json`.
+- Use `bitterblossom canary incidents|report|timeline|annotations|annotate`
+  instead of ad hoc `curl` so auth, error handling, and payload shapes stay
+  consistent.
+- Never mark an incident resolved before Canary stays healthy through the
+  service's stabilization window.
+- Never auto-merge or auto-deploy unless the catalog entry explicitly allows it.
+- If the incident is real but the service is not cataloged, annotate
+  `bitterblossom.escalated` with the missing mapping and stop.

--- a/sprites/tansy/skills/canary-responder/SKILL.md
+++ b/sprites/tansy/skills/canary-responder/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: canary-responder
+description: Handle one Canary incident end to end: claim, investigate, fix, review, verify, and annotate.
+---
+
+# /canary-responder
+
+Own one Canary incident all the way through.
+
+## Execution Stance
+
+You are the executive orchestrator.
+
+- Keep incident judgment, repo selection, merge/deploy decisions, and recovery
+  judgment on the lead model.
+- Delegate bounded evidence gathering, implementation, and review to subagents.
+- Treat Canary reads as truth and annotations as the visible audit trail.
+
+## Inputs
+
+Required environment:
+
+- `CANARY_ENDPOINT`
+- `CANARY_API_KEY`
+
+Required repo artifacts:
+
+- `canary-services.toml`
+- working `bitterblossom canary service <service> --json`
+- working `bitterblossom canary incidents|report|timeline|annotations|annotate`
+
+## Protocol
+
+### 1. Claim
+
+Pick one active incident that does not already carry a live
+`bitterblossom.claimed` annotation.
+
+Prefer:
+
+```bash
+cd conductor
+mix conductor canary incidents --without-annotation bitterblossom.claimed --json
+```
+
+Write a claim annotation immediately with:
+
+- `agent = "tansy"`
+- `action = "bitterblossom.claimed"`
+- metadata: `run_id`, `service`, `claimed_at`, `sprite`
+
+Then write `bitterblossom.investigating` before any repo mutation.
+
+### 2. Gather Truth
+
+Read the incident from Canary, then pull bounded context:
+
+- incident list/detail via `mix conductor canary incidents --json`
+- report for the service via `mix conductor canary report --window 24h --json`
+- timeline for the service via `mix conductor canary timeline --service <service> --window 24h --limit 200 --json`
+- focused error detail and target-check history when relevant
+
+Webhooks are never enough by themselves. Reconcile from read APIs before acting.
+
+### 3. Resolve the Repo
+
+Resolve the service through the catalog:
+
+```bash
+cd conductor
+mix conductor canary service <service> --json
+```
+
+That result is the only allowed authority for:
+
+- target repo
+- default branch
+- test command
+- deploy command
+- rollback command
+- auto-merge / auto-deploy policy
+- stabilization window
+
+### 4. Investigate
+
+Run `/investigate` first.
+
+You are looking for:
+
+- reproduction
+- root cause
+- strategic fix options
+- the smallest robust fix, not the fastest patch
+
+When the design is not obvious or the blast radius is high, run:
+
+```text
+/research thinktank <focused question>
+```
+
+### 5. Repair
+
+Work in the resolved target repo, not in Bitterblossom.
+
+- write or update the narrowest regression test first when practical
+- implement the chosen fix
+- run the catalog `test_cmd`
+
+If the repo is not already present, clone it into the standard sprite workspace
+root under `/home/sprite/workspace/<owner>/<repo>`.
+
+### 6. Review
+
+Run `/code-review` on the actual diff. Thinktank review is mandatory.
+
+If blocking findings appear, fix them and re-run review. Do not merge on a
+conditional or stale verdict.
+
+### 7. Merge and Deploy
+
+Only proceed when the catalog explicitly allows it.
+
+- `auto_merge = false` means stop at reviewed, verified, merge-ready state and
+  annotate `bitterblossom.escalated`.
+- `auto_deploy = false` means do not run deployment, even if the repo merged.
+
+When allowed:
+
+1. squash merge
+2. run the catalog deploy command
+3. if deploy fails or worsens the incident, run the rollback command and
+   annotate `bitterblossom.rollback`
+
+### 8. Recovery Verification
+
+Wait through the catalog stabilization window and re-check Canary.
+
+Only mark `bitterblossom.resolved` when:
+
+- the incident is resolved or materially recovering in Canary
+- no fresh contradictory timeline evidence appears during the window
+
+Otherwise annotate `bitterblossom.escalated` with the reason.
+
+## Anti-Patterns
+
+- Guessing the repo from the service name
+- Treating webhooks as truth
+- Skipping investigation and jumping straight to `/autopilot`
+- Auto-merging because the patch “looks small”
+- Declaring success before Canary stabilizes
+- Editing unrelated repos while the incident target is unresolved


### PR DESCRIPTION
## Summary
- add first-class `responder`/Tansy support so Bitterblossom can focus on Canary incidents
- add a typed Canary service catalog plus Canary CLI/client surfaces for incident/report/timeline/annotation work
- scope Canary credentials to responder sprites, add responder preflight checks, and harden review-driven validation gaps

## Validation
- `cd conductor && mix test`

## Review
- internal bench: no blocking findings
- Thinktank: prior successful pass found a stale config-path test and empty incident-id validation gap; both are fixed on this branch
- residual strategic concern: single-responder policy currently lives in fleet loader parsing as a v1 guardrail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Canary incident responder (Tansy) persona for automated incident detection and response
  * Introduced service catalog for mapping services to repositories and managing deployment policies
  * Added CLI commands for incident management: service lookup, incidents, reports, timeline, and annotations
  * Integrated Canary API for real-time incident polling and annotation-based workflow

* **Changes**
  * Simplified sprite fleet configuration and focused on incident response role
  * Added authentication requirements for incident responder functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->